### PR TITLE
Commit index updates in batch

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/job/GremlinAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/job/GremlinAPI.java
@@ -75,10 +75,11 @@ public class GremlinAPI extends API {
 
         HugeGraph g = graph(manager, graph);
         request.aliase(graph, "graph");
-        JobBuilder builder = JobBuilder.of(g).name(request.name())
-                                       .input(request.toJson())
-                                       .job(new GremlinJob());
-        return ImmutableMap.of("task_id", builder.schedule());
+        JobBuilder<Object> builder = JobBuilder.of(g);
+        builder.name(request.name())
+               .input(request.toJson())
+               .job(new GremlinJob());
+        return ImmutableMap.of("task_id", builder.schedule().id());
     }
 
     public static class GremlinJob extends Job<Object> {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeGraph.java
@@ -550,6 +550,12 @@ public class HugeGraph implements Graph {
             return this.refs.get() == 0;
         }
 
+        public void commitIfGtSize(int size) {
+            // Only committing graph transaction data if reaching batch size
+            // is OK, bacause schema transaction is auto committed.
+            this.graphTransaction().commitIfGtSize(size);
+        }
+
         @Override
         public void commit() {
             try {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/Transaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/Transaction.java
@@ -23,6 +23,8 @@ public interface Transaction {
 
     public void commit() throws BackendException;
 
+    public void commitIfGtSize(int size) throws BackendException;
+
     public void rollback() throws BackendException;
 
     public boolean autoCommit();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CacheManager.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CacheManager.java
@@ -87,11 +87,9 @@ public class CacheManager {
     }
 
     public Cache cache(String name, int capacity) {
-        Cache cache = this.caches.get(name);
-        if (cache == null) {
-            cache = new RamCache(capacity);
-            this.caches.put(name, cache);
+        if (!this.caches.containsKey(name)) {
+            this.caches.putIfAbsent(name, new RamCache(capacity));
         }
-        return cache;
+        return this.caches.get(name);
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/AbstractTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/AbstractTransaction.java
@@ -170,6 +170,12 @@ public abstract class AbstractTransaction implements Transaction {
         }
     }
 
+    public void commitIfGtSize(int size) throws BackendException {
+        if (this.mutationSize() >= size) {
+            this.commit();
+        }
+    }
+
     @Watched(prefix = "tx")
     @Override
     public void rollback() throws BackendException {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
@@ -446,7 +446,7 @@ public class GraphTransaction extends IndexableTransaction {
         return r;
     }
 
-    private Iterator<HugeVertex> queryVerticesFromBackend(Query query) {
+    protected Iterator<HugeVertex> queryVerticesFromBackend(Query query) {
         assert query.resultType().isVertex();
 
         Iterator<BackendEntry> entries = this.query(query);
@@ -562,7 +562,7 @@ public class GraphTransaction extends IndexableTransaction {
         return r;
     }
 
-    private Iterator<HugeEdge> queryEdgesFromBackend(Query query) {
+    protected Iterator<HugeEdge> queryEdgesFromBackend(Query query) {
         assert query.resultType().isEdge();
 
         Iterator<BackendEntry> entries = this.query(query);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/JobBuilder.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/JobBuilder.java
@@ -26,42 +26,42 @@ import com.baidu.hugegraph.task.HugeTaskScheduler;
 import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.util.E;
 
-public class JobBuilder {
+public class JobBuilder<T> {
 
     private final HugeGraph graph;
 
     private String name;
     private String input;
-    private Job<?> job;
+    private Job<T> job;
 
-    public static JobBuilder of(final HugeGraph graph) {
-        return new JobBuilder(graph);
+    public static <T> JobBuilder<T> of(final HugeGraph graph) {
+        return new JobBuilder<>(graph);
     }
 
     public JobBuilder(final HugeGraph graph) {
         this.graph = graph;
     }
 
-    public JobBuilder name(String name) {
+    public JobBuilder<T> name(String name) {
         this.name = name;
         return this;
     }
 
-    public JobBuilder input(String input) {
+    public JobBuilder<T> input(String input) {
         this.input = input;
         return this;
     }
 
-    public JobBuilder job(Job<?> job) {
+    public JobBuilder<T> job(Job<T> job) {
         this.job = job;
         return this;
     }
 
-    public Id schedule() {
+    public HugeTask<T> schedule() {
         E.checkArgumentNotNull(this.name, "Job name can't be null");
         E.checkArgumentNotNull(this.job, "Job can't be null");
 
-        HugeTask<?> task = new HugeTask<>(this.genTaskId(), null, this.job);
+        HugeTask<T> task = new HugeTask<>(this.genTaskId(), null, this.job);
         task.type(this.job.type());
         task.name(this.name);
         if (this.input != null) {
@@ -72,7 +72,7 @@ public class JobBuilder {
         scheduler.schedule(task);
         scheduler.save(task);
 
-        return task.id();
+        return task;
     }
 
     private Id genTaskId() {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/schema/VertexLabelRemoveCallable.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/schema/VertexLabelRemoveCallable.java
@@ -19,7 +19,19 @@
 
 package com.baidu.hugegraph.job.schema;
 
+import java.util.List;
+import java.util.Set;
+
+import com.baidu.hugegraph.HugeException;
+import com.baidu.hugegraph.HugeGraph;
+import com.baidu.hugegraph.backend.id.Id;
+import com.baidu.hugegraph.backend.tx.GraphTransaction;
 import com.baidu.hugegraph.backend.tx.SchemaTransaction;
+import com.baidu.hugegraph.schema.EdgeLabel;
+import com.baidu.hugegraph.schema.VertexLabel;
+import com.baidu.hugegraph.type.define.SchemaStatus;
+import com.baidu.hugegraph.util.LockUtil;
+import com.google.common.collect.ImmutableSet;
 
 public class VertexLabelRemoveCallable extends SchemaCallable {
 
@@ -30,7 +42,50 @@ public class VertexLabelRemoveCallable extends SchemaCallable {
 
     @Override
     public Object execute() {
-        SchemaTransaction.removeVertexLabelSync(this.graph(), this.schemaId());
+        removeVertexLabel(this.graph(), this.schemaId());
         return null;
+    }
+
+    protected static void removeVertexLabel(HugeGraph graph, Id id) {
+        GraphTransaction graphTx = graph.graphTransaction();
+        SchemaTransaction schemaTx = graph.schemaTransaction();
+        VertexLabel vertexLabel = schemaTx.getVertexLabel(id);
+        // If the vertex label does not exist, return directly
+        if (vertexLabel == null) {
+            return;
+        }
+
+        List<EdgeLabel> edgeLabels = schemaTx.getEdgeLabels();
+        for (EdgeLabel edgeLabel : edgeLabels) {
+            if (edgeLabel.linkWithLabel(id)) {
+                throw new HugeException(
+                          "Not allowed to remove vertex label '%s' " +
+                          "because the edge label '%s' still link with it",
+                          vertexLabel.name(), edgeLabel.name());
+            }
+        }
+
+        /*
+         * Copy index label ids because removeIndexLabel will mutate
+         * vertexLabel.indexLabels()
+         */
+        Set<Id> indexLabelIds = ImmutableSet.copyOf(vertexLabel.indexLabels());
+        LockUtil.Locks locks = new LockUtil.Locks();
+        try {
+            locks.lockWrites(LockUtil.VERTEX_LABEL_DELETE, id);
+            schemaTx.updateSchemaStatus(vertexLabel, SchemaStatus.DELETING);
+            for (Id indexLabelId : indexLabelIds) {
+                IndexLabelRemoveCallable.removeIndexLabel(graph, indexLabelId);
+            }
+
+            // TODO: use event to replace direct call
+            // Deleting a vertex will automatically deletes the held edge
+            graphTx.removeVertices(vertexLabel);
+            removeSchema(schemaTx, vertexLabel);
+            // Should commit changes to backend store before release delete lock
+            graph.tx().commit();
+        } finally {
+            locks.unlock();
+        }
     }
 }


### PR DESCRIPTION
1. To avoid commit all together during rebuilding index,
   especially for Cassandra backend, which has batch limit 65535
2. Also move async codes to com.baidu.hugegraph.job package
3. fix bug that CacheManager might create more than one cache with same name

fixed: #144
implemented: #82

Change-Id: I88ff4bc878bc24122f0bb6ecf9964246a083b9ab