### PR TITLE
fix: change default minimum log level to TRACE

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/BatchAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/BatchAPI.java
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class BatchAPI extends API {
 
-    private static final Logger LOG = Log.logger(RestServer.class);
+    private static final Logger LOG = Log.logger(BatchAPI.class);
 
     // NOTE: VertexAPI and EdgeAPI should share a counter
     private static final AtomicInteger batchWriteThreads = new AtomicInteger(0);

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/EdgeAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/EdgeAPI.java
@@ -63,7 +63,6 @@ import com.baidu.hugegraph.exception.NotFoundException;
 import com.baidu.hugegraph.schema.EdgeLabel;
 import com.baidu.hugegraph.schema.PropertyKey;
 import com.baidu.hugegraph.schema.VertexLabel;
-import com.baidu.hugegraph.server.RestServer;
 import com.baidu.hugegraph.structure.HugeEdge;
 import com.baidu.hugegraph.structure.HugeVertex;
 import com.baidu.hugegraph.traversal.optimize.QueryHolder;
@@ -79,7 +78,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @Singleton
 public class EdgeAPI extends BatchAPI {
 
-    private static final Logger LOG = Log.logger(RestServer.class);
+    private static final Logger LOG = Log.logger(EdgeAPI.class);
 
     @POST
     @Timed(name = "single-create")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/VertexAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/VertexAPI.java
@@ -60,7 +60,6 @@ import com.baidu.hugegraph.core.GraphManager;
 import com.baidu.hugegraph.define.UpdateStrategy;
 import com.baidu.hugegraph.schema.PropertyKey;
 import com.baidu.hugegraph.schema.VertexLabel;
-import com.baidu.hugegraph.server.RestServer;
 import com.baidu.hugegraph.structure.HugeVertex;
 import com.baidu.hugegraph.traversal.optimize.QueryHolder;
 import com.baidu.hugegraph.traversal.optimize.Text;
@@ -77,7 +76,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @Singleton
 public class VertexAPI extends BatchAPI {
 
-    private static final Logger LOG = Log.logger(RestServer.class);
+    private static final Logger LOG = Log.logger(VertexAPI.class);
 
     @POST
     @Timed(name = "single-create")

--- a/hugegraph-dist/src/assembly/static/conf/log4j2.xml
+++ b/hugegraph-dist/src/assembly/static/conf/log4j2.xml
@@ -9,7 +9,7 @@
 
         <RollingFile name="file" fileName="logs/hugegraph-server.log"
                      filePattern="logs/$${date:yyyy-MM}/hugegraph-server-%d{yyyy-MM-dd}-%i.log">
-            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
             <SizeBasedTriggeringPolicy size="100MB"/>
         </RollingFile>

--- a/hugegraph-dist/src/main/resources/log4j2.xml
+++ b/hugegraph-dist/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
 
         <RollingFile name="file" fileName="logs/hugegraph-server.log"
                      filePattern="logs/$${date:yyyy-MM}/hugegraph-server-%d{yyyy-MM-dd}-%i.log">
-            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
             <SizeBasedTriggeringPolicy size="100MB"/>
         </RollingFile>

--- a/hugegraph-example/src/main/resources/log4j2.xml
+++ b/hugegraph-example/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
 
         <RollingFile name="file" fileName="logs/hugegraph-example.log"
                      filePattern="logs/$${date:yyyy-MM}/hugegraph-example-%d{yyyy-MM-dd}-%i.log">
-            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
             <SizeBasedTriggeringPolicy size="100MB"/>
         </RollingFile>

--- a/hugegraph-test/src/main/resources/log4j2.xml
+++ b/hugegraph-test/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
 
         <RollingFile name="file" fileName="logs/hugegraph-test.log"
                      filePattern="logs/$${date:yyyy-MM}/hugegraph-test-%d{yyyy-MM-dd}-%i.log">
-            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
             <SizeBasedTriggeringPolicy size="100MB"/>
         </RollingFile>


### PR DESCRIPTION
> Log4j2 has 8 log levels: `ALL < TRACE < DEBUG < INFO < WARN < ERROR < FATAL < OFF`  (from low to high)

1. change minimum level from `INFO` to `TRACE` to **allow** print DEBUG & TRACE log
2. change `graph/*API` Log print class to themselves instead of RestServer.class

And we lack TRACE level logs now, so that the **DEBUG** output is too much (almost can't be directly opened)

My temporary solution is to dynamically modify the log level of **specified classes** to DEBUG through `Arthas` like this:
```bash
# 1.Change the same prefix classes log level together
$ logger -n com.baidu.hugegraph.api.graph -l debug

# 2.Only change one class
$ logger -n com.baidu.hugegraph.api.graph.VertexAPI -l debug
```
That's why we should let different class print its own logs separately(especially for thoses output a lot of logs), otherwise we have to change `RestServer.class` to debug, and it will print a lot of useless log.
