### PR TITLE
Fix scylladb backend init-store failed

### DIFF
--- a/hugegraph-scylladb/src/main/java/com/baidu/hugegraph/backend/store/scylladb/ScyllaDBStoreProvider.java
+++ b/hugegraph-scylladb/src/main/java/com/baidu/hugegraph/backend/store/scylladb/ScyllaDBStoreProvider.java
@@ -114,7 +114,7 @@ public class ScyllaDBStoreProvider extends CassandraStoreProvider {
                 registerTableManager(HugeType.EDGE_IN,
                                      ScyllaDBTablesWithMV.Edge.in(store));
             } else {
-                registerTableManager(HugeType.EDGE_OUT,
+                registerTableManager(HugeType.VERTEX,
                                      new ScyllaDBTables.Vertex(store));
                 registerTableManager(HugeType.EDGE_OUT,
                                      ScyllaDBTables.Edge.out(store));


### PR DESCRIPTION
The exception is "Indexes are not supported yet"

Fix: #48

Change-Id: I5012e2684b7d95ded236207b441fc71d77851fe7