### PR TITLE
fix bug "Can't operate a tx in other threads"

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
@@ -133,11 +133,13 @@ public class CachedGraphTransaction extends GraphTransaction {
 
         try {
             super.commit();
-        } finally {
             // Update vertex cache
             for (HugeVertex vertex : changes) {
+                vertex = vertex.resetTx();
                 this.verticesCache.updateIfPresent(vertex.id(), vertex);
             }
+        } finally {
+            // Update removed vertex in cache whatever success or fail
             for (HugeVertex vertex : deletions) {
                 this.verticesCache.invalidate(vertex.id());
             }


### PR DESCRIPTION
vertexes cached hava tx info after adjust cache layer

Change-Id: I7040d185ec089a6a3bd45ac305eefbfe2c0e1b73