### PR TITLE
Sigsegv problem

### DIFF
--- a/hugegraph-rocksdb/pom.xml
+++ b/hugegraph-rocksdb/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
-            <version>6.3.6</version>
+            <version>6.8.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
RocksIterator will sometimes Sigsegv on dispose. Mainly thats related
to dispose order. If the related RocksDB instance is freed beforehand
RocksIterator.dispose() will fail.  This problem is solved in version 6.8.1