### PR TITLE
fix bug: query vertices by ids with hasId() filter when using number id

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/id/IdGenerator.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/id/IdGenerator.java
@@ -184,10 +184,10 @@ public abstract class IdGenerator {
 
         @Override
         public boolean equals(Object other) {
-            if (!(other instanceof LongId)) {
+            if (!(other instanceof Number)) {
                 return false;
             }
-            return this.id == ((LongId) other).id;
+            return this.id == ((Number) other).longValue();
         }
 
         @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/TraversalUtil.java
@@ -362,25 +362,31 @@ public final class TraversalUtil {
         assert bp instanceof Contains;
         List<?> values = (List<?>) has.getValue();
 
-        try {
-            String originKey = has.getKey();
-            if (values.size() > 1) {
-                E.checkArgument(!originKey.equals(T.key) &&
-                                !originKey.equals(T.value),
-                                "Not support hasKey() or hasValue() with " +
-                                "multiple values");
-            }
-            HugeKeys key = string2HugeKey(originKey);
-            values = convSysListValueIfNeeded(graph, type, key, values);
+        String originKey = has.getKey();
+        if (values.size() > 1) {
+            E.checkArgument(!originKey.equals(T.key) &&
+                            !originKey.equals(T.value),
+                            "Not support hasKey() or hasValue() with " +
+                            "multiple values");
+        }
 
+        HugeKeys hugeKey = null;
+        try {
+            hugeKey = string2HugeKey(originKey);
+        } catch (IllegalArgumentException ignored) {
+            // Ignore
+        }
+
+        if (hugeKey != null) {
+            values = convSysListValueIfNeeded(graph, type, hugeKey, values);
 
             switch ((Contains) bp) {
                 case within:
-                    return Condition.in(key, values);
+                    return Condition.in(hugeKey, values);
                 case without:
-                    return Condition.nin(key, values);
+                    return Condition.nin(hugeKey, values);
             }
-        } catch (IllegalArgumentException e) {
+        } else {
             String key = has.getKey();
             PropertyKey pkey = graph.propertyKey(key);
 

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
@@ -528,11 +528,14 @@ public class HbaseSessions extends BackendSessionPool {
 
         public RowIterator(Result... results) {
             this.resultScanner = null;
-            if (results.length == 1 && results[0].isEmpty()) {
-                this.results = Collections.emptyIterator();
-            } else {
-                this.results = Arrays.asList(results).iterator();
+            List<Result> rs = new ArrayList<>(results.length);
+            for (Result result : results) {
+                // Get by Ids may return empty result
+                if (!result.isEmpty()) {
+                    rs.add(result);
+                }
             }
+            this.results = rs.iterator();
         }
 
         @Override

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
@@ -3333,6 +3333,101 @@ public class VertexCoreTest extends BaseCoreTest {
         });
     }
 
+    @Test
+    public void testQueryVerticesByIdsWithHasIdFilterAndNumberId() {
+        HugeGraph graph = graph();
+        SchemaManager schema = graph.schema();
+
+        schema.vertexLabel("user").useCustomizeNumberId().create();
+
+        graph.addVertex(T.label, "user", T.id, 123);
+        graph.addVertex(T.label, "user", T.id, 456);
+        graph.addVertex(T.label, "user", T.id, 789);
+        graph.tx().commit();
+
+        GraphTraversalSource g = graph.traversal();
+        List<Vertex> vertices;
+
+        vertices = g.V().hasId(P.within(123)).toList();
+        Assert.assertEquals(1, vertices.size());
+
+        vertices = g.V(123, 456).hasId(P.within(123)).toList();
+        Assert.assertEquals(1, vertices.size());
+
+        vertices = g.V(123, 456).hasId(123).toList();
+        Assert.assertEquals(1, vertices.size());
+
+        vertices = g.V(123, 456, 789).hasId(P.within(123, 456)).toList();
+        Assert.assertEquals(2, vertices.size());
+
+        vertices = g.V(123, 456, 789).hasId(456, 789).toList();
+        Assert.assertEquals(2, vertices.size());
+
+        vertices = g.V(123, 456, 789).hasId(P.within(123, 456, 789)).toList();
+        Assert.assertEquals(3, vertices.size());
+    }
+
+    @Test
+    public void testQueryVerticesByLabelsWithOneLabelNotExist() {
+        HugeGraph graph = graph();
+        SchemaManager schema = graph.schema();
+
+        schema.vertexLabel("user1").useCustomizeNumberId().create();
+        schema.vertexLabel("user2").useCustomizeNumberId().create();
+
+        graph.addVertex(T.label, "user1", T.id, 123);
+        graph.addVertex(T.label, "user2", T.id, 456);
+        graph.addVertex(T.label, "user2", T.id, 789);
+        graph.tx().commit();
+
+        GraphTraversalSource g = graph.traversal();
+        List<Vertex> vertices;
+
+        vertices = g.V().hasLabel("user1").toList();
+        Assert.assertEquals(1, vertices.size());
+
+        vertices = g.V().hasLabel("user2").toList();
+        Assert.assertEquals(2, vertices.size());
+
+        vertices = g.V().hasLabel("user1", "user2").toList();
+        Assert.assertEquals(3, vertices.size());
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            g.V().hasLabel("user3").toList();
+        }, e -> {
+            Assert.assertEquals("Undefined vertex label: 'user3'",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            g.V().hasLabel("user1", "user3").toList();
+        }, e -> {
+            Assert.assertEquals("Undefined vertex label: 'user3'",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            g.V().hasLabel("user3", "user1").toList();
+        }, e -> {
+            Assert.assertEquals("Undefined vertex label: 'user3'",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            g.V().hasLabel("user3", "user4").toList();
+        }, e -> {
+            Assert.assertEquals("Undefined vertex label: 'user3'",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            g.V().hasLabel("user4", "user3").toList();
+        }, e -> {
+            Assert.assertEquals("Undefined vertex label: 'user4'",
+                                e.getMessage());
+        });
+    }
+
     private void init10Vertices() {
         HugeGraph graph = graph();
 


### PR DESCRIPTION
Also improve exception message for query by labels
where one of labels is not exist

fixed: #302

Change-Id: I71f299061002b680a1b9d76f2bf4b34ed0f9f3cc