### PR TITLE
fix task-cancel error with saving failure task

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/job/TaskAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/job/TaskAPI.java
@@ -161,13 +161,13 @@ public class TaskAPI extends API {
 
         TaskScheduler scheduler = graph(manager, graph).taskScheduler();
         HugeTask<?> task = scheduler.task(IdGenerator.of(id));
-        if (!task.completed()) {
-            scheduler.cancel(task);
-        } else {
-            throw new BadRequestException(String.format(
-                      "Can't cancel task '%s' which is completed", id));
+        if (!task.completed() && scheduler.cancel(task)) {
+            return task.asMap();
         }
-        return task.asMap();
+
+        assert task.completed();
+        throw new BadRequestException(String.format(
+                  "Can't cancel task '%s' which is completed", id));
     }
 
     private static TaskStatus parseStatus(String status) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeException.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeException.java
@@ -38,4 +38,16 @@ public class HugeException extends RuntimeException {
     public HugeException(String message, Throwable cause, Object... args) {
         super(String.format(message, args), cause);
     }
+
+    public Throwable rootCause() {
+        return rootCause(this);
+    }
+
+    public static Throwable rootCause(Throwable e) {
+        Throwable cause = e;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
+    }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BytesBuffer.java
@@ -62,6 +62,7 @@ public final class BytesBuffer {
     public static final int BIG_ID_LEN_MAX = 0x7fff + 1; // 32768
 
     public static final byte STRING_ENDING_BYTE = (byte) 0xff;
+    public static final int STRING_LEN_MAX = UINT16_MAX;
 
     // The value must be in range [8, ID_LEN_MAX]
     public static final int INDEX_HASH_ID_THRESHOLD = 32;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendEntryIterator.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendEntryIterator.java
@@ -115,7 +115,8 @@ public abstract class BackendEntryIterator
 
     protected final void checkInterrupted() {
         if (Thread.interrupted()) {
-            throw new BackendException("Interrupted, maybe it is timed out");
+            throw new BackendException("Interrupted, maybe it is timed out",
+                                       new InterruptedException());
         }
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/GremlinJob.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/GremlinJob.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.job;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import com.baidu.hugegraph.backend.query.Query;
+import com.baidu.hugegraph.exception.LimitExceedException;
+import com.baidu.hugegraph.traversal.optimize.HugeScriptTraversal;
+import com.baidu.hugegraph.util.JsonUtil;
+
+public class GremlinJob extends Job<Object> {
+
+    public static final String TASK_TYPE = "gremlin";
+    public static final String TASK_BIND_NAME = "gremlinJob";
+    public static final int TASK_RESULTS_MAX_SIZE = 10000;
+
+    @Override
+    public String type() {
+        return TASK_TYPE;
+    }
+
+    @Override
+    public Object execute() throws Exception {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> input = JsonUtil.fromJson(this.task().input(),
+                                                      Map.class);
+        String gremlin = (String) input.get("gremlin");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> bindings = (Map<String, Object>)
+                                       input.get("bindings");
+        String language = (String) input.get("language");
+        @SuppressWarnings("unchecked")
+        Map<String, String> aliases = (Map<String, String>)
+                                      input.get("aliases");
+
+        bindings.put(TASK_BIND_NAME, new GremlinJobProxy());
+
+        HugeScriptTraversal<?, ?> traversal = new HugeScriptTraversal<>(
+                                                  this.graph().traversal(),
+                                                  language, gremlin,
+                                                  bindings, aliases);
+        List<Object> results = new ArrayList<>();
+        long capacity = Query.defaultCapacity(Query.NO_CAPACITY);
+        try {
+            while (traversal.hasNext()) {
+                Object result = traversal.next();
+                results.add(result);
+                checkResultsSize(results);
+                Thread.yield();
+            }
+        } finally {
+            Query.defaultCapacity(capacity);
+            traversal.close();
+            this.graph().tx().commit();
+        }
+
+        Object result = traversal.result();
+        if (result != null) {
+            checkResultsSize(result);
+            return result;
+        } else {
+            return results;
+        }
+    }
+
+    private void checkResultsSize(Object results) {
+        int size = 0;
+        if (results instanceof Collection) {
+            size = ((Collection<?>) results).size();
+        }
+        if (size > TASK_RESULTS_MAX_SIZE) {
+            throw new LimitExceedException(
+                      "Job results size %s has exceeded the max limit %s",
+                      size, TASK_RESULTS_MAX_SIZE);
+        }
+    }
+
+    /**
+     * Used by gremlin script
+     */
+    @SuppressWarnings("unused")
+    private class GremlinJobProxy {
+
+        public void setMinSaveInterval(long seconds) {
+            GremlinJob.this.setMinSaveInterval(seconds);
+        }
+
+        public void updateProgress(int progress) {
+            GremlinJob.this.updateProgress(progress);
+        }
+
+        public int progress() {
+            return GremlinJob.this.progress();
+        }
+    }
+}

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/GremlinJob.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/GremlinJob.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import com.baidu.hugegraph.backend.query.Query;
 import com.baidu.hugegraph.exception.LimitExceedException;
 import com.baidu.hugegraph.traversal.optimize.HugeScriptTraversal;
+import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.JsonUtil;
 
 public class GremlinJob extends Job<Object> {
@@ -42,17 +43,32 @@ public class GremlinJob extends Job<Object> {
 
     @Override
     public Object execute() throws Exception {
+        String input = this.task().input();
+        E.checkArgumentNotNull(input, "The input can't be null");
         @SuppressWarnings("unchecked")
-        Map<String, Object> input = JsonUtil.fromJson(this.task().input(),
-                                                      Map.class);
-        String gremlin = (String) input.get("gremlin");
+        Map<String, Object> map = JsonUtil.fromJson(input, Map.class);
+
+        Object value = map.get("gremlin");
+        E.checkArgument(value instanceof String,
+                        "Invalid gremlin value '%s'", value);
+        String gremlin = (String) value;
+
+        value = map.get("bindings");
+        E.checkArgument(value instanceof Map,
+                        "Invalid bindings value '%s'", value);
         @SuppressWarnings("unchecked")
-        Map<String, Object> bindings = (Map<String, Object>)
-                                       input.get("bindings");
-        String language = (String) input.get("language");
+        Map<String, Object> bindings = (Map<String, Object>) value;
+
+        value = map.get("language");
+        E.checkArgument(value instanceof String,
+                        "Invalid language value '%s'", value);
+        String language = (String) value;
+
+        value = map.get("aliases");
+        E.checkArgument(value instanceof Map,
+                        "Invalid aliases value '%s'", value);
         @SuppressWarnings("unchecked")
-        Map<String, String> aliases = (Map<String, String>)
-                                      input.get("aliases");
+        Map<String, String> aliases = (Map<String, String>) value;
 
         bindings.put(TASK_BIND_NAME, new GremlinJobProxy());
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/Job.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/Job.java
@@ -78,8 +78,13 @@ public abstract class Job<T> extends TaskCallable<T> {
         try {
             this.scheduler().save(task);
         } catch (Throwable e) {
-            task.fail(e);
-            this.scheduler().save(task);
+            if (task.fail(e)) {
+                // Failed to save, try to save the failure reason to task result
+                this.scheduler().save(task);
+            } else {
+                // Not really failed, may be interrupted by cancel()
+                throw e;
+            }
         }
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/Job.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/Job.java
@@ -67,9 +67,19 @@ public abstract class Job<T> extends TaskCallable<T> {
         }
     }
 
+    public int progress() {
+        HugeTask<T> task = this.task();
+        return task.progress();
+    }
+
     private void save() {
         HugeTask<T> task = this.task();
         task.updateTime(new Date());
-        this.scheduler().save(task);
+        try {
+            this.scheduler().save(task);
+        } catch (Throwable e) {
+            task.fail(e);
+            this.scheduler().save(task);
+        }
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/Job.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/Job.java
@@ -21,11 +21,16 @@ package com.baidu.hugegraph.job;
 
 import java.util.Date;
 
+import org.slf4j.Logger;
+
 import com.baidu.hugegraph.task.HugeTask;
 import com.baidu.hugegraph.task.TaskCallable;
 import com.baidu.hugegraph.util.E;
+import com.baidu.hugegraph.util.Log;
 
 public abstract class Job<T> extends TaskCallable<T> {
+
+    private static final Logger LOG = Log.logger(HugeTask.class);
 
     private volatile long lastSaveTime = System.currentTimeMillis();
     private volatile long saveInterval = 1000 * 30;
@@ -78,13 +83,14 @@ public abstract class Job<T> extends TaskCallable<T> {
         try {
             this.scheduler().save(task);
         } catch (Throwable e) {
-            if (task.fail(e)) {
-                // Failed to save, try to save the failure reason to task result
-                this.scheduler().save(task);
-            } else {
-                // Not really failed, may be interrupted by cancel()
-                throw e;
+            if (task.completed()) {
+                /*
+                 * Failed to save task and the status is stable(can't be update)
+                 * just log the task. seems no need try again.
+                 */
+                LOG.error("Failed to save task with error \"{}\": {}", e, task);
             }
+            throw e;
         }
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/JobBuilder.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/JobBuilder.java
@@ -67,7 +67,7 @@ public class JobBuilder<T> {
 
     public HugeTask<T> schedule() {
         E.checkArgumentNotNull(this.name, "Job name can't be null");
-        E.checkArgumentNotNull(this.job, "Job can't be null");
+        E.checkArgumentNotNull(this.job, "Job callable can't be null");
 
         HugeTask<T> task = new HugeTask<>(this.genTaskId(), null, this.job);
         task.type(this.job.type());

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/schema/RebuildIndexCallable.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/schema/RebuildIndexCallable.java
@@ -50,7 +50,11 @@ public class RebuildIndexCallable extends SchemaCallable {
 
     @Override
     public Object execute() {
-        this.rebuildIndex(this.schemaElement());
+        SchemaElement schema = this.schemaElement();
+        // If the schema does not exist, ignore it
+        if (schema != null) {
+            this.rebuildIndex(schema);
+        }
         return null;
     }
 
@@ -65,6 +69,7 @@ public class RebuildIndexCallable extends SchemaCallable {
                     assert indexLabel.baseType() == HugeType.EDGE_LABEL;
                     label = this.graph().edgeLabel(indexLabel.baseValue());
                 }
+                assert label != null;
                 this.rebuildIndex(label, ImmutableSet.of(indexLabel.id()));
                 break;
             case VERTEX_LABEL:

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/task/HugeTask.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/task/HugeTask.java
@@ -208,7 +208,7 @@ public class HugeTask<V> extends FutureTask<V> {
     @Override
     public void run() {
         if (this.cancelled()) {
-            // Scheduled task is running after canceled
+            // Scheduled task is running after cancelled
             return;
         }
         try {
@@ -238,7 +238,7 @@ public class HugeTask<V> extends FutureTask<V> {
                 // Callback for saving status to store
                 this.callable.cancelled();
             } else {
-                // Maybe the worker is still running and set status SUCCESS
+                // Maybe the worker is still running then set status SUCCESS
                 cancelled = false;
             }
         } catch (Throwable e) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/task/HugeTask.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/task/HugeTask.java
@@ -331,10 +331,7 @@ public class HugeTask<V> extends FutureTask<V> {
             E.checkState(this.type != null, "Task type can't be null");
             E.checkState(this.name != null, "Task name can't be null");
         }
-        if (!this.completed() || status == TaskStatus.FAILED) {
-            if (this.completed() && status == TaskStatus.FAILED) {
-                System.out.println(this.status);
-            }
+        if (!this.completed()) {
             this.status = status;
             return true;
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/task/TaskScheduler.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/task/TaskScheduler.java
@@ -164,10 +164,13 @@ public class TaskScheduler {
 
     public <V> Future<?> restore(HugeTask<V> task) {
         E.checkArgumentNotNull(task, "Task can't be null");
+        E.checkArgument(!this.tasks.containsKey(task.id()),
+                        "Task '%s' is already in the queue", task.id());
         E.checkArgument(!task.isDone(),
-                        "No need to restore task '%s', it has been completed",
-                        task.id());
+                        "No need to restore completed task '%s' with status %s",
+                        task.id(), task.status());
         task.status(TaskStatus.RESTORING);
+        task.retry();
         return this.submitTask(task);
     }
 
@@ -182,18 +185,36 @@ public class TaskScheduler {
         E.checkArgument(size <= MAX_PENDING_TASKS,
                         "Pending tasks size %s has exceeded the max limit %s",
                         size, MAX_PENDING_TASKS);
+        this.initTaskCallable(task);
         this.tasks.put(task.id(), task);
-        task.callable().scheduler(this);
-        task.callable().task(task);
         return this.taskExecutor.submit(task);
+    }
+
+    private <V> void initTaskCallable(HugeTask<V> task) {
+        if (this.tasks.containsKey(task.id())) {
+            // Assume initialized
+            return;
+        }
+        TaskCallable<V> callable = task.callable();
+        callable.scheduler(this);
+        callable.task(task);
     }
 
     public <V> void cancel(HugeTask<V> task) {
         E.checkArgumentNotNull(task, "Task can't be null");
         if (!task.completed()) {
+            /*
+             * Task may be loaded from backend store and not initialized. like:
+             * A task is completed but failed to save in the last step,
+             * resulting in the status of the task not being updated to storage,
+             * the task is not in memory, so it's not initialized when canceled.
+             */
+            this.initTaskCallable(task);
+
             task.cancel(true);
             this.remove(task.id());
         }
+        assert task.completed();
     }
 
     protected void remove(Id id) {
@@ -203,6 +224,9 @@ public class TaskScheduler {
 
     public <V> void save(HugeTask<V> task) {
         E.checkArgumentNotNull(task, "Task can't be null");
+        // Check property size
+        task.checkProperties();
+        // Do save
         this.call(() -> {
             // Construct vertex from task
             HugeVertex vertex = this.tx().constructVertex(task);
@@ -325,8 +349,17 @@ public class TaskScheduler {
     public <V> HugeTask<V> waitUntilTaskCompleted(Id id, long seconds)
                                                   throws TimeoutException {
         long passes = seconds * 1000 / QUERY_INTERVAL;
+        HugeTask<V> task = null;
         for (long pass = 0;; pass++) {
-            HugeTask<V> task = this.task(id);
+            try {
+                task = this.task(id);
+            } catch (NotFoundException e) {
+                if (task != null && task.completed()) {
+                    assert task.id().asLong() < 0L : task.id();
+                    return task;
+                }
+                throw e;
+            }
             if (task.completed()) {
                 return task;
             }
@@ -415,8 +448,9 @@ public class TaskScheduler {
         // Ensure all db operations are executed in dbExecutor thread(s)
         try {
             return this.dbExecutor.submit(callable).get();
-        } catch (Exception e) {
-            throw new HugeException("Failed to update/query TaskStore", e);
+        } catch (Throwable e) {
+            throw new HugeException("Failed to update/query TaskStore: %s",
+                                    e, e.toString());
         }
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/task/TaskScheduler.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/task/TaskScheduler.java
@@ -198,7 +198,7 @@ public class TaskScheduler {
 
     protected void remove(Id id) {
         HugeTask<?> task = this.tasks.remove(id);
-        assert task == null || task.completed();
+        assert task == null || task.completed() || task.isCancelled();
     }
 
     public <V> void save(HugeTask<V> task) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/HugeScriptTraversal.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/HugeScriptTraversal.java
@@ -32,6 +32,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalSourceFactory;
 
+import com.baidu.hugegraph.HugeException;
+
 /**
  * ScriptTraversal encapsulates a {@link ScriptEngine} and a script which is compiled into a {@link Traversal} at {@link Admin#applyStrategies()}.
  * This is useful for serializing traversals as the compilation can happen on the remote end where the traversal will ultimately be processed.
@@ -107,7 +109,7 @@ public final class HugeScriptTraversal<S, E> extends DefaultTraversal<S, E> {
             }
             super.applyStrategies();
         } catch (ScriptException e) {
-            throw new IllegalStateException(e.getMessage(), e);
+            throw new HugeException(e.getMessage(), e);
         }
     }
 }

--- a/hugegraph-example/src/main/java/com/baidu/hugegraph/example/TaskExample.java
+++ b/hugegraph-example/src/main/java/com/baidu/hugegraph/example/TaskExample.java
@@ -32,6 +32,7 @@ import com.baidu.hugegraph.task.TaskCallable;
 import com.baidu.hugegraph.task.TaskManager;
 import com.baidu.hugegraph.task.TaskScheduler;
 import com.baidu.hugegraph.task.TaskStatus;
+import com.baidu.hugegraph.testutil.Whitebox;
 import com.baidu.hugegraph.util.Log;
 
 public class TaskExample {
@@ -76,6 +77,7 @@ public class TaskExample {
 
         Thread.sleep(TestTask.UNIT * 10);
         System.out.println(">>>> restore task...");
+        Whitebox.setInternalState(task, "status", TaskStatus.RUNNING);
         scheduler.restore(task);
         Thread.sleep(TestTask.UNIT * 80);
         scheduler.save(task);

--- a/hugegraph-example/src/main/java/com/baidu/hugegraph/example/TaskExample.java
+++ b/hugegraph-example/src/main/java/com/baidu/hugegraph/example/TaskExample.java
@@ -42,7 +42,13 @@ public class TaskExample {
         LOG.info("TaskExample start!");
 
         HugeGraph graph = ExampleUtil.loadGraph();
+        testTask(graph);
+        graph.close();
 
+        HugeGraph.shutdown(30L);
+    }
+
+    public static void testTask(HugeGraph graph) throws InterruptedException {
         Id id = IdGenerator.of(8);
         String callable = "com.baidu.hugegraph.example.TaskExample$TestTask";
         HugeTask<?> task = new HugeTask<>(id, null, callable, "test-parameter");
@@ -76,15 +82,14 @@ public class TaskExample {
 
         iter = scheduler.findTask(TaskStatus.SUCCESS, -1, null);
         assert iter.hasNext();
-
-        graph.close();
-
-        HugeGraph.shutdown(30L);
+        task = iter.next();
+        assert task.status() == TaskStatus.SUCCESS;
+        assert task.retries() == 1;
     }
 
     public static class TestTask extends TaskCallable<Integer> {
 
-        public static final int UNIT = 100;
+        public static final int UNIT = 100; // ms
 
         public volatile boolean run = true;
 

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/BaseApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/BaseApiTest.java
@@ -135,9 +135,9 @@ public class BaseApiTest {
             return this.target.path(path).request().post(entity);
         }
 
-        public Response put(String path, String content,
+        public Response put(String path, String id, String content,
                             Map<String, Object> params) {
-            WebTarget target = this.target.path(path);
+            WebTarget target = this.target.path(path).path(id);
             for (Map.Entry<String, Object> i : params.entrySet()) {
                 target = target.queryParam(i.getKey(), i.getValue());
             }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/EdgeApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/EdgeApiTest.java
@@ -103,7 +103,7 @@ public class EdgeApiTest extends BaseApiTest {
                 + "\"check_vertex\":false,"
                 + "\"create_if_not_exist\":true"
                 + "}", edgeId, outVId, inVId);
-        r = client().put(path + "batch", edge, ImmutableMap.of());
+        r = client().put(path, "batch", edge, ImmutableMap.of());
         // Now allowed to modify sortkey values, the property 'date' has changed
         content = assertResponseStatus(400, r);
         Assert.assertTrue(content.contains(
@@ -132,7 +132,7 @@ public class EdgeApiTest extends BaseApiTest {
                 + "\"check_vertex\":false,"
                 + "\"create_if_not_exist\":true"
                 + "}", outVId, inVId);
-        r = client().put(path + "batch", edge, ImmutableMap.of());
+        r = client().put(path, "batch", edge, ImmutableMap.of());
         // Add a new edge when sortkey value has changed
         content = assertResponseStatus(200, r);
         String newEdgeId = parseId(content);

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/EdgeLabelApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/EdgeLabelApiTest.java
@@ -77,7 +77,7 @@ public class EdgeLabelApiTest extends BaseApiTest {
                 + "\"sort_keys\":[]"
                 + "}";
         Map<String, Object> params = ImmutableMap.of("action", "append");
-        r = client().put(path + "created", edgeLabel, params);
+        r = client().put(path, "created", edgeLabel, params);
         assertResponseStatus(200, r);
     }
 

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/GremlinApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/GremlinApiTest.java
@@ -67,8 +67,8 @@ public class GremlinApiTest extends BaseApiTest {
                 + "schema.propertyKey('price').asInt().ifNotExist().create();"
                 + "person=schema.vertexLabel('person').properties('name','age','city').useCustomizeUuidId().ifNotExist().create();"
                 + "knows=schema.edgeLabel('knows').sourceLabel('person').targetLabel('person').properties('date').ifNotExist().create();"
-                + "marko=hugegraph.addVertex(T.id, '835e1153928149578691cf79258e90eb', T.label,'person','name','marko','age',29,'city','135e1153928149578691cf79258e90eb');"
-                + "vadas=hugegraph.addVertex(T.id, '935e1153928149578691cf79258e90eb', T.label,'person','name','vadas','age',27,'city','235e1153928149578691cf79258e90eb');"
+                + "marko=hugegraph.addVertex(T.id,'835e1153928149578691cf79258e90eb',T.label,'person','name','marko','age',29,'city','135e1153928149578691cf79258e90eb');"
+                + "vadas=hugegraph.addVertex(T.id,'935e1153928149578691cf79258e90eb',T.label,'person','name','vadas','age',27,'city','235e1153928149578691cf79258e90eb');"
                 + "marko.addEdge('knows',vadas,'date','20160110');";
         String body = String.format(bodyTemplate, script);
         assertResponseStatus(200, client().post(path, body));

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/IndexLabelApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/IndexLabelApiTest.java
@@ -72,7 +72,6 @@ public class IndexLabelApiTest extends BaseApiTest {
                 + "\"max\": 100"
                 + "}"
                 + "}";
-        System.out.println(indexLabel);
         Map<String, Object> params = ImmutableMap.of("action", "append");
         r = client().put(path, "personByAge", indexLabel, params);
         assertResponseStatus(200, r);

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/IndexLabelApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/IndexLabelApiTest.java
@@ -26,7 +26,6 @@ import javax.ws.rs.core.Response;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.baidu.hugegraph.schema.IndexLabel;
 import com.google.common.collect.ImmutableMap;
 
 public class IndexLabelApiTest extends BaseApiTest {
@@ -75,7 +74,7 @@ public class IndexLabelApiTest extends BaseApiTest {
                 + "}";
         System.out.println(indexLabel);
         Map<String, Object> params = ImmutableMap.of("action", "append");
-        r = client().put(path + "personByAge", indexLabel, params);
+        r = client().put(path, "personByAge", indexLabel, params);
         assertResponseStatus(200, r);
     }
 
@@ -102,7 +101,7 @@ public class IndexLabelApiTest extends BaseApiTest {
                 + "}"
                 + "}";
         Map<String, Object> params = ImmutableMap.of("action", "eliminate");
-        r = client().put(path + "personByAge", indexLabel, params);
+        r = client().put(path, "personByAge", indexLabel, params);
         assertResponseStatus(200, r);
     }
 

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/TaskApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/TaskApiTest.java
@@ -29,21 +29,11 @@ import org.junit.Test;
 
 import com.baidu.hugegraph.testutil.Assert;
 
-import jersey.repackaged.com.google.common.collect.ImmutableList;
 import jersey.repackaged.com.google.common.collect.ImmutableMap;
 
 public class TaskApiTest extends BaseApiTest {
 
     private static String path = "/graphs/hugegraph/tasks/";
-    private static String rebuildPath =
-            "/graphs/hugegraph/jobs/rebuild/indexlabels/personByCity";
-    private static String personByCity = "personByCity";
-    private static Map<String, Object> personByCityIL = ImmutableMap.of(
-            "name", "personByCity",
-            "base_type", "VERTEX_LABEL",
-            "base_value", "person",
-            "index_type", "SECONDARY",
-            "fields", ImmutableList.of("city"));
 
     @Before
     public void prepareSchema() {
@@ -78,6 +68,15 @@ public class TaskApiTest extends BaseApiTest {
     }
 
     @Test
+    public void testCancel() {
+        int taskId = this.rebuild();
+
+        Map<String, Object> params = ImmutableMap.of("action", "cancel");
+        Response r = client().put(path, String.valueOf(taskId), "", params);
+        assertResponseStatus(202, r);
+    }
+
+    @Test
     public void testDelete() {
         int taskId = this.rebuild();
 
@@ -87,7 +86,10 @@ public class TaskApiTest extends BaseApiTest {
     }
 
     private int rebuild() {
-        Response r = client().put(rebuildPath, personByCity, personByCityIL);
+        String rebuildPath = "/graphs/hugegraph/jobs/rebuild/indexlabels";
+        String personByCity = "personByCity";
+        Map<String, Object> params = ImmutableMap.of();
+        Response r = client().put(rebuildPath, personByCity, "",  params);
         String content = assertResponseStatus(202, r);
         return assertJsonContains(content, "task_id");
     }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/VertexLabelApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/VertexLabelApiTest.java
@@ -70,7 +70,7 @@ public class VertexLabelApiTest extends BaseApiTest {
                 + "\"nullable_keys\":[\"lang\"]"
                 + "}";
         Map<String, Object> params = ImmutableMap.of("action", "append");
-        r = client().put(path + "person", vertexLabel, params);
+        r = client().put(path, "person", vertexLabel, params);
         assertResponseStatus(200, r);
     }
 

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/CoreTestSuite.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/CoreTestSuite.java
@@ -44,6 +44,7 @@ import com.baidu.hugegraph.util.Log;
     VertexPropertyCoreTest.class,
     EdgePropertyCoreTest.class,
     RestoreCoreTest.class,
+    TaskCoreTest.class,
     MultiGraphsTest.class
 })
 public class CoreTestSuite {

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/TaskCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/TaskCoreTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.core;
+
+import java.util.Iterator;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.baidu.hugegraph.HugeGraph;
+import com.baidu.hugegraph.api.job.GremlinAPI.GremlinRequest;
+import com.baidu.hugegraph.backend.id.Id;
+import com.baidu.hugegraph.backend.id.IdGenerator;
+import com.baidu.hugegraph.exception.NotFoundException;
+import com.baidu.hugegraph.job.EphemeralJob;
+import com.baidu.hugegraph.job.EphemeralJobBuilder;
+import com.baidu.hugegraph.job.GremlinJob;
+import com.baidu.hugegraph.job.JobBuilder;
+import com.baidu.hugegraph.task.HugeTask;
+import com.baidu.hugegraph.task.TaskCallable;
+import com.baidu.hugegraph.task.TaskScheduler;
+import com.baidu.hugegraph.task.TaskStatus;
+import com.baidu.hugegraph.testutil.Assert;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class TaskCoreTest extends BaseCoreTest {
+
+    private static final int SLEEP_TIME = 200;
+
+    @After
+    @Override
+    public void setup() {
+        super.setup();
+
+        HugeGraph graph = graph();
+        TaskScheduler scheduler = graph.taskScheduler();
+
+        Iterator<HugeTask<Object>> iter = scheduler.findAllTask(-1, null);
+        while (iter.hasNext()) {
+            scheduler.deleteTask(iter.next().id());
+        }
+    }
+
+    @Test
+    public void testTask() throws TimeoutException {
+        HugeGraph graph = graph();
+        TaskScheduler scheduler = graph.taskScheduler();
+
+        TaskCallable<Integer> callable =  new TaskCallable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                Thread.sleep(SLEEP_TIME);
+                return 125;
+            }
+            @Override
+            protected void done() {
+                scheduler.save(this.task());
+            }
+        };
+
+        Id id = IdGenerator.of(88888);
+        HugeTask<?> task = new HugeTask<>(id, null, callable);
+        task.type("test");
+        task.name("test-task");
+
+        scheduler.schedule(task);
+        Assert.assertEquals(id, task.id());
+        Assert.assertFalse(task.completed());
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            scheduler.deleteTask(id);
+        }, e -> {
+            Assert.assertContains("Can't delete incomplete task '88888'",
+                                  e.getMessage());
+        });
+
+        task = scheduler.waitUntilTaskCompleted(task.id(), 10);
+        Assert.assertEquals(id, task.id());
+        Assert.assertEquals("test-task", task.name());
+        Assert.assertEquals(TaskStatus.SUCCESS, task.status());
+
+        Assert.assertEquals("test-task", scheduler.task(id).name());
+        Assert.assertEquals("test-task", scheduler.findTask(id).name());
+
+        Iterator<HugeTask<Object>> iter = scheduler.tasks(ImmutableList.of(id));
+        Assert.assertTrue(iter.hasNext());
+        Assert.assertEquals("test-task", iter.next().name());
+        Assert.assertFalse(iter.hasNext());
+
+        iter = scheduler.findTask(TaskStatus.SUCCESS, 10, null);
+        Assert.assertTrue(iter.hasNext());
+        Assert.assertEquals("test-task", iter.next().name());
+        Assert.assertFalse(iter.hasNext());
+
+        iter = scheduler.findAllTask(10, null);
+        Assert.assertTrue(iter.hasNext());
+        Assert.assertEquals("test-task", iter.next().name());
+        Assert.assertFalse(iter.hasNext());
+
+        scheduler.deleteTask(id);
+        iter = scheduler.findAllTask(10, null);
+        Assert.assertFalse(iter.hasNext());
+        Assert.assertThrows(NotFoundException.class, () -> {
+            scheduler.task(id);
+        });
+    }
+
+    @Test
+    public void testEphemeralJob() throws TimeoutException {
+        HugeGraph graph = graph();
+        TaskScheduler scheduler = graph.taskScheduler();
+
+        EphemeralJobBuilder<Object> builder = EphemeralJobBuilder.of(graph);
+        builder.name("test-job-ephemeral")
+               .job(new EphemeralJob<Object>() {
+                    @Override
+                    public String type() {
+                        return "test";
+                    }
+                    @Override
+                    public Object execute() throws Exception {
+                        Thread.sleep(SLEEP_TIME);
+                        return ImmutableMap.of("k1", 13579, "k2", "24680");
+                    }
+               });
+
+        HugeTask<Object> task = builder.schedule();
+        Assert.assertEquals("test-job-ephemeral", task.name());
+        Assert.assertEquals("test", task.type());
+        Assert.assertFalse(task.completed());
+
+        HugeTask<?> task2 = scheduler.waitUntilTaskCompleted(task.id(), 10);
+        Assert.assertEquals(TaskStatus.SUCCESS, task.status());
+        Assert.assertEquals("{\"k1\":13579,\"k2\":\"24680\"}", task.result());
+
+        Assert.assertEquals(TaskStatus.SUCCESS, task2.status());
+        Assert.assertEquals("{\"k1\":13579,\"k2\":\"24680\"}", task2.result());
+
+        Assert.assertThrows(NotFoundException.class, () -> {
+            scheduler.waitUntilTaskCompleted(task.id(), 10);
+        });
+        Assert.assertThrows(NotFoundException.class, () -> {
+            scheduler.task(task.id());
+        });
+    }
+
+    @Test
+    public void testGremlinJob() throws TimeoutException {
+        HugeGraph graph = graph();
+        TaskScheduler scheduler = graph.taskScheduler();
+
+        GremlinRequest request = new GremlinRequest();
+        request.gremlin("3 + 5");
+
+        JobBuilder<Object> builder = JobBuilder.of(graph);
+        builder.name("test-job-gremlin")
+               .input(request.toJson())
+               .job(new GremlinJob());
+
+        HugeTask<Object> task = builder.schedule();
+        Assert.assertEquals("test-job-gremlin", task.name());
+        Assert.assertEquals("gremlin", task.type());
+        Assert.assertFalse(task.completed());
+        Assert.assertNull(task.result());
+
+        task = scheduler.waitUntilTaskCompleted(task.id(), 10);
+        Assert.assertEquals("test-job-gremlin", task.name());
+        Assert.assertEquals("gremlin", task.type());
+        Assert.assertEquals(TaskStatus.SUCCESS, task.status());
+        Assert.assertEquals("8", task.result());
+
+        task = scheduler.task(task.id());
+        Assert.assertEquals("test-job-gremlin", task.name());
+        Assert.assertEquals("gremlin", task.type());
+        Assert.assertEquals(TaskStatus.SUCCESS, task.status());
+        Assert.assertEquals("8", task.result());
+    }
+
+    @Test
+    public void testGremlinJobAndCancel() throws TimeoutException {
+        HugeGraph graph = graph();
+        TaskScheduler scheduler = graph.taskScheduler();
+
+        HugeTask<Object> task = runGremlinJob("Thread.sleep(1000 * 10);");
+        scheduler.cancel(task);
+
+        Assert.assertEquals(TaskStatus.CANCELLED, task.status());
+        Assert.assertTrue(task.result(), task.result() == null ||
+                          task.result().endsWith("InterruptedException"));
+
+        task = scheduler.findTask(task.id());
+        Assert.assertEquals(TaskStatus.CANCELLED, task.status());
+        Assert.assertEquals("test-gremlin-job", task.name());
+        Assert.assertTrue(task.result(), task.result() == null ||
+                          task.result().endsWith("InterruptedException"));
+
+        // cancel success task
+        HugeTask<Object> task2 = runGremlinJob("1+2");
+        scheduler.waitUntilTaskCompleted(task2.id(), 10);
+        Assert.assertEquals(TaskStatus.SUCCESS, task2.status());
+        scheduler.cancel(task2);
+        Assert.assertEquals(TaskStatus.SUCCESS, task2.status());
+        Assert.assertEquals("3", task2.result());
+
+        // cancel failure task with big results (job size exceeded limit)
+        String bigList = "def l=[]; for (i in 1..10001) l.add(i); l;";
+        HugeTask<Object> task3 = runGremlinJob(bigList);
+        scheduler.waitUntilTaskCompleted(task3.id(), 10);
+        Assert.assertEquals(TaskStatus.FAILED, task3.status());
+        scheduler.cancel(task3);
+        Assert.assertEquals(TaskStatus.FAILED, task3.status());
+        Assert.assertContains("LimitExceedException: Job results size 10001 " +
+                              "has exceeded the max limit 10000",
+                              task3.result());
+
+        // cancel failure task with big results (task exceeded limit 64k)
+        String bigResults = "def big='123456789'; def l=[]; " +
+                            "for (i in 1..9000) l.add(big); l;";
+        HugeTask<Object> task4 = runGremlinJob(bigResults);
+        scheduler.waitUntilTaskCompleted(task4.id(), 10);
+        Assert.assertEquals(TaskStatus.FAILED, task4.status());
+        scheduler.cancel(task4);
+        Assert.assertEquals(TaskStatus.FAILED, task4.status());
+        Assert.assertContains("LimitExceedException: Task result size 108001 " +
+                              "exceeded limit 65535 bytes", task4.result());
+    }
+
+    @Test
+    public void testGremlinJobAndRestore() throws Exception {
+        HugeGraph graph = graph();
+        TaskScheduler scheduler = graph.taskScheduler();
+
+        String gremlin = "for(int i=gremlinJob.progress(); i<=10; i++) {" +
+                         "  gremlinJob.updateProgress(i);" +
+                         "  Thread.sleep(1000);" +
+                         "}; 100;";
+        HugeTask<Object> task = runGremlinJob(gremlin);
+        Thread.sleep(1000 * 6);
+        scheduler.cancel(task);
+
+        Assert.assertEquals(TaskStatus.CANCELLED, task.status());
+        Assert.assertTrue("progress=" + task.progress(),
+                          0 < task.progress() && task.progress() < 10);
+        Assert.assertEquals(0, task.retries());
+        Assert.assertEquals(null, task.result());
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            scheduler.restore(task);
+        }, e -> {
+            Assert.assertContains("No need to restore completed task",
+                                  e.getMessage());
+        });
+
+        HugeTask<Object> task2 = scheduler.task(task.id());
+        scheduler.restore(task2);
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            scheduler.restore(task);
+        }, e -> {
+            Assert.assertContains("is already in the queue", e.getMessage());
+        });
+
+        scheduler.waitUntilTaskCompleted(task2.id(), 10);
+        Assert.assertEquals(10, task2.progress());
+        Assert.assertEquals(1, task2.retries());
+        Assert.assertEquals("100", task2.result());
+    }
+
+    private HugeTask<Object> runGremlinJob(String gremlin) {
+        HugeGraph graph = graph();
+
+        GremlinRequest request = new GremlinRequest();
+        request.gremlin(gremlin);
+
+        JobBuilder<Object> builder = JobBuilder.of(graph);
+        builder.name("test-gremlin-job")
+               .input(request.toJson())
+               .job(new GremlinJob());
+
+        HugeTask<Object> task = builder.schedule();
+        return task;
+    }
+}

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/TaskCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/TaskCoreTest.java
@@ -50,8 +50,8 @@ public class TaskCoreTest extends BaseCoreTest {
 
     @After
     @Override
-    public void setup() {
-        super.setup();
+    public void teardown() throws Exception {
+        super.teardown();
 
         HugeGraph graph = graph();
         TaskScheduler scheduler = graph.taskScheduler();
@@ -67,7 +67,7 @@ public class TaskCoreTest extends BaseCoreTest {
         HugeGraph graph = graph();
         TaskScheduler scheduler = graph.taskScheduler();
 
-        TaskCallable<Integer> callable =  new TaskCallable<Integer>() {
+        TaskCallable<Integer> callable = new TaskCallable<Integer>() {
             @Override
             public Integer call() throws Exception {
                 Thread.sleep(SLEEP_TIME);
@@ -132,7 +132,7 @@ public class TaskCoreTest extends BaseCoreTest {
         HugeGraph graph = graph();
         TaskScheduler scheduler = graph.taskScheduler();
 
-        TaskCallable<Integer> callable =  new TaskCallable<Integer>() {
+        TaskCallable<Integer> callable = new TaskCallable<Integer>() {
             @Override
             public Integer call() throws Exception {
                 Thread.sleep(SLEEP_TIME);

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/TaskCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/TaskCoreTest.java
@@ -22,7 +22,7 @@ package com.baidu.hugegraph.core;
 import java.util.Iterator;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.baidu.hugegraph.HugeGraph;
@@ -48,10 +48,10 @@ public class TaskCoreTest extends BaseCoreTest {
 
     private static final int SLEEP_TIME = 200;
 
-    @After
+    @Before
     @Override
-    public void teardown() throws Exception {
-        super.teardown();
+    public void setup() {
+        super.setup();
 
         HugeGraph graph = graph();
         TaskScheduler scheduler = graph.taskScheduler();

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/TaskCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/TaskCoreTest.java
@@ -73,6 +73,7 @@ public class TaskCoreTest extends BaseCoreTest {
                 Thread.sleep(SLEEP_TIME);
                 return 125;
             }
+
             @Override
             protected void done() {
                 scheduler.save(this.task());

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/TaskCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/TaskCoreTest.java
@@ -428,7 +428,7 @@ public class TaskCoreTest extends BaseCoreTest {
             Assert.assertContains("Job callable can't be null", e.getMessage());
         });
 
-        // failure task with big input
+        // Test failure task with big input
         char[] chars = new char[65536];
         for (int i = 0; i < chars.length; i++) {
             chars[i] = '8';
@@ -460,7 +460,7 @@ public class TaskCoreTest extends BaseCoreTest {
         Assert.assertTrue(task.result(), task.result() == null ||
                           task.result().endsWith("InterruptedException"));
 
-        // cancel success task
+        // Cancel success task
         HugeTask<Object> task2 = runGremlinJob("1+2");
         scheduler.waitUntilTaskCompleted(task2.id(), 10);
         Assert.assertEquals(TaskStatus.SUCCESS, task2.status());
@@ -468,7 +468,7 @@ public class TaskCoreTest extends BaseCoreTest {
         Assert.assertEquals(TaskStatus.SUCCESS, task2.status());
         Assert.assertEquals("3", task2.result());
 
-        // cancel failure task with big results (job size exceeded limit)
+        // Cancel failure task with big results (job size exceeded limit)
         String bigList = "def l=[]; for (i in 1..10001) l.add(i); l;";
         HugeTask<Object> task3 = runGremlinJob(bigList);
         scheduler.waitUntilTaskCompleted(task3.id(), 10);
@@ -479,7 +479,7 @@ public class TaskCoreTest extends BaseCoreTest {
                               "has exceeded the max limit 10000",
                               task3.result());
 
-        // cancel failure task with big results (task exceeded limit 64k)
+        // Cancel failure task with big results (task exceeded limit 64k)
         String bigResults = "def big='123456789'; def l=[]; " +
                             "for (i in 1..9000) l.add(big); l;";
         HugeTask<Object> task4 = runGremlinJob(bigResults);

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/SecurityManagerTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/SecurityManagerTest.java
@@ -40,8 +40,8 @@ import org.junit.Test;
 
 import com.baidu.hugegraph.HugeException;
 import com.baidu.hugegraph.HugeGraph;
-import com.baidu.hugegraph.api.job.GremlinAPI;
 import com.baidu.hugegraph.config.HugeConfig;
+import com.baidu.hugegraph.job.GremlinJob;
 import com.baidu.hugegraph.job.JobBuilder;
 import com.baidu.hugegraph.security.HugeSecurityManager;
 import com.baidu.hugegraph.task.HugeTask;
@@ -299,7 +299,7 @@ public class SecurityManagerTest {
         input.put("aliases", ImmutableMap.of());
         builder.name("test-gremlin-job")
                .input(JsonUtil.toJson(input))
-               .job(new GremlinAPI.GremlinJob());
+               .job(new GremlinJob());
         HugeTask<?> task = builder.schedule();
         try {
             graph.taskScheduler().waitUntilTaskCompleted(task.id(), 10);


### PR DESCRIPTION
This bug is caused by failure task status has not been saved to backend store(
the root cause is result size exceeded 64k, and failed to save), so its status is
still RUNNING even the task is finished, if call cancel() then the task will be loaded 
from backend store and its scheduler is null.

fix https://github.com/hugegraph/hugegraph-tools/issues/50
Change-Id: If70a2233f73c578f38842b6b015241b5ba6b86a1