### PR TITLE
suppress error log when postgre database does not exist

### DIFF
--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
@@ -94,7 +94,7 @@ public class MysqlSessions extends BackendSessionPool {
         int maxTimes = this.config.get(MysqlOptions.JDBC_RECONNECT_MAX_TIMES);
         int interval = this.config.get(MysqlOptions.JDBC_RECONNECT_INTERVAL);
 
-        URIBuilder uriBuilder = new URIBuilder();
+        URIBuilder uriBuilder = this.newConnectionURIBuilder();
         uriBuilder.setPath(url)
                   .setParameter("rewriteBatchedStatements", "true")
                   .setParameter("useServerPrepStmts", "false")
@@ -116,6 +116,10 @@ public class MysqlSessions extends BackendSessionPool {
                                        driverName);
         }
         return DriverManager.getConnection(url, username, password);
+    }
+
+    protected URIBuilder newConnectionURIBuilder() {
+        return new URIBuilder();
     }
 
     @Override

--- a/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlSessions.java
+++ b/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlSessions.java
@@ -22,6 +22,7 @@ package com.baidu.hugegraph.backend.store.postgresql;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import org.apache.http.client.utils.URIBuilder;
 import org.postgresql.util.PSQLException;
 import org.slf4j.Logger;
 
@@ -68,5 +69,16 @@ public class PostgresqlSessions extends MysqlSessions {
             }
             // Ignore exception if database already exists
         }
+    }
+
+    @Override
+    protected String buildCreateDatabase(String database) {
+        return String.format(POSTGRESQL_DB_CREATE, database);
+    }
+
+    @Override
+    protected URIBuilder newConnectionURIBuilder() {
+        // Suppress error log when database does not exist
+        return new URIBuilder().addParameter("loggerLevel", "OFF");
     }
 }

--- a/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlSessions.java
+++ b/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlSessions.java
@@ -50,12 +50,12 @@ public class PostgresqlSessions extends MysqlSessions {
         // Create database with non-database-session
         LOG.debug("Create database: {}", this.database());
 
-        String sql = String.format(POSTGRESQL_DB_CREATE, this.database());
+        String sql = this.buildCreateDatabase(this.database());
         try (Connection conn = this.openWithoutDB(0)) {
             try {
                 conn.createStatement().execute(sql);
             } catch (PSQLException e) {
-                // CockroackDB not support 'template' args of CREATE DATABASE
+                // CockroackDB not support 'template' arg of CREATE DATABASE
                 if (e.getMessage().contains("syntax error at or near " +
                                             "\"template\"")) {
                     sql = String.format(COCKROACH_DB_CREATE, this.database());


### PR DESCRIPTION
error log like this:
```
May 24, 2019 1:25:14 PM org.postgresql.Driver connect
SEVERE: Connection error:
org.postgresql.util.PSQLException: FATAL: database "hugegraph" does not exist
```

Change-Id: I48aebac67ec98f5c05b96239b497940150542dcc