### PR TITLE
optimize EdgeId.asString()

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/id/EdgeId.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/id/EdgeId.java
@@ -177,7 +177,18 @@ public class EdgeId implements Id {
 
     @Override
     public int hashCode() {
-        return this.asString().hashCode();
+        if (this.directed) {
+            return this.ownerVertexId.hashCode() ^
+                   this.direction.hashCode() ^
+                   this.edgeLabelId.hashCode() ^
+                   this.sortValues.hashCode() ^
+                   this.otherVertexId.hashCode();
+        } else {
+            return this.sourceVertexId().hashCode() ^
+                   this.edgeLabelId.hashCode() ^
+                   this.sortValues.hashCode() ^
+                   this.targetVertexId().hashCode();
+        }
     }
 
     @Override
@@ -186,7 +197,18 @@ public class EdgeId implements Id {
             return false;
         }
         EdgeId other = (EdgeId) object;
-        return this.asString().equals(other.asString());
+        if (this.directed) {
+            return this.ownerVertexId.equals(other.ownerVertexId) &&
+                   this.direction == other.direction &&
+                   this.edgeLabelId.equals(other.edgeLabelId) &&
+                   this.sortValues.equals(other.sortValues) &&
+                   this.otherVertexId.equals(other.otherVertexId);
+        } else {
+            return this.sourceVertexId().equals(other.sourceVertexId()) &&
+                   this.edgeLabelId.equals(other.edgeLabelId) &&
+                   this.sortValues.equals(other.sortValues) &&
+                   this.targetVertexId().equals(other.targetVertexId());
+        }
     }
 
     @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/id/IdGenerator.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/id/IdGenerator.java
@@ -201,7 +201,7 @@ public abstract class IdGenerator {
         @Override
         public String asString() {
             // TODO: encode with base64
-            return String.valueOf(this.id);
+            return Long.toString(this.id);
         }
 
         @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/id/IdUtil.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/id/IdUtil.java
@@ -73,7 +73,10 @@ public final class IdUtil {
     }
 
     public static String writeString(Id id) {
-        return "" + id.type().prefix() + id.asObject();
+        String idString = id.asString();
+        StringBuilder sb = new StringBuilder(1 + idString.length());
+        sb.append(id.type().prefix()).append(idString);
+        return sb.toString();
     }
 
     public static Id readString(String id) {
@@ -101,7 +104,11 @@ public final class IdUtil {
     }
 
     public static String escape(char splitor, char escape, String... values) {
-        StringBuilder escaped = new StringBuilder((values.length + 1) << 4);
+        int length = values.length + 4;
+        for (String value : values) {
+            length += value.length();
+        }
+        StringBuilder escaped = new StringBuilder(length);
         // Do escape for every item in values
         for (String value : values) {
             if (escaped.length() > 0) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/schema/PropertyKey.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/schema/PropertyKey.java
@@ -135,6 +135,16 @@ public class PropertyKey extends SchemaElement implements Propfiable {
 
     @SuppressWarnings("unchecked")
     public <T> T newValue() {
+        switch (this.cardinality) {
+            case SET:
+                return (T) new LinkedHashSet<>();
+            case LIST:
+                return (T) new ArrayList<>();
+            default:
+                // pass
+                break;
+        }
+
         try {
             return (T) this.implementClazz().newInstance();
         } catch (Exception e) {
@@ -242,15 +252,16 @@ public class PropertyKey extends SchemaElement implements Propfiable {
         if (!(value instanceof Collection)) {
             validValue = this.convSingleValue(value);
         } else {
-            if (value instanceof Set) {
-                validValues = new HashSet<>();
+            Collection<T> collection = (Collection<T>) value;
+            if (collection instanceof Set) {
+                validValues = new HashSet<>(collection.size());
             } else {
-                E.checkArgument(value instanceof List,
+                E.checkArgument(collection instanceof List,
                                 "Property value must be Single, Set, List, " +
                                 "but got %s", value);
-                validValues = new ArrayList<>();
+                validValues = new ArrayList<>(collection.size());
             }
-            for (T element : (Collection<T>) value) {
+            for (T element : collection) {
                 element = this.convSingleValue(element);
                 if (element == null) {
                     return null;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeEdge.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeEdge.java
@@ -341,7 +341,7 @@ public class HugeEdge extends HugeElement implements Edge, Cloneable {
     public HugeEdge switchOwner() {
         HugeEdge edge = this.clone();
         edge.isOutEdge = !edge.isOutEdge;
-        edge.assignId();
+        edge.id = ((EdgeId) edge.id).switchDirection();
         return edge;
     }
 

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/UnitTestSuite.java
@@ -34,7 +34,6 @@ import com.baidu.hugegraph.unit.core.ConditionQueryFlattenTest;
 import com.baidu.hugegraph.unit.core.ConditionTest;
 import com.baidu.hugegraph.unit.core.DataTypeTest;
 import com.baidu.hugegraph.unit.core.DirectionsTest;
-import com.baidu.hugegraph.unit.core.EdgeIdTest;
 import com.baidu.hugegraph.unit.core.ExceptionTest;
 import com.baidu.hugegraph.unit.core.LocksTableTest;
 import com.baidu.hugegraph.unit.core.QueryTest;
@@ -42,6 +41,7 @@ import com.baidu.hugegraph.unit.core.RowLockTest;
 import com.baidu.hugegraph.unit.core.SecurityManagerTest;
 import com.baidu.hugegraph.unit.core.SerialEnumTest;
 import com.baidu.hugegraph.unit.core.TraversalUtilTest;
+import com.baidu.hugegraph.unit.id.EdgeIdTest;
 import com.baidu.hugegraph.unit.id.IdTest;
 import com.baidu.hugegraph.unit.id.IdUtilTest;
 import com.baidu.hugegraph.unit.mysql.MysqlUtilTest;
@@ -76,13 +76,13 @@ import com.baidu.hugegraph.unit.util.VersionTest;
 
     /* id */
     IdTest.class,
+    EdgeIdTest.class,
     IdUtilTest.class,
 
     /* core */
     LocksTableTest.class,
     RowLockTest.class,
     AnalyzerTest.class,
-    EdgeIdTest.class,
     BackendMutationTest.class,
     ConditionTest.class,
     ConditionQueryFlattenTest.class,

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/id/EdgeIdTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/id/EdgeIdTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package com.baidu.hugegraph.unit.core;
+package com.baidu.hugegraph.unit.id;
 
 import java.util.Set;
 


### PR DESCRIPTION
EdgeId.asString() cost 16% time when call:
1. GraphTx.joinTxEdges() -> Edge.switchOwner() -> Edge.assignId() ->
   EdgeId.length() -> EdgeId.asString()
2. Serializer.parseEdge() -> Vertex.addOut|InEdge() -> EdgeId.hashCode() ->
   EdgeId.asString()

also optimize PropertyKey.newValue() cost 1.3% time:
1. Serializer.parseProperty() -> PropertyKey.newValue() -> Class.newInstance()

about 10% performance improvement.

Change-Id: I07159d6503cc67a63d40a8fab5d7c02a42268986