### PR TITLE
Upgrade RocksDB from v5.17.2 to v6.3.6

### DIFF
--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBOptions.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBOptions.java
@@ -162,26 +162,18 @@ public class RocksDBOptions extends OptionHolder {
                     "snappy"
             );
 
-    public static final ConfigOption<Integer> MAX_BG_COMPACTIONS =
+    public static final ConfigOption<Integer> MAX_BG_JOBS =
             new ConfigOption<>(
-                    "rocksdb.max_background_compactions",
-                    "The maximum number of concurrent background compaction jobs.",
+                    "rocksdb.max_background_jobs",
+                    "Maximum number of concurrent background jobs, including flushes and compactions.",
                     rangeInt(1, Integer.MAX_VALUE),
-                    4
+                    8
             );
 
     public static final ConfigOption<Integer> MAX_SUB_COMPACTIONS =
             new ConfigOption<>(
                     "rocksdb.max_subcompactions",
                     "The value represents the maximum number of threads per compaction job.",
-                    rangeInt(1, Integer.MAX_VALUE),
-                    4
-            );
-
-    public static final ConfigOption<Integer> MAX_BG_FLUSHES =
-            new ConfigOption<>(
-                    "rocksdb.max_background_flushes",
-                    "The maximum number of concurrent background flush jobs.",
                     rangeInt(1, Integer.MAX_VALUE),
                     4
             );
@@ -198,9 +190,63 @@ public class RocksDBOptions extends OptionHolder {
     public static final ConfigOption<Integer> MAX_OPEN_FILES =
             new ConfigOption<>(
                     "rocksdb.max_open_files",
-                    "The maximum number of open files that can be cached by RocksDB.",
+                    "The maximum number of open files that can be cached by RocksDB, " +
+                    "-1 means no limit.",
                     rangeInt(-1, Integer.MAX_VALUE),
                     -1
+            );
+
+    public static final ConfigOption<Long> MAX_MANIFEST_FILE_SIZE =
+            new ConfigOption<>(
+                    "rocksdb.max_manifest_file_size",
+                    "The max size of manifest file in bytes.",
+                    rangeInt(1L, Long.MAX_VALUE),
+                    100L * Bytes.MB
+            );
+
+    public static final ConfigOption<Boolean> SKIP_STATS_UPDATE_ON_DB_OPEN =
+            new ConfigOption<>(
+                    "rocksdb.skip_stats_update_on_db_open",
+                    "Whether to skip statistics update when opening the database, " +
+                    "setting this flag true allows us to not update statistics.",
+                    disallowEmpty(),
+                    false
+            );
+
+    public static final ConfigOption<Integer> MAX_FILE_OPENING_THREADS =
+            new ConfigOption<>(
+                    "rocksdb.max_file_opening_threads",
+                    "The max number of threads used to open files.",
+                    rangeInt(1, Integer.MAX_VALUE),
+                    16
+            );
+
+    public static final ConfigOption<Long> MAX_TOTAL_WAL_SIZE =
+            new ConfigOption<>(
+                    "rocksdb.max_total_wal_size",
+                    "Total size of WAL files in bytes. Once WALs exceed this size, " +
+                    "we will start forcing the flush of column families related, " +
+                    "0 means no limit.",
+                    rangeInt(0L, Long.MAX_VALUE),
+                    0L
+            );
+
+    public static final ConfigOption<Long> DB_MEMTABLE_SIZE =
+            new ConfigOption<>(
+                    "rocksdb.db_write_buffer_size",
+                    "Total size of write buffers in bytes across all column families, " +
+                    "0 means no limit.",
+                    rangeInt(0L, Long.MAX_VALUE),
+                    0L
+            );
+
+    public static final ConfigOption<Long> DELETE_OBSOLETE_FILE_PERIOD =
+            new ConfigOption<>(
+                    "rocksdb.delete_obsolete_files_period",
+                    "The periodicity in seconds when obsolete files get deleted, " +
+                    "0 means always do full purge.",
+                    rangeInt(0L, Long.MAX_VALUE),
+                    6L * 60 * 60
             );
 
     public static final ConfigOption<Long> MEMTABLE_SIZE =
@@ -358,31 +404,5 @@ public class RocksDBOptions extends OptionHolder {
                     "This flag allows us to not store filters for the last level.",
                     disallowEmpty(),
                     false
-            );
-
-    public static final ConfigOption<Long> MAX_MANIFEST_FILE_SIZE =
-            new ConfigOption<>(
-                    "rocksdb.max_manifest_file_size",
-                    "The max size of manifest file in bytes.",
-                    rangeInt(1L, Long.MAX_VALUE),
-                    104857600L
-            );
-
-    public static final ConfigOption<Boolean> SKIP_STATS_UPDATE_ON_DB_OPEN =
-            new ConfigOption<>(
-                    "rocksdb.skip_stats_update_on_db_open",
-                    "Whether to skip statistics update when opening the " +
-                    "database, setting this flag true allows us to not " +
-                    "update statistics.",
-                    disallowEmpty(),
-                    false
-            );
-
-    public static final ConfigOption<Integer> MAX_FILE_OPENING_THREADS =
-            new ConfigOption<>(
-                    "rocksdb.max_file_opening_threads",
-                    "The max number of threads used to open files.",
-                    rangeInt(1, Integer.MAX_VALUE),
-                    16
             );
 }

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdbsst/RocksDBSstSessions.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdbsst/RocksDBSstSessions.java
@@ -98,7 +98,7 @@ public class RocksDBSstSessions extends RocksDBSessions {
     public void createTable(String table) throws RocksDBException {
         EnvOptions env = new EnvOptions();
         Options options = new Options();
-        RocksDBStdSessions.initOptions(this.config(), options,
+        RocksDBStdSessions.initOptions(this.config(), options, options,
                                        options, options);
         // NOTE: unset merge op due to SIGSEGV when cf.setMergeOperatorName()
         options.setMergeOperatorName("not-exist-merge-op");

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <httpclient.version>4.5.2</httpclient.version>
         <datastax.cassandra.version>3.2.0</datastax.cassandra.version>
         <apache.cassandra.version>3.10</apache.cassandra.version>
-        <rocksdb.version>5.17.2</rocksdb.version>
+        <rocksdb.version>6.3.6</rocksdb.version>
         <hbase.client.version>2.0.0</hbase.client.version>
         <mysql.driver.version>5.1.45</mysql.driver.version>
         <jersey.version>2.25.1</jersey.version>


### PR DESCRIPTION
also upgraded deprecated options like max_background_jobs

and add some options:

-   max_total_wal_size
-   db_write_buffer_size
-   delete_obsolete_files_period

related: #714
Change-Id: I693a8d4550110280c46f0c40da6b4e42ad540eb3