### PR TITLE
add conf entry mysql.engine to change storage engine of mysql, defaul…

### DIFF
--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlOptions.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlOptions.java
@@ -97,4 +97,12 @@ public class MysqlOptions extends OptionHolder {
                     disallowEmpty(),
                     "disable"
             );
+
+    public static final ConfigOption<String> STORAGE_ENGINE =
+            new ConfigOption<>(
+                    "mysql.engine",
+                    "the storage engine to store graph data/schema, innodb or rocksdb.",
+                    disallowEmpty(),
+                    "InnoDB"
+            );
 }

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlStore.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlStore.java
@@ -269,9 +269,8 @@ public abstract class MysqlStore extends AbstractBackendStore<Session> {
     }
 
     protected void initTables() {
-        Session session = this.sessions.session();
         for (MysqlTable table : this.tables()) {
-            table.init(session);
+            table.init(this.sessions);
         }
     }
 

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlTable.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlTable.java
@@ -58,14 +58,21 @@ public abstract class MysqlTable
     // The template for insert and delete statements
     private String insertTemplate;
     private String deleteTemplate;
+    private MysqlSessions sessions;
 
     public MysqlTable(String table) {
         super(table);
         this.insertTemplate = null;
         this.deleteTemplate = null;
+        this.sessions = null;
     }
 
     public abstract TableDefine tableDefine();
+
+    public void init(MysqlSessions sessions) {
+        this.sessions = sessions;
+        this.init(sessions.session());
+    }
 
     @Override
     public void init(Session session) {
@@ -117,7 +124,11 @@ public abstract class MysqlTable
     }
 
     protected String engine() {
-        return " ENGINE=InnoDB";
+        StringBuilder sql = new StringBuilder();
+        sql.append(" ENGINE=");
+        sql.append(this.sessions.config().get(MysqlOptions.STORAGE_ENGINE));
+        LOG.debug("MySQL storage engine innodb/rocksdb: {}", sql.toString());
+        return sql.toString();
     }
 
     protected void dropTable(Session session) {


### PR DESCRIPTION
add conf entry mysql.engine to change storage engine of mysql
default innodb, could change to rocksdb, but not myisam, as hugegraph will create large index that myisam could not support ("Specified key was too long; max key length is 1000 bytes")