### PR TITLE
allow system async task in gremlin context

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/security/HugeSecurityManager.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/security/HugeSecurityManager.java
@@ -66,8 +66,8 @@ public class HugeSecurityManager extends SecurityManager {
 
     private static final Map<String, Set<String>> ASYNC_TASKS = ImmutableMap.of(
             "com.baidu.hugegraph.backend.tx.SchemaTransaction",
-            ImmutableSet.of("rebuildIndex", "removeVertexLabel",
-                            "removeEdgeLabel", "removeIndexLabel"),
+            ImmutableSet.of("removeVertexLabel", "removeEdgeLabel",
+                            "removeIndexLabel", "rebuildIndex"),
             "com.baidu.hugegraph.backend.tx.GraphIndexTransaction",
             ImmutableSet.of("asyncRemoveIndexLeft")
     );


### PR DESCRIPTION
Change-Id: I5ec9e09ea366ff32b6460ff138d8412065da2ca4

fix:
```
2020-03-12 10:41:27 65011 [gremlin-server-exec-4] [WARN ] com.baidu.hugegraph.security.HugeSecurityManager [] - SecurityException: Not allowed to access thread group via Gremlin
2020-03-12 10:41:27 65012 [gremlin-server-exec-4] [WARN ] org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler [] - Invalid request - responding with 500 Internal Server Error and Not allowed to access thread group via Gremlin
java.lang.SecurityException: Not allowed to access thread group via Gremlin
    at com.baidu.hugegraph.security.HugeSecurityManager.newSecurityException(HugeSecurityManager.java:357) ~[classes/:?]
    at com.baidu.hugegraph.security.HugeSecurityManager.checkAccess(HugeSecurityManager.java:136) ~[classes/:?]
    at java.lang.ThreadGroup.checkAccess(ThreadGroup.java:315) ~[?:1.8.0_121]
    at java.lang.Thread.init(Thread.java:391) ~[?:1.8.0_121]
    at java.lang.Thread.init(Thread.java:349) ~[?:1.8.0_121]
    at java.lang.Thread.<init>(Thread.java:675) ~[?:1.8.0_121]
    at java.util.concurrent.Executors$DefaultThreadFactory.newThread(Executors.java:613) ~[?:1.8.0_121]
    at org.apache.commons.lang3.concurrent.BasicThreadFactory.newThread(BasicThreadFactory.java:206) ~[commons-lang3-3.8.1.jar:3.8.1]
    at java.util.concurrent.ThreadPoolExecutor$Worker.<init>(ThreadPoolExecutor.java:612) ~[?:1.8.0_121]
    at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:925) ~[?:1.8.0_121]
    at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1357) ~[?:1.8.0_121]
    at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:112) ~[?:1.8.0_121]
    at com.baidu.hugegraph.task.TaskScheduler.submitTask(TaskScheduler.java:190) ~[classes/:?]
    at com.baidu.hugegraph.task.TaskScheduler.schedule(TaskScheduler.java:180) ~[classes/:?]
    at com.baidu.hugegraph.job.JobBuilder.schedule(JobBuilder.java:85) ~[classes/:?]
    at com.baidu.hugegraph.backend.tx.SchemaTransaction.asyncRun(SchemaTransaction.java:475) ~[classes/:?]
    at com.baidu.hugegraph.backend.tx.SchemaTransaction.rebuildIndex(SchemaTransaction.java:255) ~[classes/:?]
    at com.baidu.hugegraph.schema.builder.IndexLabelBuilder.createWithTask(IndexLabelBuilder.java:143) ~[classes/:?]
    at com.baidu.hugegraph.schema.builder.IndexLabelBuilder.create(IndexLabelBuilder.java:155) ~[classes/:?]
    at com.baidu.hugegraph.schema.builder.IndexLabelBuilder.create(IndexLabelBuilder.java:55) ~[classes/:?]
    at com.baidu.hugegraph.schema.builder.SchemaBuilder$create.call(Unknown Source) ~[?:?]
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47) ~[groovy-2.5.7-indy.jar:2.5.7]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:115) ~[groovy-2.5.7-indy.jar:2.5.7]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:119) ~[groovy-2.5.7-indy.jar:2.5.7]
    at Script5.run(Script5.groovy:1) ~[?:?]
    at org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine.eval(GremlinGroovyScriptEngine.java:674) ~[gremlin-groovy-3.4.3.jar:3.4.3]
    at org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine.eval(GremlinGroovyScriptEngine.java:376) ~[gremlin-groovy-3.4.3.jar:3.4.3]
    at javax.script.AbstractScriptEngine.eval(AbstractScriptEngine.java:233) ~[?:1.8.0_121]
    at org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor.lambda$eval$0(GremlinExecutor.java:266) ~[gremlin-groovy-3.4.3.jar:3.4.3]
    at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_121]
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_121]
    at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_121]
    at com.baidu.hugegraph.auth.HugeGraphAuthProxy$ContextTask.run(HugeGraphAuthProxy.java:282) [classes/:?]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_121]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_121]
    at java.lang.Thread.run(Thread.java:745) [?:1.8.0_121]
```