### PR TITLE
Reduce the version of Cassandra to 3.10 for ci

### DIFF
--- a/hugegraph-dist/src/assembly/travis/install-cassandra.sh
+++ b/hugegraph-dist/src/assembly/travis/install-cassandra.sh
@@ -4,7 +4,7 @@ set -ev
 
 TRAVIS_DIR=`dirname $0`
 CASSA_DOWNLOAD_ADDRESS="http://archive.apache.org/dist/cassandra"
-CASSA_VERSION="3.11.3"
+CASSA_VERSION="3.10"
 CASSA_PACKAGE="apache-cassandra-${CASSA_VERSION}"
 CASSA_TAR="${CASSA_PACKAGE}-bin.tar.gz"
 

--- a/hugegraph-scylladb/src/main/java/com/baidu/hugegraph/backend/store/scylladb/ScyllaDBStoreProvider.java
+++ b/hugegraph-scylladb/src/main/java/com/baidu/hugegraph/backend/store/scylladb/ScyllaDBStoreProvider.java
@@ -32,10 +32,10 @@ import com.baidu.hugegraph.util.Log;
 
 public class ScyllaDBStoreProvider extends CassandraStoreProvider {
 
-    private static final Logger LOG = Log.logger(CassandraStore.class);
-
     // TODO: read ScyllaDB version from conf
-    private static final int VERSION = 20;
+    public static int VERSION = 20;
+
+    private static final Logger LOG = Log.logger(CassandraStore.class);
 
     private static final BackendFeatures FEATURES = new ScyllaDBFeatures();
 


### PR DESCRIPTION
C* 3.11 can not pass the tinkerpop tests, it may be a bug.

also set ScyllaDB.VERSION public access.

Change-Id: I23c0ed924ee7c7cdb58416b0160fa319959b90af
related: #463