### PR TITLE
add option vertex.check_adjacent_vertex_exist

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/config/CoreOptions.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/config/CoreOptions.java
@@ -143,6 +143,14 @@ public class CoreOptions extends OptionHolder {
                     false
             );
 
+    public static final ConfigOption<Boolean> VERTEX_ADJACENT_VERTEX_EXIST =
+            new ConfigOption<>(
+                    "vertex.check_adjacent_vertex_exist",
+                    "Whether to check the adjacent vertices of edges exist",
+                    disallowEmpty(),
+                    false
+            );
+
     public static final ConfigOption<Integer> QUERY_BATCH_SIZE =
             new ConfigOption<>(
                     "query.batch_size",

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/schema/VertexLabel.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/schema/VertexLabel.java
@@ -34,8 +34,10 @@ import com.baidu.hugegraph.type.define.IdStrategy;
 
 public class VertexLabel extends SchemaLabel {
 
-    public static final VertexLabel NONE =
-                        new VertexLabel(null, IdGenerator.of(0), "");
+    private static final Id ZERO = IdGenerator.of(0L);
+    private static final String UNDEF = "~undefined";
+
+    public static final VertexLabel NONE = new VertexLabel(null, ZERO, UNDEF);
 
     private IdStrategy idStrategy;
     private List<Id> primaryKeys;
@@ -69,6 +71,14 @@ public class VertexLabel extends SchemaLabel {
 
     public void primaryKeys(Id... ids) {
         this.primaryKeys.addAll(Arrays.asList(ids));
+    }
+
+    public boolean undefined() {
+        return this.id() == ZERO && this.name() == UNDEF;
+    }
+
+    public static VertexLabel undefined(HugeGraph graph) {
+        return new VertexLabel(graph, ZERO, UNDEF);
     }
 
     public interface Builder extends SchemaBuilder<VertexLabel> {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeElement.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeElement.java
@@ -122,7 +122,7 @@ public abstract class HugeElement implements Element, GraphType, Idfiable {
 
     public Map<Id, HugeProperty<?>> getFilledProperties() {
         this.ensureFilledProperties(true);
-        return Collections.unmodifiableMap(this.properties);
+        return this.getProperties();
     }
 
     public Map<Id, Object> getPropertiesMap() {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeVertex.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeVertex.java
@@ -94,7 +94,6 @@ public class HugeVertex extends HugeElement implements Vertex, Cloneable {
 
     @Override
     public VertexLabel schemaLabel() {
-        this.ensureFilledProperties(false);
         return this.label;
     }
 

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/EdgeCoreTest.java
@@ -1363,6 +1363,7 @@ public class EdgeCoreTest extends BaseCoreTest {
                         .has("score", 3).otherV().toList();
         Assert.assertEquals(1, vertices.size());
         adjacent = (HugeVertex) vertices.get(0);
+        adjacent.properties();
         // NOTE: if not commit, adjacent.label() will return 'book'
         Assert.assertTrue(adjacent.schemaLabel().undefined());
         Assert.assertEquals("~undefined", adjacent.label());
@@ -1398,7 +1399,7 @@ public class EdgeCoreTest extends BaseCoreTest {
             Assert.assertThrows(HugeException.class, () -> {
                 Vertex v = graph.traversal().V(james.id()).outE()
                                 .has("score", 3).otherV().next();
-                v.label(); // throw
+                v.properties(); // throw
             }, e -> {
                 Assert.assertContains("Vertex 'java' does not exist",
                                       e.getMessage());
@@ -1407,7 +1408,7 @@ public class EdgeCoreTest extends BaseCoreTest {
             Assert.assertThrows(HugeException.class, () -> {
                 Vertex v = graph.traversal().V(james.id()).outE()
                                 .has("score", 3).otherV().next();
-                v.properties(); // throw
+                v.values(); // throw
             }, e -> {
                 Assert.assertContains("Vertex 'java' does not exist",
                                       e.getMessage());


### PR DESCRIPTION
when check_adjacent_vertex_exist=true: 
    throw exception: "vertex does not exist" if not exist adjacent vertex

when check_adjacent_vertex_exist=false:
    return vertex with "~undefined" label if not exist adjacent vertex

fix: #835
Change-Id: I30ce32ae358d0483888895a0017b77d55f346491