### PR TITLE
Speed up tinkerpop test

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/GraphsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/GraphsAPI.java
@@ -36,13 +36,10 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 
 import com.baidu.hugegraph.HugeGraph;
 import com.baidu.hugegraph.core.GraphManager;
-import com.baidu.hugegraph.schema.SchemaManager;
 import com.baidu.hugegraph.server.RestServer;
 import com.baidu.hugegraph.util.Log;
 import com.codahale.metrics.annotation.Timed;
@@ -127,27 +124,7 @@ public class GraphsAPI extends API {
             throw new IllegalArgumentException(String.format(
                       "Please take the message: %s", CONFIRM_CLEAR));
         }
-
-        // Clear vertex and edge
-        commit(g, () -> {
-            g.traversal().E().toStream().forEach(Edge::remove);
-            g.traversal().V().toStream().forEach(Vertex::remove);
-        });
-
-        // Schema operation will auto commit
-        SchemaManager schema = g.schema();
-        schema.getIndexLabels().forEach(elem -> {
-            schema.indexLabel(elem.name()).remove();
-        });
-        schema.getEdgeLabels().forEach(elem -> {
-            schema.edgeLabel(elem.name()).remove();
-        });
-        schema.getVertexLabels().forEach(elem -> {
-            schema.vertexLabel(elem.name()).remove();
-        });
-        schema.getPropertyKeys().forEach(elem -> {
-            schema.propertyKey(elem.name()).remove();
-        });
+        g.truncateBackend();
     }
 
     @PUT

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/job/TaskAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/job/TaskAPI.java
@@ -108,7 +108,7 @@ public class TaskAPI extends API {
         HugeGraph g = graph(manager, graph);
         HugeTaskScheduler scheduler = g.taskScheduler();
 
-        HugeTask task = scheduler.task(IdGenerator.of(id));
+        HugeTask<?> task = scheduler.task(IdGenerator.of(id));
         if (task.completed()) {
             scheduler.deleteTask(IdGenerator.of(id));
         } else {

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/auth/HugeGraphAuthProxy.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/auth/HugeGraphAuthProxy.java
@@ -168,6 +168,11 @@ public class HugeGraphAuthProxy implements Graph {
         this.hugegraph.clearBackend();
     }
 
+    public void truncateBackend() {
+        this.verifyPermission(ROLE_ADMIN);
+        this.hugegraph.truncateBackend();
+    }
+
     public void restoring(boolean restoring) {
         this.verifyPermission(ROLE_ADMIN);
         this.hugegraph.restoring(restoring);

--- a/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraSessionPool.java
+++ b/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraSessionPool.java
@@ -222,6 +222,10 @@ public class CassandraSessionPool extends BackendSessionPool {
             this.session = cluster().connect(keyspace());
         }
 
+        public boolean opened() {
+            return this.session != null;
+        }
+
         @Override
         public boolean closed() {
             if (this.session == null) {

--- a/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraStore.java
+++ b/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraStore.java
@@ -19,8 +19,11 @@
 
 package com.baidu.hugegraph.backend.store.cassandra;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -242,12 +245,25 @@ public abstract class CassandraStore implements BackendStore {
     @Override
     public void init() {
         this.checkClusterConnected();
-        this.initKeyspace();
 
+        if (this.sessions.session().opened()) {
+            // Session has ever been opened.
+            LOG.warn("Session has ever been opened(exist keyspace '{}' before)",
+                     this.keyspace);
+        } else {
+            // Create keyspace if need
+            if (!this.existsKeyspace()) {
+                this.initKeyspace();
+            }
+            // Open session explicitly to get the exception when it fails
+            this.sessions.session().open();
+        }
+
+        // Create tables
         this.checkSessionConnected();
         this.initTables();
 
-        LOG.info("Store initialized: {}", this.store);
+        LOG.debug("Store initialized: {}", this.store);
     }
 
     @Override
@@ -260,7 +276,15 @@ public abstract class CassandraStore implements BackendStore {
             this.clearKeyspace();
         }
 
-        LOG.info("Store cleared: {}", this.store);
+        LOG.debug("Store cleared: {}", this.store);
+    }
+
+    @Override
+    public void truncate() {
+        this.checkSessionConnected();
+
+        this.truncateTables();
+        LOG.debug("Store truncated: {}", this.store);
     }
 
     @Override
@@ -358,7 +382,8 @@ public abstract class CassandraStore implements BackendStore {
         replication.putIfAbsent("replication_factor", factor);
 
         Statement stmt = SchemaBuilder.createKeyspace(this.keyspace)
-                         .ifNotExists().with().replication(replication);
+                                      .ifNotExists().with()
+                                      .replication(replication);
 
         // Create keyspace with non-keyspace-session
         LOG.debug("Create keyspace: {}", stmt);
@@ -370,7 +395,6 @@ public abstract class CassandraStore implements BackendStore {
                 session.close();
             }
         }
-        this.sessions.session().open();
     }
 
     protected void clearKeyspace() {
@@ -394,16 +418,27 @@ public abstract class CassandraStore implements BackendStore {
 
     protected void initTables() {
         CassandraSessionPool.Session session = this.sessions.session();
-        for (CassandraTable table : this.tables.values()) {
+        for (CassandraTable table : this.tables()) {
             table.init(session);
         }
     }
 
     protected void clearTables() {
         CassandraSessionPool.Session session = this.sessions.session();
-        for (CassandraTable table : this.tables.values()) {
+        for (CassandraTable table : this.tables()) {
             table.clear(session);
         }
+    }
+
+    protected void truncateTables() {
+        CassandraSessionPool.Session session = this.sessions.session();
+        for (CassandraTable table : this.tables()) {
+            table.truncate(session);
+        }
+    }
+
+    protected Collection<CassandraTable> tables() {
+        return this.tables.values();
     }
 
     protected final CassandraTable table(HugeType type) {
@@ -464,19 +499,10 @@ public abstract class CassandraStore implements BackendStore {
         }
 
         @Override
-        protected void initTables() {
-            super.initTables();
-
-            CassandraSessionPool.Session session = super.sessions.session();
-            this.counters.init(session);
-        }
-
-        @Override
-        protected void clearTables() {
-            super.clearTables();
-
-            CassandraSessionPool.Session session = super.sessions.session();
-            this.counters.clear(session);
+        protected Collection<CassandraTable> tables() {
+            List<CassandraTable> tables = new ArrayList<>(super.tables());
+            tables.add(this.counters);
+            return tables;
         }
 
         @Override

--- a/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraTable.java
+++ b/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraTable.java
@@ -570,4 +570,9 @@ public abstract class CassandraTable
     public void clear(CassandraSessionPool.Session session) {
         this.dropTable(session);
     }
+
+    public void truncate(CassandraSessionPool.Session session) {
+        LOG.debug("Truncate table: {}", this.table());
+        session.execute(QueryBuilder.truncate(this.table()));
+    }
 }

--- a/hugegraph-core/pom.xml
+++ b/hugegraph-core/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.baidu.hugegraph</groupId>
             <artifactId>hugegraph-common</artifactId>
-            <version>1.4.9</version>
+            <version>1.5.1</version>
         </dependency>
 
         <!-- tinkerpop -->

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeGraph.java
@@ -208,6 +208,11 @@ public class HugeGraph implements Graph {
         }
     }
 
+    public void truncateBackend() {
+        this.storeProvider.truncate();
+        new BackendStoreInfo(this).init();
+    }
+
     private SchemaTransaction openSchemaTransaction() throws HugeException {
         try {
             return new CachedSchemaTransaction(this, this.loadSchemaStore());

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/LocalCounter.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/LocalCounter.java
@@ -46,4 +46,8 @@ public class LocalCounter {
         }
         return IdGenerator.of(counter.incrementAndGet());
     }
+
+    public void reset() {
+        this.counters.clear();
+    }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedBackendStore.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedBackendStore.java
@@ -82,6 +82,11 @@ public class CachedBackendStore implements BackendStore {
     }
 
     @Override
+    public void truncate() {
+        this.store.truncate();
+    }
+
+    @Override
     public void beginTx() {
         this.store.beginTx();
     }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedSchemaTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedSchemaTransaction.java
@@ -22,6 +22,7 @@ package com.baidu.hugegraph.backend.cache;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -33,15 +34,19 @@ import com.baidu.hugegraph.backend.tx.SchemaTransaction;
 import com.baidu.hugegraph.config.CoreOptions;
 import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.event.EventHub;
+import com.baidu.hugegraph.event.EventListener;
 import com.baidu.hugegraph.schema.SchemaElement;
 import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.util.Events;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class CachedSchemaTransaction extends SchemaTransaction {
 
     private final Cache idCache;
     private final Cache nameCache;
+
+    private EventListener storeEventListener;
+    private EventListener cacheEventListener;
 
     private final Map<HugeType, Boolean> cachedTypes;
 
@@ -56,6 +61,12 @@ public class CachedSchemaTransaction extends SchemaTransaction {
         this.listenChanges();
     }
 
+    @Override
+    public void close() {
+        super.close();
+        this.unlistenChanges();
+    }
+
     private Cache cache(String prefix) {
         HugeConfig conf = super.graph().configuration();
 
@@ -66,45 +77,59 @@ public class CachedSchemaTransaction extends SchemaTransaction {
     }
 
     private void listenChanges() {
-        // Listen store event: "store.init", "store.clear"
-        List<String> events = ImmutableList.of(Events.STORE_INIT,
-                                               Events.STORE_CLEAR);
-        super.store().provider().listen(event -> {
-            if (events.contains(event.name())) {
-                LOG.info("Clear cache on event '{}'", event.name());
+        // Listen store event: "store.init", "store.clear", ...
+        Set<String> storeEvents = ImmutableSet.of(Events.STORE_INIT,
+                                                  Events.STORE_CLEAR,
+                                                  Events.STORE_TRUNCATE);
+        this.storeEventListener = event -> {
+            if (storeEvents.contains(event.name())) {
+                LOG.debug("Graph {} clear cache on event '{}'",
+                          this.graph(), event.name());
                 this.idCache.clear();
                 this.nameCache.clear();
                 this.cachedTypes.clear();
                 return true;
             }
             return false;
-        });
+        };
+        this.store().provider().listen(this.storeEventListener);
 
         // Listen cache event: "cache"(invalid cache item)
-        EventHub schemaEventHub = super.graph().schemaEventHub();
-        if (!schemaEventHub.containsListener(Events.CACHE)) {
-            schemaEventHub.listen(Events.CACHE, event -> {
-                LOG.debug("Received event: {}", event);
-                event.checkArgs(String.class, Id.class);
-                Object[] args = event.args();
-                if (args[0].equals("invalid")) {
-                    Id id = (Id) args[1];
-                    Object value = this.idCache.get(id);
-                    if (value != null) {
-                        // Invalidate id cache
-                        this.idCache.invalidate(id);
+        this.cacheEventListener = event -> {
+            LOG.debug("Graph {} received cache event: {}",
+                      this.graph(), event);
+            event.checkArgs(String.class, Id.class);
+            Object[] args = event.args();
+            if (args[0].equals("invalid")) {
+                Id id = (Id) args[1];
+                Object value = this.idCache.get(id);
+                if (value != null) {
+                    // Invalidate id cache
+                    this.idCache.invalidate(id);
 
-                        // Invalidate name cache
-                        SchemaElement schema = (SchemaElement) value;
-                        Id prefixedName = generateId(schema.type(),
-                                                     schema.name());
-                        this.nameCache.invalidate(prefixedName);
-                    }
-                    return true;
+                    // Invalidate name cache
+                    SchemaElement schema = (SchemaElement) value;
+                    Id prefixedName = generateId(schema.type(),
+                                                 schema.name());
+                    this.nameCache.invalidate(prefixedName);
                 }
-                return false;
-            });
+                return true;
+            }
+            return false;
+        };
+        EventHub schemaEventHub = this.graph().schemaEventHub();
+        if (!schemaEventHub.containsListener(Events.CACHE)) {
+            schemaEventHub.listen(Events.CACHE, this.cacheEventListener);
         }
+    }
+
+    private void unlistenChanges() {
+        // Unlisten store event
+        this.store().provider().unlisten(this.storeEventListener);
+
+        // Unlisten cache event
+        EventHub schemaEventHub = this.graph().schemaEventHub();
+        schemaEventHub.unlisten(Events.CACHE, this.cacheEventListener);
     }
 
     private void resetCachedAllIfReachedCapacity() {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinarySerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinarySerializer.java
@@ -536,6 +536,7 @@ public class BinarySerializer extends AbstractSerializer {
             case SEARCH_INDEX:
                 String idString = id.asString();
                 int idLength = idString.length();
+                // TODO: to improve, use BytesBuffer to generate a mask
                 for (int i = idLength - 1; i < 128; i++) {
                     BytesBuffer buffer = BytesBuffer.allocate(idLength + 1);
                     /*

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStore.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStore.java
@@ -45,6 +45,9 @@ public interface BackendStore {
     public void init();
     public void clear();
 
+    // Delete all data of database (keep table structure)
+    public void truncate();
+
     // Add/delete data
     public void mutate(BackendMutation mutation);
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStoreProvider.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStoreProvider.java
@@ -46,5 +46,9 @@ public interface BackendStoreProvider {
 
     public void clear();
 
+    public void truncate();
+
     public void listen(EventListener listener);
+
+    public void unlisten(EventListener listener);
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/memory/InMemoryDBStore.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/memory/InMemoryDBStore.java
@@ -19,6 +19,7 @@
 
 package com.baidu.hugegraph.backend.store.memory;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -81,6 +82,10 @@ public class InMemoryDBStore implements BackendStore {
 
     protected void registerTableManager(HugeType type, InMemoryDBTable table) {
         this.tables.put(type, table);
+    }
+
+    protected Collection<InMemoryDBTable> tables() {
+        return this.tables.values();
     }
 
     protected final InMemoryDBTable table(HugeType type) {
@@ -153,28 +158,41 @@ public class InMemoryDBStore implements BackendStore {
 
     @Override
     public void open(HugeConfig config) {
-        LOG.debug("open()");
+        LOG.debug("Store opened: {}", this.store);
     }
 
     @Override
     public void close() throws BackendException {
-        LOG.debug("close()");
+        LOG.debug("Store closed: {}", this.store);
     }
 
     @Override
     public void init() {
-        LOG.info("init()");
-        for (InMemoryDBTable table : this.tables.values()) {
+        for (InMemoryDBTable table : this.tables()) {
             table.init(null);
         }
+
+        LOG.debug("Store initialized: {}", this.store);
     }
 
     @Override
     public void clear() {
-        LOG.info("clear()");
-        for (InMemoryDBTable table : this.tables.values()) {
+        for (InMemoryDBTable table : this.tables()) {
             table.clear(null);
         }
+        this.counter.reset();
+
+        LOG.debug("Store cleared: {}", this.store);
+    }
+
+    @Override
+    public void truncate() {
+        for (InMemoryDBTable table : this.tables()) {
+            table.clear(null);
+        }
+        this.counter.reset();
+
+        LOG.debug("Store truncated: {}", this.store);
     }
 
     @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/memory/InMemoryDBTables.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/memory/InMemoryDBTables.java
@@ -345,16 +345,21 @@ public class InMemoryDBTables {
                                                     Object keyMin,
                                                     boolean keyMinEq) {
             NavigableMap<Id, BackendEntry> rs = this.store();
-            Map<Id, BackendEntry> results = new HashMap<>();
 
             Id min = HugeIndex.formatIndexId(HugeType.RANGE_INDEX,
                                              indexLabelId, keyMin);
             Id max = HugeIndex.formatIndexId(HugeType.RANGE_INDEX,
                                              indexLabelId, keyMax);
+
+            max = keyMaxEq ? rs.floorKey(max) : rs.lowerKey(max);
+            if (max == null) {
+                return Collections.emptyIterator();
+            }
+
+            Map<Id, BackendEntry> results = new HashMap<>();
             Map.Entry<Id, BackendEntry> entry = keyMinEq ?
                                                 rs.ceilingEntry(min) :
                                                 rs.higherEntry(min);
-            max = keyMaxEq ? rs.floorKey(max) : rs.lowerKey(max);
             while (entry != null) {
                 if (entry.getKey().compareTo(max) > 0) {
                     break;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
@@ -676,7 +676,8 @@ public class GraphTransaction extends IndexableTransaction {
             return;
         }
         // Check is updating property of added/removed vertex
-        E.checkArgument(!this.addedVertexes.containsKey(vertex.id()),
+        E.checkArgument(!this.addedVertexes.containsKey(vertex.id()) ||
+                        this.updatedVertexes.containsKey(vertex.id()),
                         "Can't remove property '%s' for adding-state vertex",
                         prop.key());
         E.checkArgument(!this.removedVertexes.containsKey(vertex.id()),

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/SchemaTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/SchemaTransaction.java
@@ -446,6 +446,7 @@ public class SchemaTransaction extends IndexableTransaction {
             assert baseType == HugeType.EDGE_LABEL;
             schemaLabel = this.getEdgeLabel(baseValue);
         }
+        assert schemaLabel != null;
         schemaLabel.removeIndexLabel(label.id());
         this.updateSchema(schemaLabel);
     }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/task/HugeTaskScheduler.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/task/HugeTaskScheduler.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -55,6 +56,7 @@ import com.baidu.hugegraph.type.define.HugeKeys;
 import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.Events;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 public class HugeTaskScheduler {
 
@@ -105,9 +107,11 @@ public class HugeTaskScheduler {
     }
 
     private void listenChanges() {
-        // Listen store event: "store.init"
+        // Listen store event: "store.init", "store.truncate"
+        Set<String> storeEvents = ImmutableSet.of(Events.STORE_INIT,
+                                                  Events.STORE_TRUNCATE);
         this.graph.loadSystemStore().provider().listen(event -> {
-            if (Events.STORE_INIT.equals(event.name())) {
+            if (storeEvents.contains(event.name())) {
                 this.submit(() -> this.tx().initSchema());
                 return true;
             }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/util/Events.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/util/Events.java
@@ -27,4 +27,5 @@ public final class Events {
     public static final String STORE_CLOSE = "store.close";
     public static final String STORE_INIT = "store.init";
     public static final String STORE_CLEAR = "store.clear";
+    public static final String STORE_TRUNCATE = "store.truncate";
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/version/CoreVersion.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/version/CoreVersion.java
@@ -38,7 +38,7 @@ public class CoreVersion {
 
     public static void check() {
         // Check version of hugegraph-common
-        VersionUtil.check(CommonVersion.VERSION, "1.4.0", "1.5",
+        VersionUtil.check(CommonVersion.VERSION, "1.5", "1.6",
                           CommonVersion.NAME);
     }
 }

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.Future;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -169,6 +170,19 @@ public class HbaseSessions extends BackendSessionPool {
                 // pass
             }
             admin.deleteTable(tableName);
+        }
+    }
+
+    public Future<Void> truncateTable(String table) throws IOException {
+        assert this.existsTable(table);
+        TableName tableName = TableName.valueOf(this.namespace, table);
+        try(Admin admin = this.hbase.getAdmin()) {
+            try {
+                admin.disableTable(tableName);
+            } catch (TableNotEnabledException ignored) {
+                // pass
+            }
+            return admin.truncateTableAsync(tableName, false);
         }
     }
 

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStore.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStore.java
@@ -216,6 +216,8 @@ public abstract class HbaseStore implements BackendStore {
                           e, table, this.store);
             }
         }
+
+        LOG.debug("Store initialized: {}", this.store);
     }
 
     @Override
@@ -258,6 +260,26 @@ public abstract class HbaseStore implements BackendStore {
                           e, this.namespace, this.store);
             }
         }
+
+        LOG.debug("Store cleared: {}", this.store);
+    }
+
+    @Override
+    public void truncate() {
+        this.checkOpened();
+
+        // Truncate tables
+        for (String table : this.tableNames()) {
+            try {
+                this.sessions.truncateTable(table);
+            } catch (IOException e) {
+                throw new BackendException(
+                          "Failed to truncate table '%s' for '%s'",
+                          e, table, this.store);
+            }
+        }
+
+        LOG.debug("Store truncated: {}", this.store);
     }
 
     @Override

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseTables.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseTables.java
@@ -157,6 +157,12 @@ public class HbaseTables {
         }
 
         @Override
+        public void eliminate(Session session, BackendEntry entry) {
+            assert entry.columns().size() == 1;
+            super.delete(session, entry);
+        }
+
+        @Override
         public void delete(Session session, BackendEntry entry) {
             /*
              * Only delete index by label will come here
@@ -164,6 +170,7 @@ public class HbaseTables {
              */
             int count = 0;
             for (BackendColumn column : entry.columns()) {
+                session.commit();
                 // Prefix query index label related indexes
                 RowIterator iter = session.scan(this.table(), column.name);
                 while (iter.hasNext()) {
@@ -190,7 +197,7 @@ public class HbaseTables {
         }
     }
 
-    public static class SearchIndex extends SecondaryIndex {
+    public static class SearchIndex extends IndexTable {
 
         public static final String TABLE = "fi";
 

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
@@ -293,6 +293,10 @@ public class MysqlSessions extends BackendSessionPool {
             this.conn.setAutoCommit(false);
         }
 
+        public void end() throws SQLException {
+            this.conn.setAutoCommit(true);
+        }
+
         @Override
         public Integer commit() {
             int updated = 0;
@@ -304,6 +308,10 @@ public class MysqlSessions extends BackendSessionPool {
                 this.clear();
             } catch (SQLException e) {
                 throw new BackendException("Failed to commit", e);
+            } finally {
+                try {
+                    this.end();
+                } catch (SQLException ignored) {}
             }
             return updated;
         }
@@ -314,6 +322,10 @@ public class MysqlSessions extends BackendSessionPool {
                 this.conn.rollback();
             } catch (SQLException e) {
                 throw new BackendException("Failed to rollback", e);
+            } finally {
+                try {
+                    this.end();
+                } catch (SQLException ignored) {}
             }
         }
 
@@ -323,6 +335,7 @@ public class MysqlSessions extends BackendSessionPool {
         }
 
         public ResultSet select(String sql) throws SQLException {
+            assert this.conn.getAutoCommit();
             return this.conn.createStatement().executeQuery(sql);
         }
 

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlStoreProvider.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlStoreProvider.java
@@ -55,7 +55,7 @@ public class MysqlStoreProvider extends AbstractBackendStoreProvider {
         if (itor.hasNext()) {
             itor.next().clear();
         }
-        this.storeEventHub.notify(Events.STORE_CLEAR, this);
+        this.notifyAndWaitEvent(Events.STORE_CLEAR);
     }
 
     @Override

--- a/hugegraph-palo/src/main/java/com/baidu/hugegraph/backend/store/palo/PaloStore.java
+++ b/hugegraph-palo/src/main/java/com/baidu/hugegraph/backend/store/palo/PaloStore.java
@@ -47,7 +47,7 @@ public abstract class PaloStore extends MysqlStore {
     }
 
     private List<String> tableNames() {
-        return this.tables().values().stream().map(BackendTable::table)
+        return this.tables().stream().map(BackendTable::table)
                    .collect(Collectors.toList());
     }
 }

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStore.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStore.java
@@ -276,7 +276,7 @@ public abstract class RocksDBStore implements BackendStore {
             this.createTable(db, table);
         }
 
-        LOG.info("Store initialized: {}", this.store);
+        LOG.debug("Store initialized: {}", this.store);
     }
 
     private void createTable(RocksDBSessions db, String table) {
@@ -303,7 +303,7 @@ public abstract class RocksDBStore implements BackendStore {
             this.dropTable(db, table);
         }
 
-        LOG.info("Store cleared: {}", this.store);
+        LOG.debug("Store cleared: {}", this.store);
     }
 
     private void dropTable(RocksDBSessions db, String table) {
@@ -318,6 +318,16 @@ public abstract class RocksDBStore implements BackendStore {
             throw new BackendException("Failed to drop '%s' for '%s'",
                                        e, table, this.store);
         }
+    }
+
+    @Override
+    public void truncate() {
+        this.checkOpened();
+
+        this.clear();
+        this.init();
+
+        LOG.debug("Store truncated: {}", this.store);
     }
 
     @Override

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBTables.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBTables.java
@@ -152,16 +152,16 @@ public class RocksDBTables {
         }
     }
 
-    public static class SecondaryIndex extends RocksDBTable {
+    public static class IndexTable extends RocksDBTable {
 
-        public static final String TABLE = "si";
-
-        public SecondaryIndex(String database) {
-            this(database, TABLE);
+        public IndexTable(String database, String table) {
+            super(database, table);
         }
 
-        protected SecondaryIndex(String database, String table) {
-            super(database, table);
+        @Override
+        public void eliminate(Session session, BackendEntry entry) {
+            assert entry.columns().size() == 1;
+            super.delete(session, entry);
         }
 
         @Override
@@ -177,7 +177,16 @@ public class RocksDBTables {
         }
     }
 
-    public static class SearchIndex extends SecondaryIndex {
+    public static class SecondaryIndex extends IndexTable {
+
+        public static final String TABLE = "si";
+
+        public SecondaryIndex(String database) {
+            super(database, TABLE);
+        }
+    }
+
+    public static class SearchIndex extends IndexTable {
 
         public static final String TABLE = "fi";
 
@@ -186,7 +195,7 @@ public class RocksDBTables {
         }
     }
 
-    public static class RangeIndex extends RocksDBTable {
+    public static class RangeIndex extends IndexTable {
 
         public static final String TABLE = "ri";
 
@@ -245,17 +254,6 @@ public class RocksDBTables {
                 byte[] end = max.asBytes();
                 int type = maxEq ? Session.SCAN_LTE_END : Session.SCAN_LT_END;
                 return session.scan(this.table(), begin, end, type);
-            }
-        }
-
-        @Override
-        public void delete(Session session, BackendEntry entry) {
-            /*
-             * Only delete index by label will come here
-             * Regular index delete will call eliminate()
-             */
-            for (BackendEntry.BackendColumn column : entry.columns()) {
-                session.delete(this.table(), column.name);
             }
         }
     }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/tinkerpop/TestGraph.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/tinkerpop/TestGraph.java
@@ -35,6 +35,7 @@ import org.apache.tinkerpop.gremlin.structure.io.Io;
 
 import com.baidu.hugegraph.HugeGraph;
 import com.baidu.hugegraph.io.HugeGraphIoRegistry;
+import com.baidu.hugegraph.schema.PropertyKey;
 import com.baidu.hugegraph.schema.SchemaManager;
 import com.baidu.hugegraph.structure.HugeFeatures;
 import com.baidu.hugegraph.type.define.IdStrategy;
@@ -46,6 +47,9 @@ import com.baidu.hugegraph.type.define.IdStrategy;
 public class TestGraph implements Graph {
 
     public static final String DEFAULT_VL = "vertex";
+
+    public static final List<String> TRUNCATE_BACKENDS =
+           Arrays.asList("rocksdb", "mysql");
 
     private static volatile int id = 666;
 
@@ -72,6 +76,33 @@ public class TestGraph implements Graph {
     protected void clearBackend() {
         this.graph.clearBackend();
         this.initedBackend = false;
+    }
+
+    protected void clearAll(String testClass) {
+        List<PropertyKey> pks = this.graph.schema().getPropertyKeys();
+        if (pks.isEmpty()) {
+            // No need to clear if there is no PKs(that's no schema and data)
+            return;
+        }
+
+        if (TRUNCATE_BACKENDS.contains(this.graph.backend())) {
+            // Delete all data by truncating tables
+            this.truncateBackend();
+        } else {
+            // Clear schema (also include data)
+            this.clearSchema();
+
+            // Clear variables if needed (would not clear when clearing schema)
+            if (testClass.endsWith("VariableAsMapTest")) {
+                this.clearVariables();
+            }
+
+            this.tx().commit();
+        }
+    }
+
+    protected void truncateBackend() {
+        this.graph.truncateBackend();
     }
 
     protected void clearSchema() {

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/tinkerpop/TestGraphProvider.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/tinkerpop/TestGraphProvider.java
@@ -63,15 +63,18 @@ public class TestGraphProvider extends AbstractGraphProvider {
     private static final String CONF_PATH = "hugegraph.properties";
     private static final String FILTER = "test.tinkerpop.filter";
     private static final String DEFAULT_FILTER = "methods.filter";
+
     private static final String TEST_CLASS = "testClass";
     private static final String TEST_METHOD = "testMethod";
+
     private static final String LOAD_GRAPH = "loadGraph";
-    private static final String AKEY = "aKey";
     private static final String STANDARD = "standard";
     private static final String REGULAR_LOAD = "regularLoad";
+
     private static final String GREMLIN_GRAPH_KEY = "gremlin.graph";
     private static final String GREMLIN_GRAPH_VALUE =
             "com.baidu.hugegraph.tinkerpop.TestGraphFactory";
+
     private static final String AKEY_CLASS_PREFIX =
             "org.apache.tinkerpop.gremlin.structure." +
             "PropertyTest.PropertyFeatureSupportTest";
@@ -160,10 +163,10 @@ public class TestGraphProvider extends AbstractGraphProvider {
     @Override
     public Map<String, Object> getBaseConfiguration(
                                String graphName,
-                               Class<?> test, String testMethod,
+                               Class<?> testClass, String testMethod,
                                LoadGraphWith.GraphData graphData) {
         // Check if test in blackList
-        String testFullName = test.getCanonicalName() + "." + testMethod;
+        String testFullName = testClass.getCanonicalName() + "." + testMethod;
         int index = testFullName.indexOf('@') == -1 ?
                     testFullName.length() : testFullName.indexOf('@');
 
@@ -187,7 +190,7 @@ public class TestGraphProvider extends AbstractGraphProvider {
         confMap.put(CoreOptions.STORE.name(),
                     storePrefix + "_" + this.suite + "_" + graphName);
         confMap.put(GREMLIN_GRAPH_KEY, GREMLIN_GRAPH_VALUE);
-        confMap.put(TEST_CLASS, test);
+        confMap.put(TEST_CLASS, testClass);
         confMap.put(TEST_METHOD, testMethod);
         confMap.put(LOAD_GRAPH, graphData);
 
@@ -223,34 +226,30 @@ public class TestGraphProvider extends AbstractGraphProvider {
         }
 
         TestGraph testGraph = this.graphs.get(graphName);
+
         // Ensure tx clean
         testGraph.tx().rollback();
 
         // Define property key 'aKey' based on specified type in test name
-        String aKeyType = getAKeyType(
-                          (Class<?>) config.getProperty(TEST_CLASS),
-                          config.getString(TEST_METHOD));
+        Class<?> testClass = (Class<?>) config.getProperty(TEST_CLASS);
+        String testMethod = config.getString(TEST_METHOD);
+        String aKeyType = getAKeyType(testClass, testMethod);
         if (aKeyType != null) {
-            testGraph.initPropertyKey(AKEY, aKeyType);
+            testGraph.initPropertyKey("aKey", aKeyType);
         }
 
-        String ioType = getIoType((Class<?>) config.getProperty(TEST_CLASS),
-                                  config.getString(TEST_METHOD));
-
         // Basic schema is initiated by default once a graph is open
-        testGraph.initBasicSchema(IdStrategy.AUTOMATIC,
-                                  TestGraph.DEFAULT_VL);
+        testGraph.initBasicSchema(IdStrategy.AUTOMATIC, TestGraph.DEFAULT_VL);
         testGraph.tx().commit();
 
         testGraph.isLastIdCustomized(false);
-        testGraph.loadedGraph(ioType);
+        testGraph.loadedGraph(getIoType(testClass, testMethod));
         testGraph.autoPerson(false);
-        testGraph.ioTest(ioTest((Class<?>) config.getProperty(TEST_CLASS)));
+        testGraph.ioTest(ioTest(testClass));
 
         Object loadGraph = config.getProperty(LOAD_GRAPH);
         if (loadGraph != null && !graphName.endsWith(STANDARD)) {
-            this.loadGraphData(testGraph,
-                               (LoadGraphWith.GraphData) loadGraph);
+            this.loadGraphData(testGraph, (LoadGraphWith.GraphData) loadGraph);
         }
 
         return testGraph;
@@ -273,12 +272,9 @@ public class TestGraphProvider extends AbstractGraphProvider {
         graph.tx().onReadWrite(Transaction.READ_WRITE_BEHAVIOR.AUTO);
         graph.tx().onClose(Transaction.CLOSE_BEHAVIOR.ROLLBACK);
 
-        // Clear schema (also include data)
-        testGraph.clearSchema();
-
-        // Clear variables (would not clear when clearing schema)
-        testGraph.clearVariables();
-        graph.tx().commit();
+        // Clear all data
+        Class<?> testClass = (Class<?>) config.getProperty(TEST_CLASS);
+        testGraph.clearAll(testClass.getCanonicalName());
     }
 
     public void clearBackends() {
@@ -308,8 +304,7 @@ public class TestGraphProvider extends AbstractGraphProvider {
         TestGraph testGraph = (TestGraph) graph;
 
         // Clear basic schema initiated in openTestGraph
-        testGraph.clearSchema();
-        testGraph.tx().commit();
+        testGraph.clearAll("");
 
         if (testGraph.loadedGraph() == null) {
             testGraph.loadedGraph(REGULAR_LOAD);

--- a/hugegraph-test/src/main/resources/hugegraph.properties
+++ b/hugegraph-test/src/main/resources/hugegraph.properties
@@ -1,7 +1,10 @@
 gremlin.graph=com.baidu.hugegraph.HugeFactory
 
-backend=${backend}
-serializer=${serializer}
+backend=rocksdb
+serializer=binary
+
+#backend=cassandra
+#serializer=cassandra
 
 store=hugegraph
 
@@ -21,9 +24,13 @@ cassandra.read_timeout=120
 #rocksdb.wal_path=
 
 # hbase backend config
-hbase.hosts=localhost
-hbase.port=8218
+#backend=hbase
+#serializer=hbase
+hbase.hosts=127.0.0.1
+hbase.port=2181
 
+#backend=mysql
+#serializer=mysql
 # mysql backend config
 jdbc.driver=com.mysql.jdbc.Driver
 jdbc.url=jdbc:mysql://127.0.0.1:3306


### PR DESCRIPTION
how to:
1.speed up rocksdb backend by truncating tables
2.don't need to clear if the database is empty
3.don't need to clear variables if it's empty
4.don't need to commit hbase each len-prefix for delete index-label

potential problems:
1.mysql may block if create task vertex-label when truncating table
2.rocksdb may miss CF if create task vertex-label when truncating table
3.hbase may block if truncate hbase with version<2.0

improve #14

Change-Id: I4b2393aea8b0fc63c1886e984a576a1f5808b25c