### PR TITLE
lock graph when close()

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
@@ -697,15 +697,14 @@ public class StandardHugeGraph implements HugeGraph {
         try {
             this.userManager.close();
             this.taskManager.closeScheduler(this.params);
-            try {
-                this.closeTx();
-            } finally {
-                this.closed = true;
-                this.storeProvider.close();
-                LockUtil.destroy(this.name);
-            }
+
+            this.closeTx();
         } finally {
+            this.closed = true;
             LockUtil.unlock(this.name, LockUtil.GRAPH_LOCK);
+            LockUtil.destroy(this.name);
+
+            this.storeProvider.close();
         }
 
         // Make sure that all transactions are closed in all threads

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
@@ -686,7 +686,7 @@ public class StandardHugeGraph implements HugeGraph {
     }
 
     @Override
-    public void close() throws Exception {
+    public synchronized void close() throws Exception {
         if (this.closed()) {
             return;
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
@@ -692,21 +692,15 @@ public class StandardHugeGraph implements HugeGraph {
         }
 
         LOG.info("Close graph {}", this);
-
-        LockUtil.lock(this.name, LockUtil.GRAPH_LOCK);
+        this.userManager.close();
+        this.taskManager.closeScheduler(this.params);
         try {
-            this.userManager.close();
-            this.taskManager.closeScheduler(this.params);
-
             this.closeTx();
         } finally {
             this.closed = true;
-            LockUtil.unlock(this.name, LockUtil.GRAPH_LOCK);
-            LockUtil.destroy(this.name);
-
             this.storeProvider.close();
+            LockUtil.destroy(this.name);
         }
-
         // Make sure that all transactions are closed in all threads
         E.checkState(this.tx.closed(),
                      "Ensure tx closed in all threads when closing graph '%s'",

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/task/ServerInfoManager.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/task/ServerInfoManager.java
@@ -72,6 +72,7 @@ public class ServerInfoManager {
     private NodeRole selfServerRole;
 
     private volatile boolean onlySingleNode;
+    private volatile boolean closed;
 
     public ServerInfoManager(HugeGraphParams graph,
                              ExecutorService dbExecutor) {
@@ -85,7 +86,9 @@ public class ServerInfoManager {
 
         this.selfServerId = null;
         this.selfServerRole = null;
+
         this.onlySingleNode = false;
+        this.closed = false;
     }
 
     private EventListener listenChanges() {
@@ -112,6 +115,7 @@ public class ServerInfoManager {
     }
 
     public boolean close() {
+        this.closed = true;
         this.unlistenChanges();
         if (!this.dbExecutor.isShutdown()) {
             this.removeSelfServerInfo();
@@ -203,6 +207,10 @@ public class ServerInfoManager {
     protected boolean initialized() {
         return this.call(() -> this.graph.graph().backendStoreSystemInfo()
                                          .exists());
+    }
+
+    protected boolean closed() {
+        return this.closed;
     }
 
     protected synchronized HugeServerInfo pickWorkerNode(

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/task/TaskManager.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/task/TaskManager.java
@@ -293,15 +293,18 @@ public final class TaskManager {
         try {
             /*
              * Skip if:
-             * graph is not initialized(maybe truncated or cleared)
+             * graph is closed (iterate schedulers before graph is closing)
              *  or
-             * graph is closed.
+             * graph is not initialized(maybe truncated or cleared).
+             *
              * If graph is closing by other thread, current thread get
              * serverManager and try lock graph, at the same time other
              * thread deleted the lock-group, current thread would get
              * exception 'LockGroup xx does not exists'.
+             * If graph is closed, don't call serverManager.initialized()
+             * due to it will reopen graph tx.
              */
-            if (!serverManager.initialized() || serverManager.closed()) {
+            if (serverManager.closed() || !serverManager.initialized()) {
                 return;
             }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/task/TaskManager.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/task/TaskManager.java
@@ -20,7 +20,6 @@
 package com.baidu.hugegraph.task;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -96,8 +95,23 @@ public final class TaskManager {
 
     public void closeScheduler(HugeGraphParams graph) {
         TaskScheduler scheduler = this.schedulers.get(graph);
-        if (scheduler != null && scheduler.close()) {
-            this.schedulers.remove(graph);
+        if (scheduler != null) {
+            /*
+             * Synch close+remove scheduler and iterate scheduler, details:
+             * 'closeScheduler' should sync with 'scheduleOrExecuteJob'.
+             * Because 'closeScheduler' will be called by 'graph.close()' in
+             * main thread and there is gap between 'scheduler.close()'
+             * (will close graph tx) and 'this.schedulers.remove(graph)'.
+             * In this gap 'scheduleOrExecuteJob' may be run in
+             * scheduler-db-thread and 'scheduleOrExecuteJob' will reopen
+             * graph tx. As a result, graph tx will mistakenly not be closed
+             * after 'graph.close()'.
+             */
+            synchronized (scheduler) {
+                if (scheduler.close()) {
+                    this.schedulers.remove(graph);
+                }
+            }
         }
 
         if (!this.taskExecutor.isTerminated()) {
@@ -255,65 +269,63 @@ public final class TaskManager {
     }
 
     private void scheduleOrExecuteJob() {
-        List<String> graphs = new ArrayList<>();
+        // Called by scheduler timer
         try {
             for (TaskScheduler entry : this.schedulers.values()) {
                 StandardTaskScheduler scheduler = (StandardTaskScheduler) entry;
-                ServerInfoManager serverManager = scheduler.serverManager();
-
-                String graph = scheduler.graphName();
-                LockUtil.lock(graph, LockUtil.GRAPH_LOCK);
-                graphs.add(graph);
-
-                /*
-                 * Skip if:
-                 * graph is not initialized(maybe truncated or cleared)
-                 *  or
-                 * graph is closed, details reason:
-                 * 'closeScheduler' should sync with 'scheduleOrExecuteJob'.
-                 * Because 'closeScheduler' will be called by 'graph.close()'
-                 * in main thread and there is gap between 'scheduler.close()'
-                 * (will close graph tx) and 'this.schedulers.remove(graph)'.
-                 * In this gap 'scheduleOrExecuteJob' may be run in
-                 * scheduler-db-thread and 'scheduleOrExecuteJob' will reopen
-                 * graph tx. As a result, graph tx will mistakenly not be closed
-                 * after 'graph.close()'.
-                 * If graph is closing by other thread, current thread get
-                 * serverManager and try lock graph, at the same time graph is
-                 * unlocked by other thread and deleted lock-group, current
-                 * thread would get exception 'LockGroup xx does not exists'.
-                 */
-                if (!serverManager.initialized() || serverManager.closed()) {
-                    continue;
+                // Maybe other thread close&remove scheduler at the same time
+                synchronized (scheduler) {
+                    this.scheduleOrExecuteJobForGraph(scheduler);
                 }
-
-                // Update server heartbeat
-                serverManager.heartbeat();
-
-                /*
-                 * Master schedule tasks to suitable servers.
-                 * There is no suitable server when these tasks are created
-                 */
-                if (serverManager.master()) {
-                    scheduler.scheduleTasks();
-                    if (!serverManager.onlySingleNode()) {
-                        continue;
-                    }
-                }
-
-                // Schedule queued tasks scheduled to current server
-                scheduler.executeTasksOnWorker(serverManager.selfServerId());
-
-                // Cancel tasks scheduled to current server
-                scheduler.cancelTasksOnWorker(serverManager.selfServerId());
             }
         } catch (Throwable e) {
             LOG.error("Exception occurred when schedule job", e);
-        } finally {
-            Collections.reverse(graphs);
-            for (String graph : graphs) {
-                LockUtil.unlock(graph, LockUtil.GRAPH_LOCK);
+        }
+    }
+
+    private void scheduleOrExecuteJobForGraph(StandardTaskScheduler scheduler) {
+        E.checkNotNull(scheduler, "scheduler");
+
+        ServerInfoManager serverManager = scheduler.serverManager();
+        String graph = scheduler.graphName();
+
+        LockUtil.lock(graph, LockUtil.GRAPH_LOCK);
+        try {
+            /*
+             * Skip if:
+             * graph is not initialized(maybe truncated or cleared)
+             *  or
+             * graph is closed.
+             * If graph is closing by other thread, current thread get
+             * serverManager and try lock graph, at the same time other
+             * thread deleted the lock-group, current thread would get
+             * exception 'LockGroup xx does not exists'.
+             */
+            if (!serverManager.initialized() || serverManager.closed()) {
+                return;
             }
+
+            // Update server heartbeat
+            serverManager.heartbeat();
+
+            /*
+             * Master schedule tasks to suitable servers.
+             * There is no suitable server when these tasks are created
+             */
+            if (serverManager.master()) {
+                scheduler.scheduleTasks();
+                if (!serverManager.onlySingleNode()) {
+                    return;
+                }
+            }
+
+            // Schedule queued tasks scheduled to current server
+            scheduler.executeTasksOnWorker(serverManager.selfServerId());
+
+            // Cancel tasks scheduled to current server
+            scheduler.cancelTasksOnWorker(serverManager.selfServerId());
+        } finally {
+            LockUtil.unlock(graph, LockUtil.GRAPH_LOCK);
         }
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/task/TaskManager.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/task/TaskManager.java
@@ -277,7 +277,11 @@ public final class TaskManager {
                  * In this gap 'scheduleOrExecuteJob' may be run in
                  * scheduler-db-thread and 'scheduleOrExecuteJob' will reopen
                  * graph tx. As a result, graph tx will mistakenly not be closed
-                 * after 'graph.close()'
+                 * after 'graph.close()'.
+                 * If graph is closing by other thread, current thread get
+                 * serverManager and try lock graph, at the same time graph is
+                 * unlocked by other thread and deleted lock-group, current
+                 * thread would get exception 'LockGroup xx does not exists'.
                  */
                 if (!serverManager.initialized() || serverManager.closed()) {
                     continue;


### PR DESCRIPTION
also fix scheduleOrExecuteJob and closeScheduler dead lock:
when main thread catched lock in closeScheduler() then call closeSchedulerTx()
and wait for schedulerExecutor, at the same time scheduler thread call
scheduleOrExecuteJob() but can't get synchronized lock, caused dead lock.

fix #1075
Change-Id: I47e7d4bbb87dd1330dd33616b6d2c33b2a39a89e