### PR TITLE
speed up tinkerpop test

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/GraphsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/GraphsAPI.java
@@ -37,13 +37,10 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 
 import com.baidu.hugegraph.HugeGraph;
 import com.baidu.hugegraph.core.GraphManager;
-import com.baidu.hugegraph.schema.SchemaManager;
 import com.baidu.hugegraph.server.RestServer;
 import com.baidu.hugegraph.type.define.GraphMode;
 import com.baidu.hugegraph.util.E;
@@ -129,27 +126,7 @@ public class GraphsAPI extends API {
             throw new IllegalArgumentException(String.format(
                       "Please take the message: %s", CONFIRM_CLEAR));
         }
-
-        // Clear vertex and edge
-        commit(g, () -> {
-            g.traversal().E().toStream().forEach(Edge::remove);
-            g.traversal().V().toStream().forEach(Vertex::remove);
-        });
-
-        // Schema operation will auto commit
-        SchemaManager schema = g.schema();
-        schema.getIndexLabels().forEach(elem -> {
-            schema.indexLabel(elem.name()).remove();
-        });
-        schema.getEdgeLabels().forEach(elem -> {
-            schema.edgeLabel(elem.name()).remove();
-        });
-        schema.getVertexLabels().forEach(elem -> {
-            schema.vertexLabel(elem.name()).remove();
-        });
-        schema.getPropertyKeys().forEach(elem -> {
-            schema.propertyKey(elem.name()).remove();
-        });
+        g.truncateBackend();
     }
 
     @PUT

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/auth/HugeGraphAuthProxy.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/auth/HugeGraphAuthProxy.java
@@ -178,6 +178,12 @@ public class HugeGraphAuthProxy implements GremlinGraph {
         this.hugegraph.clearBackend();
     }
 
+    @Override
+    public void truncateBackend() {
+        this.verifyPermission(ROLE_ADMIN);
+        this.hugegraph.truncateBackend();
+    }
+
     private void verifyPermission() {
         /*
          * The owner role should match the graph name

--- a/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraSessionPool.java
+++ b/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraSessionPool.java
@@ -222,6 +222,10 @@ public class CassandraSessionPool extends BackendSessionPool {
             this.session = cluster().connect(keyspace());
         }
 
+        public boolean opened() {
+            return this.session != null;
+        }
+
         @Override
         public boolean closed() {
             if (this.session == null) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/GremlinGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/GremlinGraph.java
@@ -33,6 +33,8 @@ public interface GremlinGraph extends Graph {
     public SchemaManager schema();
 
     public String backend();
+
     public void initBackend();
     public void clearBackend();
+    public void truncateBackend();
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/LocalCounter.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/LocalCounter.java
@@ -72,4 +72,8 @@ public class LocalCounter {
         AtomicLong value = new AtomicLong(oldValue + increment);
         this.counters.put(type, value);
     }
+
+    public void reset() {
+        this.counters.clear();
+    }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedBackendStore.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedBackendStore.java
@@ -82,6 +82,11 @@ public class CachedBackendStore implements BackendStore {
     }
 
     @Override
+    public void truncate() {
+        this.store.truncate();
+    }
+
+    @Override
     public void beginTx() {
         this.store.beginTx();
     }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinarySerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinarySerializer.java
@@ -536,6 +536,7 @@ public class BinarySerializer extends AbstractSerializer {
             case SEARCH_INDEX:
                 String idString = id.asString();
                 int idLength = idString.length();
+                // TODO: to improve, use BytesBuffer to generate a mask
                 for (int i = idLength - 1; i < 128; i++) {
                     BytesBuffer buffer = BytesBuffer.allocate(idLength + 1);
                     /*

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStore.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStore.java
@@ -47,6 +47,9 @@ public interface BackendStore {
     public void init();
     public void clear();
 
+    // Delete all data of database (keep table structure)
+    public void truncate();
+
     // Add/delete data
     public void mutate(BackendMutation mutation);
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStoreProvider.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStoreProvider.java
@@ -46,5 +46,9 @@ public interface BackendStoreProvider {
 
     public void clear();
 
+    public void truncate();
+
     public void listen(EventListener listener);
+
+    public void unlisten(EventListener listener);
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/memory/InMemoryDBStoreProvider.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/memory/InMemoryDBStoreProvider.java
@@ -26,6 +26,7 @@ import com.baidu.hugegraph.backend.store.AbstractBackendStoreProvider;
 import com.baidu.hugegraph.backend.store.BackendStore;
 import com.baidu.hugegraph.backend.store.memory.InMemoryDBStore.InMemoryGraphStore;
 import com.baidu.hugegraph.backend.store.memory.InMemoryDBStore.InMemorySchemaStore;
+import com.baidu.hugegraph.util.Events;
 
 public class InMemoryDBStoreProvider extends AbstractBackendStoreProvider {
 
@@ -50,6 +51,18 @@ public class InMemoryDBStoreProvider extends AbstractBackendStoreProvider {
 
     private InMemoryDBStoreProvider(String graph) {
         this.open(graph);
+    }
+
+    @Override
+    public void open(String graph) {
+        super.open(graph);
+        /*
+         * Memory store need to init some system property,
+         * like task related property-keys and vertex-labels.
+         * don't notify from store.open() due to task-tx will
+         * call it again and cause dead
+         */
+        this.notifyAndWaitEvent(Events.STORE_INIT);
     }
 
     @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/memory/InMemoryDBTables.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/memory/InMemoryDBTables.java
@@ -345,16 +345,21 @@ public class InMemoryDBTables {
                                                     Object keyMin,
                                                     boolean keyMinEq) {
             NavigableMap<Id, BackendEntry> rs = this.store();
-            Map<Id, BackendEntry> results = new HashMap<>();
 
             Id min = HugeIndex.formatIndexId(HugeType.RANGE_INDEX,
                                              indexLabelId, keyMin);
             Id max = HugeIndex.formatIndexId(HugeType.RANGE_INDEX,
                                              indexLabelId, keyMax);
+
+            max = keyMaxEq ? rs.floorKey(max) : rs.lowerKey(max);
+            if (max == null) {
+                return Collections.emptyIterator();
+            }
+
+            Map<Id, BackendEntry> results = new HashMap<>();
             Map.Entry<Id, BackendEntry> entry = keyMinEq ?
                                                 rs.ceilingEntry(min) :
                                                 rs.higherEntry(min);
-            max = keyMaxEq ? rs.floorKey(max) : rs.lowerKey(max);
             while (entry != null) {
                 if (entry.getKey().compareTo(max) > 0) {
                     break;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
@@ -741,7 +741,8 @@ public class GraphTransaction extends IndexableTransaction {
             return;
         }
         // Check is updating property of added/removed vertex
-        E.checkArgument(!this.addedVertexes.containsKey(vertex.id()),
+        E.checkArgument(!this.addedVertexes.containsKey(vertex.id()) ||
+                        this.updatedVertexes.containsKey(vertex.id()),
                         "Can't remove property '%s' for adding-state vertex",
                         prop.key());
         E.checkArgument(!this.removedVertexes.containsKey(vertex.id()),

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/config/CoreOptions.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/config/CoreOptions.java
@@ -103,6 +103,15 @@ public class CoreOptions extends OptionHolder {
                     0
             );
 
+    public static final ConfigOption<Long> TASK_WAIT_TIMEOUT =
+            new ConfigOption<>(
+                    "task.wait_timeout",
+                    "Timeout in seconds for waiting for the task to complete," +
+                    "such as when truncating or clearing the backend.",
+                    rangeInt(0L, Long.MAX_VALUE),
+                    10L
+            );
+
     public static final ConfigOption<String> VERTEX_DEFAULT_LABEL =
             new ConfigOption<>(
                     "vertex.default_label",
@@ -155,6 +164,14 @@ public class CoreOptions extends OptionHolder {
                     "The max cache size(items) of schema cache.",
                     rangeInt(1, Integer.MAX_VALUE),
                     100000
+            );
+
+    public static final ConfigOption<Boolean> SCHEMA_SYNC_DELETION =
+            new ConfigOption<>(
+                    "schema.sync_deletion",
+                    "Whether to delete schema synchronously.",
+                    disallowEmpty(),
+                    false
             );
 
     public static final ConfigOption<Integer> VERTEX_CACHE_CAPACITY =
@@ -247,12 +264,5 @@ public class CoreOptions extends OptionHolder {
                     "}",
                     disallowEmpty(),
                     "smart"
-            );
-    public static final ConfigOption<Boolean> SCHEMA_SYNC_DELETION =
-            new ConfigOption<>(
-                    "schema.sync_deletion",
-                    "Whether to delete schema synchronously.",
-                    disallowEmpty(),
-                    false
             );
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/schema/SchemaCallable.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/schema/SchemaCallable.java
@@ -58,6 +58,7 @@ public abstract class SchemaCallable extends Job<Object> {
             assert baseType == HugeType.EDGE_LABEL;
             schemaLabel = tx.getEdgeLabel(baseValue);
         }
+        assert schemaLabel != null;
         schemaLabel.removeIndexLabel(label.id());
         updateSchema(tx, schemaLabel);
     }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/schema/builder/IndexLabelBuilder.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/schema/builder/IndexLabelBuilder.java
@@ -31,6 +31,7 @@ import com.baidu.hugegraph.backend.id.Id;
 import com.baidu.hugegraph.backend.id.IdGenerator;
 import com.baidu.hugegraph.backend.tx.GraphTransaction;
 import com.baidu.hugegraph.backend.tx.SchemaTransaction;
+import com.baidu.hugegraph.config.CoreOptions;
 import com.baidu.hugegraph.exception.ExistedException;
 import com.baidu.hugegraph.exception.NotSupportException;
 import com.baidu.hugegraph.schema.EdgeLabel;
@@ -39,7 +40,6 @@ import com.baidu.hugegraph.schema.PropertyKey;
 import com.baidu.hugegraph.schema.SchemaElement;
 import com.baidu.hugegraph.schema.SchemaLabel;
 import com.baidu.hugegraph.schema.VertexLabel;
-import com.baidu.hugegraph.task.TaskScheduler;
 import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.type.define.Cardinality;
 import com.baidu.hugegraph.type.define.DataType;
@@ -136,10 +136,10 @@ public class IndexLabelBuilder implements IndexLabel.Builder {
             E.checkNotNull(indexLabel, "index label");
             return indexLabel;
         }
-        TaskScheduler scheduler = this.transaction.graph().taskScheduler();
+        HugeGraph graph = this.transaction.graph();
+        long timeout = graph.configuration().get(CoreOptions.TASK_WAIT_TIMEOUT);
         try {
-            // TODO: read timeout from config file
-            scheduler.waitUntilTaskCompleted(task, 30L);
+            graph.taskScheduler().waitUntilTaskCompleted(task, timeout);
         } catch (TimeoutException e) {
             throw new HugeException(
                       "Failed to wait index-creating task completed", e);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/HugeGraphStepStrategy.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/HugeGraphStepStrategy.java
@@ -60,7 +60,7 @@ public final class HugeGraphStepStrategy
             // TODO: support order-by optimize
             // TraversalUtil.extractOrder(newStep, traversal);
 
-            TraversalUtil.extractRange(newStep, traversal);
+            TraversalUtil.extractRange(newStep, traversal, false);
 
             TraversalUtil.extractCount(newStep, traversal);
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/HugeVertexStepStrategy.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/HugeVertexStepStrategy.java
@@ -59,7 +59,7 @@ public final class HugeVertexStepStrategy
             // TODO: support order-by optimize
             // TraversalUtil.extractOrder(newStep, traversal);
 
-            TraversalUtil.extractRange(newStep, traversal);
+            TraversalUtil.extractRange(newStep, traversal, true);
 
             TraversalUtil.extractCount(newStep, traversal);
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/util/Events.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/util/Events.java
@@ -27,4 +27,5 @@ public final class Events {
     public static final String STORE_CLOSE = "store.close";
     public static final String STORE_INIT = "store.init";
     public static final String STORE_CLEAR = "store.clear";
+    public static final String STORE_TRUNCATE = "store.truncate";
 }

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.Future;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -169,6 +170,19 @@ public class HbaseSessions extends BackendSessionPool {
                 // pass
             }
             admin.deleteTable(tableName);
+        }
+    }
+
+    public Future<Void> truncateTable(String table) throws IOException {
+        assert this.existsTable(table);
+        TableName tableName = TableName.valueOf(this.namespace, table);
+        try(Admin admin = this.hbase.getAdmin()) {
+            try {
+                admin.disableTable(tableName);
+            } catch (TableNotEnabledException ignored) {
+                // pass
+            }
+            return admin.truncateTableAsync(tableName, false);
         }
     }
 

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStore.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStore.java
@@ -225,6 +225,8 @@ public abstract class HbaseStore extends AbstractBackendStore {
                           e, table, this.store);
             }
         }
+
+        LOG.debug("Store initialized: {}", this.store);
     }
 
     @Override
@@ -267,6 +269,26 @@ public abstract class HbaseStore extends AbstractBackendStore {
                           e, this.namespace, this.store);
             }
         }
+
+        LOG.debug("Store cleared: {}", this.store);
+    }
+
+    @Override
+    public void truncate() {
+        this.checkOpened();
+
+        // Truncate tables
+        for (String table : this.tableNames()) {
+            try {
+                this.sessions.truncateTable(table);
+            } catch (IOException e) {
+                throw new BackendException(
+                          "Failed to truncate table '%s' for '%s'",
+                          e, table, this.store);
+            }
+        }
+
+        LOG.debug("Store truncated: {}", this.store);
     }
 
     @Override

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseTables.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseTables.java
@@ -228,7 +228,7 @@ public class HbaseTables {
         }
     }
 
-    public static class SearchIndex extends SecondaryIndex {
+    public static class SearchIndex extends IndexTable {
 
         public static final String TABLE = "fi";
 

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlStoreProvider.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlStoreProvider.java
@@ -55,7 +55,7 @@ public class MysqlStoreProvider extends AbstractBackendStoreProvider {
         if (itor.hasNext()) {
             itor.next().clear();
         }
-        this.storeEventHub.notify(Events.STORE_CLEAR, this);
+        this.notifyAndWaitEvent(Events.STORE_CLEAR);
     }
 
     @Override

--- a/hugegraph-palo/src/main/java/com/baidu/hugegraph/backend/store/palo/PaloStore.java
+++ b/hugegraph-palo/src/main/java/com/baidu/hugegraph/backend/store/palo/PaloStore.java
@@ -47,7 +47,7 @@ public abstract class PaloStore extends MysqlStore {
     }
 
     private List<String> tableNames() {
-        return this.tables().values().stream().map(BackendTable::table)
+        return this.tables().stream().map(BackendTable::table)
                    .collect(Collectors.toList());
     }
 }

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStore.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStore.java
@@ -312,7 +312,7 @@ public abstract class RocksDBStore extends AbstractBackendStore {
             this.createTable(db, table);
         }
 
-        LOG.info("Store initialized: {}", this.store);
+        LOG.debug("Store initialized: {}", this.store);
     }
 
     private void createTable(RocksDBSessions db, String table) {
@@ -339,7 +339,7 @@ public abstract class RocksDBStore extends AbstractBackendStore {
             this.dropTable(db, table);
         }
 
-        LOG.info("Store cleared: {}", this.store);
+        LOG.debug("Store cleared: {}", this.store);
     }
 
     private void dropTable(RocksDBSessions db, String table) {
@@ -354,6 +354,16 @@ public abstract class RocksDBStore extends AbstractBackendStore {
             throw new BackendException("Failed to drop '%s' for '%s'",
                                        e, table, this.store);
         }
+    }
+
+    @Override
+    public void truncate() {
+        this.checkOpened();
+
+        this.clear();
+        this.init();
+
+        LOG.debug("Store truncated: {}", this.store);
     }
 
     @Override

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBTables.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBTables.java
@@ -138,16 +138,16 @@ public class RocksDBTables {
         }
     }
 
-    public static class SecondaryIndex extends RocksDBTable {
+    public static class IndexTable extends RocksDBTable {
 
-        public static final String TABLE = "si";
-
-        public SecondaryIndex(String database) {
-            this(database, TABLE);
+        public IndexTable(String database, String table) {
+            super(database, table);
         }
 
-        protected SecondaryIndex(String database, String table) {
-            super(database, table);
+        @Override
+        public void eliminate(Session session, BackendEntry entry) {
+            assert entry.columns().size() == 1;
+            super.delete(session, entry);
         }
 
         @Override
@@ -163,7 +163,16 @@ public class RocksDBTables {
         }
     }
 
-    public static class SearchIndex extends SecondaryIndex {
+    public static class SecondaryIndex extends IndexTable {
+
+        public static final String TABLE = "si";
+
+        public SecondaryIndex(String database) {
+            super(database, TABLE);
+        }
+    }
+
+    public static class SearchIndex extends IndexTable {
 
         public static final String TABLE = "fi";
 
@@ -172,7 +181,7 @@ public class RocksDBTables {
         }
     }
 
-    public static class RangeIndex extends RocksDBTable {
+    public static class RangeIndex extends IndexTable {
 
         public static final String TABLE = "ri";
 
@@ -231,17 +240,6 @@ public class RocksDBTables {
                 byte[] end = max.asBytes();
                 int type = maxEq ? Session.SCAN_LTE_END : Session.SCAN_LT_END;
                 return session.scan(this.table(), begin, end, type);
-            }
-        }
-
-        @Override
-        public void delete(Session session, BackendEntry entry) {
-            /*
-             * Only delete index by label will come here
-             * Regular index delete will call eliminate()
-             */
-            for (BackendEntry.BackendColumn column : entry.columns()) {
-                session.delete(this.table(), column.name);
             }
         }
     }

--- a/hugegraph-scylladb/src/main/java/com/baidu/hugegraph/backend/store/scylladb/ScyllaDBTables.java
+++ b/hugegraph-scylladb/src/main/java/com/baidu/hugegraph/backend/store/scylladb/ScyllaDBTables.java
@@ -114,7 +114,8 @@ public class ScyllaDBTables {
      * Query data from label index table if just want to query by label
      */
     private static Query queryByLabelIndex(
-            CassandraSessionPool.Session session, String table, Query query) {
+                         CassandraSessionPool.Session session,
+                         String table, Query query) {
         Set<Condition> conditions = query.conditions();
 
         if (!(query instanceof ConditionQuery) || conditions.isEmpty()) {
@@ -145,8 +146,8 @@ public class ScyllaDBTables {
     }
 
     private static Set<String> queryByLabelIndex(
-            CassandraSessionPool.Session session, String table, Id label) {
-
+                               CassandraSessionPool.Session session,
+                               String table, Id label) {
         Select select = QueryBuilder.select().from(table);
         select.where(CassandraTable.formatEQ(HugeKeys.LABEL, label.asLong()));
 
@@ -170,20 +171,26 @@ public class ScyllaDBTables {
             super(store);
         }
 
+        private String indexTable() {
+            return joinTableName(this.table(), CassandraTables.LABEL_INDEX);
+        }
+
         @Override
         protected void createIndex(CassandraSessionPool.Session session,
                                    String indexLabel, HugeKeys column) {
             createIndexTable(session, this.indexTable());
         }
 
-        private String indexTable() {
-            return joinTableName(this.table(), CassandraTables.LABEL_INDEX);
+        @Override
+        protected void dropTable(CassandraSessionPool.Session session) {
+            session.execute(SchemaBuilder.dropTable(indexTable()).ifExists());
+            super.dropTable(session);
         }
 
         @Override
-        public void dropTable(CassandraSessionPool.Session session) {
-            session.execute(SchemaBuilder.dropTable(indexTable()).ifExists());
-            super.dropTable(session);
+        protected void truncateTable(CassandraSessionPool.Session session) {
+            session.execute(QueryBuilder.truncate(indexTable()));
+            super.truncateTable(session);
         }
 
         @Override
@@ -218,6 +225,10 @@ public class ScyllaDBTables {
             super(store, direction);
         }
 
+        private String indexTable() {
+            return joinTableName(this.table(), CassandraTables.LABEL_INDEX);
+        }
+
         @Override
         protected void createIndex(CassandraSessionPool.Session session,
                                    String indexLabel, HugeKeys column) {
@@ -225,14 +236,18 @@ public class ScyllaDBTables {
             createIndexTable(session, this.indexTable());
         }
 
-        private String indexTable() {
-            return joinTableName(this.table(), CassandraTables.LABEL_INDEX);
+        @Override
+        protected void dropTable(CassandraSessionPool.Session session) {
+            session.execute(SchemaBuilder.dropTable(indexTable()).ifExists());
+            super.dropTable(session);
         }
 
         @Override
-        public void dropTable(CassandraSessionPool.Session session) {
-            session.execute(SchemaBuilder.dropTable(indexTable()).ifExists());
-            super.dropTable(session);
+        protected void truncateTable(CassandraSessionPool.Session session) {
+            if (this.direction() == Directions.OUT) {
+                session.execute(QueryBuilder.truncate(indexTable()));
+            }
+            super.truncateTable(session);
         }
 
         @Override
@@ -340,6 +355,10 @@ public class ScyllaDBTables {
             session.execute(SchemaBuilder.dropTable(this.table).ifExists());
         }
 
+        public void truncateTable(CassandraSessionPool.Session session) {
+            session.execute(QueryBuilder.truncate(this.table));
+        }
+
         public void insert(CassandraSessionPool.Session session,
                            CassandraBackendEntry.Row entry) {
             Update update = QueryBuilder.update(this.table);
@@ -398,9 +417,11 @@ public class ScyllaDBTables {
         }
 
         private static Set<Integer> queryByNameIndex(
-                CassandraSessionPool.Session session,
-                String table, String name) {
-
+                                    CassandraSessionPool.Session session,
+                                    String table, String name) {
+            if (name.isEmpty()) {
+                return ImmutableSet.of();
+            }
             Select select = QueryBuilder.select().from(table);
             select.where(CassandraTable.formatEQ(HugeKeys.NAME, name));
 
@@ -430,9 +451,15 @@ public class ScyllaDBTables {
         }
 
         @Override
-        public void dropTable(CassandraSessionPool.Session session) {
+        protected void dropTable(CassandraSessionPool.Session session) {
             this.schema.dropTable(session);
             super.dropTable(session);
+        }
+
+        @Override
+        protected void truncateTable(CassandraSessionPool.Session session) {
+            this.schema.truncateTable(session);
+            super.truncateTable(session);
         }
 
         @Override
@@ -471,9 +498,15 @@ public class ScyllaDBTables {
         }
 
         @Override
-        public void dropTable(CassandraSessionPool.Session session) {
+        protected void dropTable(CassandraSessionPool.Session session) {
             this.schema.dropTable(session);
             super.dropTable(session);
+        }
+
+        @Override
+        protected void truncateTable(CassandraSessionPool.Session session) {
+            this.schema.truncateTable(session);
+            super.truncateTable(session);
         }
 
         @Override
@@ -512,9 +545,15 @@ public class ScyllaDBTables {
         }
 
         @Override
-        public void dropTable(CassandraSessionPool.Session session) {
+        protected void dropTable(CassandraSessionPool.Session session) {
             this.schema.dropTable(session);
             super.dropTable(session);
+        }
+
+        @Override
+        protected void truncateTable(CassandraSessionPool.Session session) {
+            this.schema.truncateTable(session);
+            super.truncateTable(session);
         }
 
         @Override
@@ -553,9 +592,15 @@ public class ScyllaDBTables {
         }
 
         @Override
-        public void dropTable(CassandraSessionPool.Session session) {
+        protected void dropTable(CassandraSessionPool.Session session) {
             this.schema.dropTable(session);
             super.dropTable(session);
+        }
+
+        @Override
+        protected void truncateTable(CassandraSessionPool.Session session) {
+            this.schema.truncateTable(session);
+            super.truncateTable(session);
         }
 
         @Override

--- a/hugegraph-scylladb/src/main/java/com/baidu/hugegraph/backend/store/scylladb/ScyllaDBTablesWithMV.java
+++ b/hugegraph-scylladb/src/main/java/com/baidu/hugegraph/backend/store/scylladb/ScyllaDBTablesWithMV.java
@@ -76,12 +76,16 @@ public class ScyllaDBTablesWithMV {
         }
 
         @Override
-        public void dropTable(CassandraSessionPool.Session session) {
+        protected void dropTable(CassandraSessionPool.Session session) {
+            this.dropIndexTable(session);
+            super.dropTable(session);
+        }
+
+        private void dropIndexTable(CassandraSessionPool.Session session) {
             String cql = String.format(
                          "DROP MATERIALIZED VIEW IF EXISTS %s",
                          MV_LABEL2VERTEX);
             session.execute(cql);
-            super.dropTable(session);
         }
 
         /**
@@ -131,12 +135,16 @@ public class ScyllaDBTablesWithMV {
         }
 
         @Override
-        public void dropTable(CassandraSessionPool.Session session) {
+        protected void dropTable(CassandraSessionPool.Session session) {
+            this.dropIndexTable(session);
+            super.dropTable(session);
+        }
+
+        private void dropIndexTable(CassandraSessionPool.Session session) {
             String cql = String.format(
                          "DROP MATERIALIZED VIEW IF EXISTS %s",
                          MV_LABEL2EDGE);
             session.execute(cql);
-            super.dropTable(session);
         }
 
         /**


### PR DESCRIPTION
how to:
1.speed up rocksdb backend by truncating tables
2.don't need to clear if the database is empty
3.don't need to clear variables if it's empty
4.don't need to commit hbase each len-prefix for delete index-label

potential problems:
1.mysql may block if create task vertex-label when truncating table
2.rocksdb may miss CF if create task vertex-label when truncating table
3.hbase may block if truncate hbase with version<2.0

improve #14

Change-Id: I4b2393aea8b0fc63c1886e984a576a1f5808b25c