### PR TITLE
optimize: don't do remove-index if it's CREATING status

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/serializer/JsonSerializer.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/serializer/JsonSerializer.java
@@ -33,9 +33,7 @@ import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 
 import com.baidu.hugegraph.HugeException;
 import com.baidu.hugegraph.api.API;
-import com.baidu.hugegraph.backend.id.Id;
 import com.baidu.hugegraph.backend.page.PageState;
-import com.baidu.hugegraph.backend.store.Shard;
 import com.baidu.hugegraph.iterator.Metadatable;
 import com.baidu.hugegraph.schema.EdgeLabel;
 import com.baidu.hugegraph.schema.IndexLabel;

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/serializer/Serializer.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/serializer/Serializer.java
@@ -27,8 +27,6 @@ import java.util.Map;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-import com.baidu.hugegraph.backend.id.Id;
-import com.baidu.hugegraph.backend.store.Shard;
 import com.baidu.hugegraph.schema.EdgeLabel;
 import com.baidu.hugegraph.schema.IndexLabel;
 import com.baidu.hugegraph.schema.PropertyKey;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TextSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TextSerializer.java
@@ -328,7 +328,7 @@ public class TextSerializer extends AbstractSerializer {
          * meaningful for deletion of index data in secondary/range index.
          */
         if (index.fieldValues() == null && index.elementIds().size() == 0) {
-            entry.column(formatSyspropName(HugeKeys.INDEX_LABEL_ID),
+            entry.column(HugeKeys.INDEX_LABEL_ID,
                          writeId(index.indexLabel()));
         } else {
             // TODO: field-values may be a number (range index)

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphIndexTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphIndexTransaction.java
@@ -229,7 +229,7 @@ public class GraphIndexTransaction extends AbstractTransaction {
      * @return      converted id query
      */
     @Watched(prefix = "index")
-    public List<IdHolder> indexQuery(ConditionQuery query) {
+    public List<IdHolder> queryIndex(ConditionQuery query) {
         // Index query must have been flattened in Graph tx
         query.checkFlattened();
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
@@ -1042,7 +1042,7 @@ public class GraphTransaction extends IndexableTransaction {
          */
         this.beforeRead();
         try {
-            return this.indexTx.indexQuery(query);
+            return this.indexTx.queryIndex(query);
         } finally {
             this.afterRead();
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/schema/RebuildIndexCallable.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/schema/RebuildIndexCallable.java
@@ -100,7 +100,7 @@ public class RebuildIndexCallable extends SchemaCallable {
             locks.lockWrites(LockUtil.INDEX_LABEL_DELETE, indexLabelIds);
 
             Set<IndexLabel> ils = indexLabelIds.stream()
-                                               .map(schemaTx::getIndexLabel)
+                                               .map(this.graph()::indexLabel)
                                                .collect(Collectors.toSet());
             for (IndexLabel il : ils) {
                 if (il.status() == SchemaStatus.CREATING) {
@@ -147,15 +147,15 @@ public class RebuildIndexCallable extends SchemaCallable {
         GraphTransaction graphTx = this.graph().graphTransaction();
 
         for (Id id : indexLabelIds) {
-            IndexLabel indexLabel = schemaTx.getIndexLabel(id);
-            if (indexLabel == null) {
+            IndexLabel il = schemaTx.getIndexLabel(id);
+            if (il == null || il.status() == SchemaStatus.CREATING) {
                 /*
                  * TODO: How to deal with non-existent index name:
                  * continue or throw exception?
                  */
                 continue;
             }
-            graphTx.removeIndex(indexLabel);
+            graphTx.removeIndex(il);
         }
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/NeighborRankTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/NeighborRankTraverser.java
@@ -278,8 +278,8 @@ public class NeighborRankTraverser extends HugeTraverser {
         }
 
         public long degree() {
-            E.checkArgument(degree > 0,
-                            "The degree must be > 0, but got %s", degree);
+            E.checkArgument(this.degree > 0,
+                            "The degree must be > 0, but got %s", this.degree);
             return this.degree;
         }
 
@@ -289,6 +289,8 @@ public class NeighborRankTraverser extends HugeTraverser {
     }
 
     private static class Ranks extends OrderLimitMap<Id, Double> {
+
+        private static final long serialVersionUID = 2041529946017356029L;
 
         public Ranks(int capacity) {
             super(capacity);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/PersonalRankTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/PersonalRankTraverser.java
@@ -109,7 +109,7 @@ public class PersonalRankTraverser extends HugeTraverser {
                     newRanks.put(seed, oldRank);
                     continue;
                 }
-                double incrRank = oldRank * alpha / degree;
+                double incrRank = oldRank * this.alpha / degree;
 
                 // Collect all neighbors increment
                 for (Id neighbor : neighbors) {
@@ -157,11 +157,6 @@ public class PersonalRankTraverser extends HugeTraverser {
             assert targetLabel.equals(vertexLabel.id());
             return Directions.IN;
         }
-    }
-
-    private long degreeOfVertex(Id source, Directions dir, Id label) {
-        return IteratorUtils.count(this.edgesOfVertex(source, dir, label,
-                                                      this.degree));
     }
 
     private static void removeAll(Map<Id, Double> map, Set<Id> keys) {

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
@@ -64,7 +64,6 @@ import org.apache.hadoop.hbase.filter.PrefixFilter;
 import org.apache.hadoop.hbase.util.VersionInfo;
 
 import com.baidu.hugegraph.backend.BackendException;
-import com.baidu.hugegraph.backend.serializer.BinarySerializer;
 import com.baidu.hugegraph.backend.store.BackendEntry.BackendColumn;
 import com.baidu.hugegraph.backend.store.BackendEntry.BackendIterator;
 import com.baidu.hugegraph.backend.store.BackendSession;


### PR DESCRIPTION
about 10% performance improvement with tinkerpop tests.

also fix bug: delete-index-by-label deosn't work in InMemory backend.

Change-Id: Ie2cab7aef7e6e992d9dc3e3814eddf4adbc9f1bd