### PR TITLE
 add conf entry jdbc.storage_engine to change storage engine

### DIFF
--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlOptions.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlOptions.java
@@ -97,4 +97,12 @@ public class MysqlOptions extends OptionHolder {
                     disallowEmpty(),
                     "disable"
             );
+
+    public static final ConfigOption<String> STORAGE_ENGINE =
+            new ConfigOption<>(
+                   "jdbc.storage_engine",
+                   "The storage engine of backend store database, like InnoDB/MyISAM/RocksDB for MySQL.",
+                    disallowEmpty(),
+                    "InnoDB"
+            );
 }

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
@@ -135,7 +135,7 @@ public class MysqlSessions extends BackendSessionPool {
 
     @Override
     protected Session newSession() {
-        return new Session(this.config);
+        return new Session();
     }
 
     public void checkSessionConnected() {
@@ -229,20 +229,7 @@ public class MysqlSessions extends BackendSessionPool {
             this.statements = new HashMap<>();
             this.opened = false;
             this.count = 0;
-            this.config = null;
-            try {
-                this.open();
-            } catch (SQLException ignored) {
-                // Ignore
-            }
-        }
-
-        public Session(HugeConfig config) {
-            this.conn = null;
-            this.statements = new HashMap<>();
-            this.opened = false;
-            this.count = 0;
-            this.config = config;
+            this.config = MysqlSessions.this.config();
             try {
                 this.open();
             } catch (SQLException ignored) {

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
@@ -135,7 +135,7 @@ public class MysqlSessions extends BackendSessionPool {
 
     @Override
     protected Session newSession() {
-        return new Session();
+        return new Session(this.config);
     }
 
     public void checkSessionConnected() {
@@ -222,17 +222,36 @@ public class MysqlSessions extends BackendSessionPool {
         private Map<String, PreparedStatement> statements;
         private boolean opened;
         private int count;
+        private HugeConfig config;
 
         public Session() {
             this.conn = null;
             this.statements = new HashMap<>();
             this.opened = false;
             this.count = 0;
+            this.config = null;
             try {
                 this.open();
             } catch (SQLException ignored) {
                 // Ignore
             }
+        }
+
+        public Session(HugeConfig config) {
+            this.conn = null;
+            this.statements = new HashMap<>();
+            this.opened = false;
+            this.count = 0;
+            this.config = config;
+            try {
+                this.open();
+            } catch (SQLException ignored) {
+                // Ignore
+            }
+        }
+
+        public HugeConfig config() {
+            return this.config;
         }
 
         public void open() throws SQLException {

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
@@ -222,14 +222,12 @@ public class MysqlSessions extends BackendSessionPool {
         private Map<String, PreparedStatement> statements;
         private boolean opened;
         private int count;
-        private HugeConfig config;
 
         public Session() {
             this.conn = null;
             this.statements = new HashMap<>();
             this.opened = false;
             this.count = 0;
-            this.config = MysqlSessions.this.config();
             try {
                 this.open();
             } catch (SQLException ignored) {
@@ -238,7 +236,7 @@ public class MysqlSessions extends BackendSessionPool {
         }
 
         public HugeConfig config() {
-            return this.config;
+            return MysqlSessions.this.config();
         }
 
         public void open() throws SQLException {

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlTable.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlTable.java
@@ -121,10 +121,6 @@ public abstract class MysqlTable
         return " ENGINE=" + engine;
     }
 
-    protected String engine() {
-        return " ENGINE=InnoDB";
-    }
-
     protected void dropTable(Session session) {
         LOG.debug("Drop table: {}", this.table());
         String sql = this.buildDropTemplate();

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlTable.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlTable.java
@@ -104,7 +104,7 @@ public abstract class MysqlTable
             }
         }
         sql.append("))");
-        sql.append(this.engine());
+        sql.append(this.engine(session));
         sql.append(";");
 
         LOG.debug("Create table: {}", sql);
@@ -114,6 +114,11 @@ public abstract class MysqlTable
             throw new BackendException("Failed to create table with '%s'",
                                        e, sql);
         }
+    }
+
+    protected String engine(Session session) {
+        String engine = session.config().get(MysqlOptions.STORAGE_ENGINE);
+        return " ENGINE=" + engine;
     }
 
     protected String engine() {

--- a/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlTable.java
+++ b/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlTable.java
@@ -47,11 +47,6 @@ public abstract class PostgresqlTable extends MysqlTable {
     }
 
     @Override
-    protected String engine() {
-        return Strings.EMPTY;
-    }
-
-    @Override
     protected String engine(Session session) {
         return Strings.EMPTY;
     }

--- a/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlTable.java
+++ b/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlTable.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.util.Strings;
 
 import com.baidu.hugegraph.backend.store.mysql.MysqlBackendEntry;
 import com.baidu.hugegraph.backend.store.mysql.MysqlTable;
+import com.baidu.hugegraph.backend.store.mysql.MysqlSessions.Session;
 import com.baidu.hugegraph.type.define.HugeKeys;
 
 public abstract class PostgresqlTable extends MysqlTable {
@@ -47,6 +48,11 @@ public abstract class PostgresqlTable extends MysqlTable {
 
     @Override
     protected String engine() {
+        return Strings.EMPTY;
+    }
+
+    @Override
+    protected String engine(Session session) {
         return Strings.EMPTY;
     }
 


### PR DESCRIPTION
default innodb, could change to rocksdb, but not myisam, as hugegraph will create large index that myisam could not support ("Specified key was too long; max key length is 1000 bytes")