### PR TITLE
fix: Invalid column family specified in write batch

### DIFF
--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStore.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStore.java
@@ -321,7 +321,7 @@ public abstract class RocksDBStore extends AbstractBackendStore<Session> {
     }
 
     @Override
-    public void init() {
+    public synchronized void init() {
         this.checkOpened();
 
         for (String table : this.tableNames()) {
@@ -347,7 +347,7 @@ public abstract class RocksDBStore extends AbstractBackendStore<Session> {
     }
 
     @Override
-    public void clear() {
+    public synchronized void clear() {
         this.checkOpened();
 
         for (String table : this.tableNames()) {
@@ -378,7 +378,7 @@ public abstract class RocksDBStore extends AbstractBackendStore<Session> {
     }
 
     @Override
-    public void truncate() {
+    public synchronized void truncate() {
         this.checkOpened();
 
         this.clear();


### PR DESCRIPTION
Accidental error when truncating rocksdb(drop CF) and
running api tests(read/write CF) at the same time.

fix: #697
Change-Id: Idcb6b2e04bde4cc7648ebe0787661b0d01c3f5e9