### PR TITLE
fix delete/read without READ permission throw 'no such id' 

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/API.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/API.java
@@ -20,7 +20,6 @@
 package com.baidu.hugegraph.api;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
@@ -30,7 +29,6 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
 import org.slf4j.Logger;
 
 import com.baidu.hugegraph.HugeException;
@@ -39,7 +37,6 @@ import com.baidu.hugegraph.core.GraphManager;
 import com.baidu.hugegraph.define.Checkable;
 import com.baidu.hugegraph.metrics.MetricsUtil;
 import com.baidu.hugegraph.server.RestServer;
-import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.JsonUtil;
 import com.baidu.hugegraph.util.Log;
@@ -132,20 +129,6 @@ public class API {
             list[i++] = prop.getValue();
         }
         return list;
-    }
-
-    protected static void checkExist(Iterator<?> iter,
-                                     HugeType type,
-                                     String id) {
-        if (!iter.hasNext()) {
-            try {
-                CloseableIterator.closeIterator(iter);
-            } catch (Exception ignored) {}
-
-            throw new NotFoundException(String.format(
-                      "%s with id '%s' does not exist",
-                      type.readableName(), id));
-        }
     }
 
     protected static void checkCreatingBody(Checkable body) {

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/EdgeAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/EdgeAPI.java
@@ -371,7 +371,8 @@ public class EdgeAPI extends BatchAPI {
             try {
                 edge = g.edge(id);
             } catch (NotFoundException e) {
-                throw new IllegalArgumentException(e.getMessage());
+                throw new IllegalArgumentException(String.format(
+                          "No such edge with id: '%s', %s", id, e));
             } catch (NoSuchElementException e) {
                 throw new IllegalArgumentException(String.format(
                           "No such edge with id: '%s'", id));

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/EdgeAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/EdgeAPI.java
@@ -67,7 +67,6 @@ import com.baidu.hugegraph.structure.HugeEdge;
 import com.baidu.hugegraph.structure.HugeVertex;
 import com.baidu.hugegraph.traversal.optimize.QueryHolder;
 import com.baidu.hugegraph.traversal.optimize.TraversalUtil;
-import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.type.define.Directions;
 import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.Log;
@@ -346,9 +345,8 @@ public class EdgeAPI extends BatchAPI {
 
         HugeGraph g = graph(manager, graph);
         try {
-            Iterator<Edge> edges = g.edges(id);
-            checkExist(edges, HugeType.EDGE, id);
-            return manager.serializer(g).writeEdge(edges.next());
+            Edge edge = g.edge(id);
+            return manager.serializer(g).writeEdge(edge);
         } finally {
             if (g.tx().isOpen()) {
                 g.tx().close();
@@ -371,7 +369,7 @@ public class EdgeAPI extends BatchAPI {
         commit(g, () -> {
             Edge edge;
             try {
-                edge = g.edges(id).next();
+                edge = g.edge(id);
             } catch (NotFoundException e) {
                 throw new IllegalArgumentException(e.getMessage());
             } catch (NoSuchElementException e) {

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/VertexAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/graph/VertexAPI.java
@@ -319,7 +319,8 @@ public class VertexAPI extends BatchAPI {
             try {
                 vertex = g.vertex(id);
             } catch (NotFoundException e) {
-                throw new IllegalArgumentException(e.getMessage());
+                throw new IllegalArgumentException(String.format(
+                          "No such vertex with id: '%s', %s", id, e));
             } catch (NoSuchElementException e) {
                 throw new IllegalArgumentException(String.format(
                           "No such vertex with id: '%s'", id));

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CountAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CountAPI.java
@@ -19,8 +19,11 @@
 
 package com.baidu.hugegraph.api.traversers;
 
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_SKIP_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
+
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -37,8 +40,6 @@ import com.baidu.hugegraph.HugeGraph;
 import com.baidu.hugegraph.api.API;
 import com.baidu.hugegraph.backend.id.Id;
 import com.baidu.hugegraph.core.GraphManager;
-import com.baidu.hugegraph.schema.EdgeLabel;
-import com.baidu.hugegraph.schema.PropertyKey;
 import com.baidu.hugegraph.server.RestServer;
 import com.baidu.hugegraph.structure.HugeVertex;
 import com.baidu.hugegraph.traversal.algorithm.CountTraverser;
@@ -48,8 +49,6 @@ import com.baidu.hugegraph.util.Log;
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
-
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.*;
 
 @Path("graphs/{graph}/traversers/count")
 @Singleton
@@ -129,40 +128,18 @@ public class CountAPI extends API {
         @JsonProperty("skip_degree")
         public long skipDegree = Long.valueOf(DEFAULT_SKIP_DEGREE);
 
-        private CountTraverser.Step jsonToStep(HugeGraph graph) {
-            E.checkArgument(this.degree == NO_LIMIT || this.degree > 0,
-                            "The degree must be > 0, but got: %s",
-                            this.degree);
-            E.checkArgument(this.skipDegree == NO_LIMIT ||
-                            this.skipDegree >= 0,
-                            "The skip degree must be >= 0, but got: %s",
-                            this.skipDegree);
-
-            Map<Id, String> labelIds = new HashMap<>();
-            if (this.labels != null) {
-                for (String label : this.labels) {
-                    EdgeLabel el = graph.edgeLabel(label);
-                    labelIds.put(el.id(), label);
-                }
-            }
-            Map<Id, Object> pks = null;
-            if (this.properties != null && !this.properties.isEmpty()) {
-                pks = new HashMap<>(this.properties.size());
-                for (Map.Entry<String, Object> e: this.properties.entrySet()) {
-                    PropertyKey pk = graph.propertyKey(e.getKey());
-                    pks.put(pk.id(), e.getValue());
-                }
-            }
-            return new CountTraverser.Step(this.direction, labelIds,
-                                           pks, this.degree, this.skipDegree);
-        }
-
         @Override
         public String toString() {
             return String.format("Step{direction=%s,labels=%s,properties=%s" +
                                  "degree=%s,skipDegree=%s}",
                                  this.direction, this.labels, this.properties,
                                  this.degree, this.skipDegree);
+        }
+
+        private CountTraverser.Step jsonToStep(HugeGraph graph) {
+            return new CountTraverser.Step(graph, this.direction, this.labels,
+                                           this.properties, this.degree,
+                                           this.skipDegree);
         }
     }
 }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
@@ -22,10 +22,8 @@ package com.baidu.hugegraph.api.traversers;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -48,7 +46,6 @@ import com.baidu.hugegraph.api.API;
 import com.baidu.hugegraph.backend.id.Id;
 import com.baidu.hugegraph.backend.query.QueryResults;
 import com.baidu.hugegraph.core.GraphManager;
-import com.baidu.hugegraph.schema.EdgeLabel;
 import com.baidu.hugegraph.server.RestServer;
 import com.baidu.hugegraph.traversal.algorithm.CustomizedCrosspointsTraverser;
 import com.baidu.hugegraph.traversal.algorithm.HugeTraverser;
@@ -178,29 +175,23 @@ public class CustomizedCrosspointsAPI extends API {
         public Map<String, Object> properties;
         @JsonProperty("degree")
         public long degree = Long.valueOf(DEFAULT_DEGREE);
+        @JsonProperty("skip_degree")
+        public long skipDegree = 0L;
 
         @Override
         public String toString() {
             return String.format("Step{direction=%s,labels=%s,properties=%s," +
-                                 "degree=%s}", this.direction, this.labels,
-                                 this.properties, this.degree);
+                                 "degree=%s,skipDegree=%s}",
+                                 this.direction, this.labels, this.properties,
+                                 this.degree, this.skipDegree);
         }
 
         private CustomizedCrosspointsTraverser.Step jsonToStep(HugeGraph g) {
-            E.checkArgument(this.degree > 0 || this.degree == NO_LIMIT,
-                            "The degree must be > 0 or == -1, but got: %s",
-                            this.degree);
-            Map<Id, String> labelIds = new HashMap<>();
-            if (this.labels != null) {
-                for (String label : this.labels) {
-                    EdgeLabel el = g.edgeLabel(label);
-                    labelIds.put(el.id(), label);
-                }
-            }
-            return new CustomizedCrosspointsTraverser.Step(this.direction,
-                                                           labelIds,
+            return new CustomizedCrosspointsTraverser.Step(g, this.direction,
+                                                           this.labels,
                                                            this.properties,
-                                                           this.degree);
+                                                           this.degree,
+                                                           this.skipDegree);
         }
     }
 }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedPathsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedPathsAPI.java
@@ -24,10 +24,8 @@ import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGR
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_SAMPLE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_WEIGHT;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -50,8 +48,6 @@ import com.baidu.hugegraph.api.API;
 import com.baidu.hugegraph.backend.id.Id;
 import com.baidu.hugegraph.backend.query.QueryResults;
 import com.baidu.hugegraph.core.GraphManager;
-import com.baidu.hugegraph.schema.EdgeLabel;
-import com.baidu.hugegraph.schema.PropertyKey;
 import com.baidu.hugegraph.server.RestServer;
 import com.baidu.hugegraph.traversal.algorithm.CustomizePathsTraverser;
 import com.baidu.hugegraph.traversal.algorithm.HugeTraverser;
@@ -163,51 +159,37 @@ public class CustomizedPathsAPI extends API {
         public List<String> labels;
         @JsonProperty("properties")
         public Map<String, Object> properties;
+        @JsonProperty("degree")
+        public long degree = Long.valueOf(DEFAULT_DEGREE);
+        @JsonProperty("skip_degree")
+        public long skipDegree = 0L;
         @JsonProperty("weight_by")
         public String weightBy;
         @JsonProperty("default_weight")
         public double defaultWeight = Double.valueOf(DEFAULT_WEIGHT);
-        @JsonProperty("degree")
-        public long degree = Long.valueOf(DEFAULT_DEGREE);
         @JsonProperty("sample")
         public long sample = Long.valueOf(DEFAULT_SAMPLE);
 
         @Override
         public String toString() {
             return String.format("Step{direction=%s,labels=%s,properties=%s," +
-                                 "weightBy=%s,defaultWeight=%s,degree=%s," +
-                                 "sample=%s}", this.direction, this.labels,
-                                 this.properties, this.weightBy,
-                                 this.defaultWeight, this.degree, this.sample);
+                                 "degree=%s,skipDegree=%s," +
+                                 "weightBy=%s,defaultWeight=%s,sample=%s}",
+                                 this.direction, this.labels, this.properties,
+                                 this.degree, this.skipDegree,
+                                 this.weightBy, this.defaultWeight,
+                                 this.sample);
         }
 
-        private CustomizePathsTraverser.Step jsonToStep(HugeGraph graph) {
-            E.checkArgument(this.degree > 0 || this.degree == NO_LIMIT,
-                            "The degree must be > 0, but got: %s",
-                            this.degree);
-            E.checkArgument(this.sample > 0 || this.sample == NO_LIMIT,
-                            "The sample must be > 0, but got: %s",
-                            this.sample);
-            E.checkArgument(this.degree == NO_LIMIT ||
-                            this.degree >= this.sample,
-                            "Degree must be greater than or equal to sample," +
-                            " but got degree %s and sample %s",
-                            this.degree, this.sample);
-            Map<Id, String> labelIds = new HashMap<>();
-            if (this.labels != null) {
-                for (String label : this.labels) {
-                    EdgeLabel el = graph.edgeLabel(label);
-                    labelIds.put(el.id(), label);
-                }
-            }
-            PropertyKey weightBy = null;
-            if (this.weightBy != null) {
-                weightBy = graph.propertyKey(this.weightBy);
-            }
-            return new CustomizePathsTraverser.Step(this.direction, labelIds,
-                                                    this.properties, weightBy,
+        private CustomizePathsTraverser.Step jsonToStep(HugeGraph g) {
+            return new CustomizePathsTraverser.Step(g, this.direction,
+                                                    this.labels,
+                                                    this.properties,
+                                                    this.degree,
+                                                    this.skipDegree,
+                                                    this.weightBy,
                                                     this.defaultWeight,
-                                                    this.degree, this.sample);
+                                                    this.sample);
         }
     }
 

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/NeighborRankAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/NeighborRankAPI.java
@@ -23,11 +23,8 @@ import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPA
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEPTH;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
-import static com.baidu.hugegraph.traversal.algorithm.NeighborRankTraverser.MAX_TOP;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,7 +41,6 @@ import com.baidu.hugegraph.HugeGraph;
 import com.baidu.hugegraph.api.API;
 import com.baidu.hugegraph.backend.id.Id;
 import com.baidu.hugegraph.core.GraphManager;
-import com.baidu.hugegraph.schema.EdgeLabel;
 import com.baidu.hugegraph.server.RestServer;
 import com.baidu.hugegraph.structure.HugeVertex;
 import com.baidu.hugegraph.traversal.algorithm.NeighborRankTraverser;
@@ -129,8 +125,12 @@ public class NeighborRankAPI extends API {
         public List<String> labels;
         @JsonProperty("degree")
         public long degree = Long.valueOf(DEFAULT_DEGREE);
+        @JsonProperty("skip_degree")
+        public long skipDegree = 0L;
         @JsonProperty("top")
         public int top = Integer.valueOf(DEFAULT_PATHS_LIMIT);
+
+        public static final int DEFAULT_CAPACITY_PER_LAYER = 100000;
 
         @Override
         public String toString() {
@@ -139,21 +139,13 @@ public class NeighborRankAPI extends API {
                                  this.degree, this.top);
         }
 
-        private NeighborRankTraverser.Step jsonToStep(HugeGraph graph) {
-            E.checkArgument(this.degree > 0 || this.degree == NO_LIMIT,
-                            "The degree must be > 0, but got: %s",
-                            this.degree);
-            E.checkArgument(this.top > 0 && this.top <= MAX_TOP,
-                            "The top of each layer can't exceed %s", MAX_TOP);
-            Map<Id, String> labelIds = new HashMap<>();
-            if (this.labels != null) {
-                for (String label : this.labels) {
-                    EdgeLabel el = graph.edgeLabel(label);
-                    labelIds.put(el.id(), label);
-                }
-            }
-            return new NeighborRankTraverser.Step(this.direction, labelIds,
-                                                  this.degree, this.top);
+        private NeighborRankTraverser.Step jsonToStep(HugeGraph g) {
+            return new NeighborRankTraverser.Step(g, this.direction,
+                                                  this.labels,
+                                                  this.degree,
+                                                  this.skipDegree,
+                                                  this.top,
+                                                  DEFAULT_CAPACITY_PER_LAYER);
         }
     }
 }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/SourceVertices.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/SourceVertices.java
@@ -20,7 +20,6 @@
 package com.baidu.hugegraph.api.traversers;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -30,9 +29,9 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import com.baidu.hugegraph.HugeGraph;
 import com.baidu.hugegraph.backend.id.Id;
-import com.baidu.hugegraph.backend.query.Condition;
 import com.baidu.hugegraph.backend.query.ConditionQuery;
 import com.baidu.hugegraph.structure.HugeVertex;
+import com.baidu.hugegraph.traversal.optimize.TraversalUtil;
 import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.type.define.HugeKeys;
 import com.baidu.hugegraph.util.E;
@@ -69,15 +68,8 @@ public class SourceVertices {
                 query.eq(HugeKeys.LABEL, label);
             }
             if (props != null && !props.isEmpty()) {
-                for (Map.Entry<String, Object> entry : props.entrySet()) {
-                    Id pkeyId = g.propertyKey(entry.getKey()).id();
-                    Object value = entry.getValue();
-                    if (value instanceof Collection) {
-                        query.query(Condition.in(pkeyId, (List<?>) value));
-                    } else {
-                        query.query(Condition.eq(pkeyId, value));
-                    }
-                }
+                Map<Id, Object> pks = TraversalUtil.transProperties(g, props);
+                TraversalUtil.fillConditionQuery(query, pks, g);
             }
             assert !query.empty();
             iterator = g.vertices(query);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeGraph.java
@@ -107,14 +107,14 @@ public interface HugeGraph extends Graph {
     public <V> void addEdgeProperty(Property<V> property);
     public <V> void removeEdgeProperty(Property<V> property);
 
-    public Vertex vertex(Object objects);
+    public Vertex vertex(Object object);
     @Override
     public Iterator<Vertex> vertices(Object... objects);
     public Iterator<Vertex> vertices(Query query);
     public Iterator<Vertex> adjacentVertex(Object id);
     public boolean checkAdjacentVertexExist();
 
-    public Edge edge(Object objects);
+    public Edge edge(Object object);
     @Override
     public Iterator<Edge> edges(Object... objects);
     public Iterator<Edge> edges(Query query);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeGraph.java
@@ -107,10 +107,16 @@ public interface HugeGraph extends Graph {
     public <V> void addEdgeProperty(Property<V> property);
     public <V> void removeEdgeProperty(Property<V> property);
 
+    public Vertex vertex(Object objects);
+    @Override
+    public Iterator<Vertex> vertices(Object... objects);
     public Iterator<Vertex> vertices(Query query);
     public Iterator<Vertex> adjacentVertex(Object id);
     public boolean checkAdjacentVertexExist();
 
+    public Edge edge(Object objects);
+    @Override
+    public Iterator<Edge> edges(Object... objects);
     public Iterator<Edge> edges(Query query);
     public Iterator<Vertex> adjacentVertices(Iterator<Edge> edges) ;
     public Iterator<Edge> adjacentEdges(Id vertexId);
@@ -120,7 +126,6 @@ public interface HugeGraph extends Graph {
     public String name();
     public String backend();
     public String backendVersion();
-    public boolean backendStoreInitialized();
     public BackendStoreSystemInfo backendStoreSystemInfo();
     public BackendFeatures backendStoreFeatures();
 
@@ -145,6 +150,8 @@ public interface HugeGraph extends Graph {
     public TaskScheduler taskScheduler();
 
     public void proxy(HugeGraph graph);
+
+    public boolean sameAs(HugeGraph graph);
 
     public long now();
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
@@ -186,11 +186,6 @@ public class StandardHugeGraph implements HugeGraph {
     }
 
     @Override
-    public boolean backendStoreInitialized() {
-        return this.graphTransaction().initialized();
-    }
-
-    @Override
     public BackendStoreSystemInfo backendStoreSystemInfo() {
         return new BackendStoreSystemInfo(this.schemaTransaction());
     }
@@ -468,6 +463,11 @@ public class StandardHugeGraph implements HugeGraph {
     }
 
     @Override
+    public Vertex vertex(Object objects) {
+        return this.graphTransaction().queryVertex(objects);
+    }
+
+    @Override
     public Iterator<Vertex> vertices(Object... objects) {
         if (objects.length == 0) {
             return this.graphTransaction().queryVertices();
@@ -488,6 +488,11 @@ public class StandardHugeGraph implements HugeGraph {
     @Override
     public boolean checkAdjacentVertexExist() {
         return this.graphTransaction().checkAdjacentVertexExist();
+    }
+
+    @Override
+    public Edge edge(Object objects) {
+        return this.graphTransaction().queryEdge(objects);
     }
 
     @Override
@@ -782,6 +787,21 @@ public class StandardHugeGraph implements HugeGraph {
         return StringFactory.graphString(this, this.name());
     }
 
+    @Override
+    public final void proxy(HugeGraph graph) {
+        this.params.graph(graph);
+    }
+
+    @Override
+    public boolean sameAs(HugeGraph graph) {
+        return this == graph;
+    }
+
+    @Override
+    public long now() {
+        return ((TinkerpopTransaction) this.tx()).openedTime();
+    }
+
     private void closeTx() {
         try {
             if (this.tx.isOpen()) {
@@ -799,16 +819,6 @@ public class StandardHugeGraph implements HugeGraph {
         } catch (TimeoutException e) {
             throw new HugeException("Failed to wait all tasks to complete", e);
         }
-    }
-
-    @Override
-    public final void proxy(HugeGraph graph) {
-        this.params.graph(graph);
-    }
-
-    @Override
-    public long now() {
-        return ((TinkerpopTransaction) this.tx()).openedTime();
     }
 
     private class StandardHugeGraphParams implements HugeGraphParams {
@@ -872,7 +882,7 @@ public class StandardHugeGraph implements HugeGraph {
 
         @Override
         public boolean initialized() {
-            return StandardHugeGraph.this.backendStoreInitialized();
+            return StandardHugeGraph.this.graphTransaction().storeInitialized();
         }
 
         @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
@@ -463,8 +463,8 @@ public class StandardHugeGraph implements HugeGraph {
     }
 
     @Override
-    public Vertex vertex(Object objects) {
-        return this.graphTransaction().queryVertex(objects);
+    public Vertex vertex(Object object) {
+        return this.graphTransaction().queryVertex(object);
     }
 
     @Override
@@ -491,8 +491,8 @@ public class StandardHugeGraph implements HugeGraph {
     }
 
     @Override
-    public Edge edge(Object objects) {
-        return this.graphTransaction().queryEdge(objects);
+    public Edge edge(Object object) {
+        return this.graphTransaction().queryEdge(object);
     }
 
     @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStoreSystemInfo.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStoreSystemInfo.java
@@ -86,7 +86,7 @@ public class BackendStoreSystemInfo {
     }
 
     public boolean exists() {
-        if (!this.schemaTx.graph().backendStoreInitialized()) {
+        if (!this.schemaTx.storeInitialized()) {
             return false;
         }
         return this.info() != null;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/AbstractTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/AbstractTransaction.java
@@ -96,7 +96,7 @@ public abstract class AbstractTransaction implements Transaction {
         return this.store.features();
     }
 
-    public boolean initialized() {
+    public boolean storeInitialized() {
         return this.store.initialized();
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
@@ -619,7 +619,6 @@ public class GraphTransaction extends IndexableTransaction {
         } else {
             vertex.assignId(id);
         }
-        vertex.setExpiredTime();
 
         return vertex;
     }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/system/DeleteExpiredElementJob.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/system/DeleteExpiredElementJob.java
@@ -45,6 +45,8 @@ public class DeleteExpiredElementJob<V> extends DeleteExpiredJob<V> {
 
     @Override
     public V execute() throws Exception {
+        LOG.debug("Delete expired elements: {}", this.elements);
+
         HugeGraphParams graph = this.params();
         GraphTransaction tx = graph.graphTransaction();
         try {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/job/system/DeleteExpiredIndexJob.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/job/system/DeleteExpiredIndexJob.java
@@ -49,6 +49,8 @@ public class DeleteExpiredIndexJob<V> extends DeleteExpiredJob<V> {
 
     @Override
     public V execute() throws Exception {
+        LOG.debug("Delete expired indexes: {}", this.indexes);
+
         HugeGraphParams graph = this.params();
         GraphTransaction tx = graph.graphTransaction();
         try {
@@ -56,7 +58,7 @@ public class DeleteExpiredIndexJob<V> extends DeleteExpiredJob<V> {
                 this.deleteExpiredIndex(graph, index);
             }
             tx.commit();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             tx.rollback();
             LOG.warn("Failed to delete expired indexes: {}", this.indexes);
             throw e;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/schema/SchemaLabel.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/schema/SchemaLabel.java
@@ -118,10 +118,12 @@ public abstract class SchemaLabel extends SchemaElement
     }
 
     public void ttl(long ttl) {
+        assert ttl >= 0L;
         this.ttl = ttl;
     }
 
     public long ttl() {
+        assert this.ttl >= 0L;
         return this.ttl;
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeEdge.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeEdge.java
@@ -90,7 +90,7 @@ public class HugeEdge extends HugeElement implements Edge, Cloneable {
 
     @Override
     public EdgeLabel schemaLabel() {
-        assert this.graph() == this.label.graph();
+        assert this.graph().sameAs(this.label.graph());
         return this.label;
     }
 
@@ -196,7 +196,7 @@ public class HugeEdge extends HugeElement implements Edge, Cloneable {
             E.checkArgument(!this.hasProperty(propertyKey.id()),
                             "Can't update sort key: '%s'", key);
         }
-        return this.addProperty(propertyKey, value, true);
+        return this.addProperty(propertyKey, value, !this.fresh());
     }
 
     @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeElement.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeElement.java
@@ -122,9 +122,11 @@ public abstract class HugeElement implements Element, GraphType, Idfiable {
 
     public void committed() {
         this.fresh = false;
+        // Set expired time
+        this.setExpiredTimeIfNeeded();
     }
 
-    public void setExpiredTime() {
+    public void setExpiredTimeIfNeeded() {
         SchemaLabel label = this.schemaLabel();
         if (label.ttl() == 0L) {
             return;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeIndex.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeIndex.java
@@ -121,8 +121,7 @@ public class HugeIndex implements GraphType, Cloneable {
 
     public Set<IdWithExpiredTime> expiredElementIds() {
         long now = this.graph.now();
-        Set<IdWithExpiredTime> expired = InsertionOrderUtil.newSet(
-                                         this.elementIds.size());
+        Set<IdWithExpiredTime> expired = InsertionOrderUtil.newSet();
         for (IdWithExpiredTime id : this.elementIds) {
             if (0L < id.expiredTime && id.expiredTime < now) {
                 expired.add(id);
@@ -290,6 +289,11 @@ public class HugeIndex implements GraphType, Cloneable {
 
         public long expiredTime() {
             return this.expiredTime;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s(%s)", this.id, this.expiredTime);
         }
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeVertex.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeVertex.java
@@ -96,7 +96,7 @@ public class HugeVertex extends HugeElement implements Vertex, Cloneable {
 
     @Override
     public VertexLabel schemaLabel() {
-        assert this.graph() == this.label.graph();
+        assert this.graph().sameAs(this.label.graph());
         return this.label;
     }
 
@@ -404,7 +404,6 @@ public class HugeVertex extends HugeElement implements Vertex, Cloneable {
 
     @Watched(prefix = "vertex")
     @Override
-    @SuppressWarnings("unchecked") // (VertexProperty<V>) prop
     public <V> VertexProperty<V> property(
                VertexProperty.Cardinality cardinality,
                String key, V value, Object... objects) {
@@ -445,7 +444,11 @@ public class HugeVertex extends HugeElement implements Vertex, Cloneable {
             E.checkArgument(!this.hasProperty(propertyKey.id()),
                             "Can't update primary key: '%s'", key);
         }
-        return (VertexProperty<V>) this.addProperty(propertyKey, value, true);
+
+        @SuppressWarnings("unchecked")
+        VertexProperty<V> prop = (VertexProperty<V>) this.addProperty(
+                                 propertyKey, value, !this.fresh());
+        return prop;
     }
 
     @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeVertex.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeVertex.java
@@ -305,9 +305,6 @@ public class HugeVertex extends HugeElement implements Vertex, Cloneable {
             edge.assignId();
         }
 
-        // Set expired time
-        edge.setExpiredTime();
-
         return edge;
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/CustomizePathsTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/CustomizePathsTraverser.java
@@ -76,9 +76,7 @@ public class CustomizePathsTraverser extends HugeTraverser {
             // Traversal vertices of previous level
             for (Map.Entry<Id, List<Node>> entry : sources.entrySet()) {
                 List<Node> adjacency = new ArrayList<>();
-                edges = edgesOfVertex(entry.getKey(), step.direction,
-                                      step.labels, step.properties,
-                                      step.degree);
+                edges = this.edgesOfVertex(entry.getKey(), step.edgeStep);
                 while (edges.hasNext()) {
                     HugeEdge edge = (HugeEdge) edges.next();
                     Id target = edge.id().otherVertexId();
@@ -243,23 +241,31 @@ public class CustomizePathsTraverser extends HugeTraverser {
 
     public static class Step {
 
-        private Directions direction;
-        private Map<Id, String> labels;
-        private Map<String, Object> properties;
-        private PropertyKey weightBy;
-        private double defaultWeight;
-        private long degree;
-        private long sample;
+        private final EdgeStep edgeStep;
+        private final PropertyKey weightBy;
+        private final double defaultWeight;
+        private final long sample;
 
-        public Step(Directions direction, Map<Id, String> labels,
-                    Map<String, Object> properties, PropertyKey weightBy,
-                    double defaultWeight, long degree, long sample) {
-            this.direction = direction;
-            this.labels = labels;
-            this.properties = properties;
-            this.weightBy = weightBy;
+        public Step(HugeGraph g, Directions direction, List<String> labels,
+                    Map<String, Object> properties,
+                    long degree, long skipDegree,
+                    String weightBy, double defaultWeight, long sample) {
+            E.checkArgument(sample > 0L || sample == NO_LIMIT,
+                            "The sample must be > 0 or == -1, but got: %s",
+                            sample);
+            E.checkArgument(degree == NO_LIMIT || degree >= sample,
+                            "Degree must be greater than or equal to sample," +
+                            " but got degree %s and sample %s",
+                            degree, sample);
+
+            this.edgeStep = new EdgeStep(g, direction, labels, properties,
+                                         degree, skipDegree);
+            if (weightBy != null) {
+                this.weightBy = g.propertyKey(weightBy);
+            } else {
+                this.weightBy = null;
+            }
             this.defaultWeight = defaultWeight;
-            this.degree = degree;
             this.sample = sample;
         }
     }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/CustomizedCrosspointsTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/CustomizedCrosspointsTraverser.java
@@ -81,9 +81,7 @@ public class CustomizedCrosspointsTraverser extends HugeTraverser {
                 // Traversal vertices of previous level
                 for (Map.Entry<Id, List<Node>> entry : sources.entrySet()) {
                     List<Node> adjacency = new ArrayList<>();
-                    edges = edgesOfVertex(entry.getKey(), step.direction,
-                                          step.labels, step.properties,
-                                          step.degree);
+                    edges = this.edgesOfVertex(entry.getKey(), step.edgeStep);
                     while (edges.hasNext()) {
                         HugeEdge edge = (HugeEdge) edges.next();
                         Id target = edge.id().otherVertexId();
@@ -190,17 +188,13 @@ public class CustomizedCrosspointsTraverser extends HugeTraverser {
 
     public static class Step {
 
-        private Directions direction;
-        private Map<Id, String> labels;
-        private Map<String, Object> properties;
-        private long degree;
+        private final EdgeStep edgeStep;
 
-        public Step(Directions direction, Map<Id, String> labels,
-                    Map<String, Object> properties, long degree) {
-            this.direction = direction;
-            this.labels = labels;
-            this.properties = properties;
-            this.degree = degree;
+        public Step(HugeGraph g, Directions direction, List<String> labels,
+                    Map<String, Object> properties, long degree,
+                    long skipDegree) {
+            this.edgeStep = new EdgeStep(g, direction, labels, properties,
+                                         degree, skipDegree);
         }
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/EdgeStep.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/EdgeStep.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.traversal.algorithm;
+
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.tinkerpop.gremlin.structure.Edge;
+
+import com.baidu.hugegraph.HugeGraph;
+import com.baidu.hugegraph.backend.id.Id;
+import com.baidu.hugegraph.schema.EdgeLabel;
+import com.baidu.hugegraph.traversal.optimize.TraversalUtil;
+import com.baidu.hugegraph.type.define.Directions;
+import com.baidu.hugegraph.util.E;
+
+public class EdgeStep {
+
+    protected final Directions direction;
+    protected final Map<Id, String> labels;
+    protected final Map<Id, Object> properties;
+    protected final long degree;
+    protected final long skipDegree;
+
+    public EdgeStep(HugeGraph g, Directions direction, List<String> labels,
+                    Map<String, Object> properties,
+                    long degree, long skipDegree) {
+        E.checkArgument(degree == NO_LIMIT || degree > 0L,
+                        "The degree must be > 0 or == -1, but got: %s",
+                        degree);
+        E.checkArgument(skipDegree == NO_LIMIT ||
+                        skipDegree >= 0L,
+                        "The skip degree must be >= 0 or == -1, but got: %s",
+                        skipDegree);
+        HugeTraverser.checkSkipDegree(skipDegree, degree,
+                                      HugeTraverser.NO_LIMIT);
+        this.direction = direction;
+
+        // Parse edge labels
+        Map<Id, String> labelIds = new HashMap<>();
+        if (labels != null) {
+            for (String label : labels) {
+                EdgeLabel el = g.edgeLabel(label);
+                labelIds.put(el.id(), label);
+            }
+        }
+        this.labels = labelIds;
+
+        // Parse properties
+        if (properties == null || properties.isEmpty()) {
+            this.properties = null;
+        } else {
+            this.properties = TraversalUtil.transProperties(g, properties);
+        }
+
+        this.degree = degree;
+        this.skipDegree = skipDegree;
+    }
+
+    public Id[] edgeLabels() {
+        int elsSize = this.labels.size();
+        Id[] edgeLabels = this.labels.keySet().toArray(new Id[elsSize]);
+        return edgeLabels;
+    }
+
+    public long limit() {
+        long limit = this.skipDegree > 0L ? this.skipDegree : this.degree;
+        return limit;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("EdgeStep{direction=%s,labels=%s,properties=%s}",
+                             this.direction, this.labels, this.properties);
+    }
+
+    public Iterator<Edge> skipSuperNodeIfNeeded(Iterator<Edge> edges) {
+        return HugeTraverser.skipSuperNodeIfNeeded(edges, this.degree,
+                                                   this.skipDegree);
+    }
+}

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/NeighborRankTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/NeighborRankTraverser.java
@@ -41,7 +41,6 @@ import com.baidu.hugegraph.util.OrderLimitMap;
 public class NeighborRankTraverser extends HugeTraverser {
 
     public static final int MAX_TOP = 1000;
-    public static final int DEFAULT_CAPACITY_PER_LAYER = 100000;
 
     private final double alpha;
     private final long capacity;
@@ -74,9 +73,8 @@ public class NeighborRankTraverser extends HugeTraverser {
             // Traversal vertices of previous level
             for (Map.Entry<Id, List<Node>> entry : sources.entrySet()) {
                 Id vertex = entry.getKey();
-                Iterator<Edge> edges = edgesOfVertex(vertex, step.direction,
-                                                     step.labels, null,
-                                                     step.degree);
+                Iterator<Edge> edges = this.edgesOfVertex(vertex,
+                                                          step.edgeStep);
 
                 Adjacencies adjacenciesV = new Adjacencies(vertex);
                 Set<Id> sameLayerNodesV = new HashSet<>();
@@ -237,19 +235,19 @@ public class NeighborRankTraverser extends HugeTraverser {
 
     public static class Step {
 
-        private final Directions direction;
-        private final Map<Id, String> labels;
-        private final long degree;
+        private final EdgeStep edgeStep;
         private final int top;
         private final int capacity;
 
-        public Step(Directions direction, Map<Id, String> labels,
-                    long degree, int top) {
-            this.direction = direction;
-            this.labels = labels;
-            this.degree = degree;
+        public Step(HugeGraph g, Directions direction, List<String> labels,
+                    long degree, long skipDegree, int top, int capacity) {
+            E.checkArgument(top > 0 && top <= MAX_TOP,
+                            "The top of each layer can't exceed %s", MAX_TOP);
+
+            this.edgeStep = new EdgeStep(g, direction, labels, null,
+                                         degree, skipDegree);
             this.top = top;
-            this.capacity = DEFAULT_CAPACITY_PER_LAYER;
+            this.capacity = capacity;
         }
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/HugeGraphStep.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/HugeGraphStep.java
@@ -150,8 +150,8 @@ public final class HugeGraphStep<S, E extends Element>
             query = new Query(type);
         } else {
             ConditionQuery q = new ConditionQuery(type);
-            query = TraversalUtil.fillConditionQuery(this.hasContainers,
-                                                     q, graph);
+            query = TraversalUtil.fillConditionQuery(q, this.hasContainers,
+                                                     graph);
         }
 
         query = this.injectQueryInfo(query);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/HugeVertexStep.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/HugeVertexStep.java
@@ -123,7 +123,7 @@ public final class HugeVertexStep<E extends Element>
                                vertex, direction, edgeLabels);
         // Query by sort-keys
         if (withEdgeCond && edgeLabels.length > 0) {
-            TraversalUtil.fillConditionQuery(conditions, query, graph);
+            TraversalUtil.fillConditionQuery(query, conditions, graph);
             if (!GraphTransaction.matchPartialEdgeSortKeys(query, graph)) {
                 // Can't query by sysprop and by index (HugeGraph-749)
                 query.resetUserpropConditions();

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/EdgeCoreTest.java
@@ -3097,7 +3097,8 @@ public class EdgeCoreTest extends BaseCoreTest {
         Assert.assertTrue(adjacent.schemaLabel().undefined());
         Assert.assertEquals("~undefined", adjacent.label());
 
-        params().graphEventHub().notify(Events.CACHE, "clear", null, null).get();
+        params().graphEventHub().notify(Events.CACHE, "clear",
+                                        null, null).get();
         vertices = graph.traversal().V(james.id()).outE().otherV().toList();
         Assert.assertEquals(1, vertices.size());
         adjacent = (HugeVertex) vertices.get(0);
@@ -3142,7 +3143,8 @@ public class EdgeCoreTest extends BaseCoreTest {
 
         Whitebox.setInternalState(params().graphTransaction(),
                                   "checkAdjacentVertexExist", true);
-        params().graphEventHub().notify(Events.CACHE, "clear", null).get();
+        params().graphEventHub().notify(Events.CACHE, "clear",
+                                        null, null).get();
         try {
             Assert.assertEquals(0, graph.traversal().V(java).toList().size());
 
@@ -3255,7 +3257,8 @@ public class EdgeCoreTest extends BaseCoreTest {
                                   "lazyLoadAdjacentVertex", false);
         Whitebox.setInternalState(params().graphTransaction(),
                                   "checkAdjacentVertexExist", true);
-        params().graphEventHub().notify(Events.CACHE, "clear", null).get();
+        params().graphEventHub().notify(Events.CACHE, "clear",
+                                        null, null).get();
         try {
             Assert.assertEquals(0, graph.traversal().V(java).toList().size());
 
@@ -5323,8 +5326,8 @@ public class EdgeCoreTest extends BaseCoreTest {
             Assert.assertThrows(LimitExceedException.class, () -> {
                 graph.tx().commit();
             }, e -> {
-                Assert.assertTrue(e.getMessage().contains(
-                                  "Edges size has reached tx capacity"));
+                Assert.assertContains("Edges size has reached tx capacity",
+                                      e.getMessage());
                 graph.tx().rollback();
             });
         } finally {
@@ -5939,8 +5942,8 @@ public class EdgeCoreTest extends BaseCoreTest {
             schema.indexLabel("attackByTimes")
                   .onE("attack").by("times").range().ifNotExist().create();
         }, e -> {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(
-                              "The aggregate type SUM is not indexable"));
+            Assert.assertContains("The aggregate type SUM is not indexable",
+                                  e.getMessage());
         });
         schema.indexLabel("attackByFirstTime")
               .onE("attack").by("firstTime").range().ifNotExist().create();

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/IndexLabelCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/IndexLabelCoreTest.java
@@ -339,16 +339,16 @@ public class IndexLabelCoreTest extends SchemaCoreTest {
             schema.indexLabel("authorByName").onV("author")
                   .by("name").range().create();
         }, e -> {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(
-                              "Range index can only build on numeric"));
+            Assert.assertContains("Range index can only build on numeric",
+                                  e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
             schema.indexLabel("authoredByAgeAndWeight").onE("authored")
                   .by("age", "weight").range().create();
         }, e -> {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(
-                              "Range index can only build on one field"));
+            Assert.assertContains("Range index can only build on one field",
+                                  e.getMessage());
         });
 
         // Invalid search-index
@@ -364,8 +364,8 @@ public class IndexLabelCoreTest extends SchemaCoreTest {
             schema.indexLabel("authorByNameAndAge").onV("author")
                   .by("name", "age").search().create();
         }, e -> {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(
-                              "Search index can only build on one field"));
+            Assert.assertContains("Search index can only build on one field",
+                                  e.getMessage());
         });
     }
 
@@ -384,8 +384,8 @@ public class IndexLabelCoreTest extends SchemaCoreTest {
                   .onV("author").by("sumProp").secondary()
                   .ifNotExist().create();
         }, e -> {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(
-                              "The aggregate type SUM is not indexable"));
+            Assert.assertContains("The aggregate type SUM is not indexable",
+                                  e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
@@ -393,8 +393,8 @@ public class IndexLabelCoreTest extends SchemaCoreTest {
                   .onV("author").by("sumProp").range()
                   .ifNotExist().create();
         }, e -> {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(
-                              "The aggregate type SUM is not indexable"));
+            Assert.assertContains("The aggregate type SUM is not indexable",
+                                  e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
@@ -402,8 +402,8 @@ public class IndexLabelCoreTest extends SchemaCoreTest {
                   .onV("author").by("sumProp").shard()
                   .ifNotExist().create();
         }, e -> {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(
-                              "The aggregate type SUM is not indexable"));
+            Assert.assertContains("The aggregate type SUM is not indexable",
+                                  e.getMessage());
         });
     }
 

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/MultiGraphsTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/MultiGraphsTest.java
@@ -236,9 +236,9 @@ public class MultiGraphsTest {
         HugeGraph g3 = graphs.get(2);
 
         g1.initBackend();
-        Assert.assertTrue(g1.backendStoreInitialized());
-        Assert.assertTrue(g2.backendStoreInitialized());
-        Assert.assertTrue(g3.backendStoreInitialized());
+        Assert.assertTrue(g1.backendStoreSystemInfo().exists());
+        Assert.assertTrue(g2.backendStoreSystemInfo().exists());
+        Assert.assertTrue(g3.backendStoreSystemInfo().exists());
 
         g2.initBackend(); // no error
         g3.initBackend();

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
@@ -2830,8 +2830,8 @@ public class VertexCoreTest extends BaseCoreTest {
             graph.traversal().V().hasLabel("person")
                  .has("age", (Object) null).toList();
         }, e -> {
-            String error = "Invalid data type of query value";
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(error));
+            Assert.assertContains("Invalid data type of query value",
+                                  e.getMessage());
         });
     }
 
@@ -3477,8 +3477,8 @@ public class VertexCoreTest extends BaseCoreTest {
                                  .has("lived", "Bay Area")
                                  .toList();
         }, e -> {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(
-                              "may not match secondary condition"));
+            Assert.assertContains("may not match secondary condition",
+                                  e.getMessage());
         });
     }
 
@@ -5502,8 +5502,8 @@ public class VertexCoreTest extends BaseCoreTest {
             schema.indexLabel("studentByTestNum")
                   .onV("student").by("testNum").range().ifNotExist().create();
         }, e -> {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(
-                              "The aggregate type SUM is not indexable"));
+            Assert.assertContains("The aggregate type SUM is not indexable",
+                                  e.getMessage());
         });
         schema.indexLabel("studentByNo")
               .onV("student").by("no").secondary().ifNotExist().create();
@@ -5742,8 +5742,8 @@ public class VertexCoreTest extends BaseCoreTest {
             schema.indexLabel("studentByTestNum")
                   .onV("student").by("testNum").range().ifNotExist().create();
         }, e -> {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains(
-                              "The aggregate type SUM is not indexable"));
+            Assert.assertContains("The aggregate type SUM is not indexable",
+                                  e.getMessage());
         });
         schema.indexLabel("studentByNo")
               .onV("student").by("no").secondary().ifNotExist().create();

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/FakeObjects.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/FakeObjects.java
@@ -49,14 +49,15 @@ public final class FakeObjects {
 
     private final HugeGraph graph;
 
-    public FakeObjects() {
-        this.graph = Mockito.mock(HugeGraph.class);
-        Mockito.doReturn(newConfig()).when(this.graph).configuration();
-    }
-
     public FakeObjects(String name) {
         this();
         Mockito.doReturn(name).when(this.graph).name();
+    }
+
+    public FakeObjects() {
+        this.graph = Mockito.mock(HugeGraph.class);
+        Mockito.doReturn(newConfig()).when(this.graph).configuration();
+        Mockito.doReturn(true).when(this.graph).sameAs(this.graph);
     }
 
     public static HugeConfig newConfig() {

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedGraphTransactionTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedGraphTransactionTest.java
@@ -86,8 +86,8 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
         Assert.assertEquals(2L,
                             Whitebox.invoke(cache, "verticesCache", "size"));
 
-        this.params.graphEventHub().notify(Events.CACHE, "clear", null, null)
-                   .get();
+        this.params.graphEventHub().notify(Events.CACHE, "clear",
+                                           null, null).get();
 
         Assert.assertEquals(0L,
                             Whitebox.invoke(cache, "verticesCache", "size"));

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedSchemaTransactionTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedSchemaTransactionTest.java
@@ -83,8 +83,8 @@ public class CachedSchemaTransactionTest extends BaseUnitTest {
         Assert.assertEquals(IdGenerator.of(2),
                             cache.getPropertyKey("fake-pk-2").id());
 
-        this.params.schemaEventHub().notify(Events.CACHE, "clear", null, null)
-                   .get();
+        this.params.schemaEventHub().notify(Events.CACHE, "clear",
+                                            null, null).get();
 
         Assert.assertEquals(0L, Whitebox.invoke(cache, "idCache", "size"));
         Assert.assertEquals(0L, Whitebox.invoke(cache, "nameCache", "size"));
@@ -155,13 +155,15 @@ public class CachedSchemaTransactionTest extends BaseUnitTest {
         cache.addPropertyKey(objects.newPropertyKey(IdGenerator.of(1),
                                                     "fake-pk-1"));
 
-        this.params.schemaEventHub().notify(Events.CACHE, "clear", null).get();
+        this.params.schemaEventHub().notify(Events.CACHE, "clear",
+                                            null, null).get();
         Assert.assertEquals("fake-pk-1",
                             cache.getPropertyKey(IdGenerator.of(1)).name());
         Assert.assertEquals(IdGenerator.of(1),
                             cache.getPropertyKey("fake-pk-1").id());
 
-        this.params.schemaEventHub().notify(Events.CACHE, "clear", null).get();
+        this.params.schemaEventHub().notify(Events.CACHE, "clear",
+                                            null, null).get();
         Assert.assertEquals(IdGenerator.of(1),
                             cache.getPropertyKey("fake-pk-1").id());
         Assert.assertEquals("fake-pk-1",

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/BackendStoreSystemInfoTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/BackendStoreSystemInfoTest.java
@@ -41,7 +41,7 @@ public class BackendStoreSystemInfoTest {
                .thenThrow(new IllegalStateException("Should not exist schema " +
                           "with same name '~backend_info'"));
         Mockito.when(stx.graph()).thenReturn(graph);
-        Mockito.when(graph.backendStoreInitialized()).thenReturn(true);
+        Mockito.when(stx.storeInitialized()).thenReturn(true);
 
         BackendStoreSystemInfo info = new BackendStoreSystemInfo(stx);
 

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/serializer/SerializerFactoryTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/serializer/SerializerFactoryTest.java
@@ -47,8 +47,7 @@ public class SerializerFactoryTest extends BaseUnitTest {
         Assert.assertThrows(BackendException.class, () -> {
             SerializerFactory.serializer("invalid");
         }, e -> {
-            Assert.assertTrue(e.getMessage().contains(
-                              "Not exists serializer:"));
+            Assert.assertContains("Not exists serializer:", e.getMessage());
         });
     }
 
@@ -62,22 +61,22 @@ public class SerializerFactoryTest extends BaseUnitTest {
             // exist
             SerializerFactory.register("fake", FakeSerializer.class.getName());
         }, e -> {
-            Assert.assertTrue(e.getMessage().contains("Exists serializer:"));
+            Assert.assertContains("Exists serializer:", e.getMessage());
         });
 
         Assert.assertThrows(BackendException.class, () -> {
             // invalid class
             SerializerFactory.register("fake", "com.baidu.hugegraph.Invalid");
         }, e -> {
-            Assert.assertTrue(e.getMessage().contains("Invalid class:"));
+            Assert.assertContains("Invalid class:", e.getMessage());
         });
 
         Assert.assertThrows(BackendException.class, () -> {
             // subclass
             SerializerFactory.register("fake", "com.baidu.hugegraph.HugeGraph");
         }, e -> {
-            Assert.assertTrue(e.getMessage().contains(
-                              "Class is not a subclass of class"));
+            Assert.assertContains("Class is not a subclass of class",
+                                  e.getMessage());
         });
     }
 


### PR DESCRIPTION
* fix delete/read without READ permission throw 'no such id' 
  this patch define delete/update requires read permission, an ForbiddenException
  is thrown when there is no read permission instead 'No such vertex with id: xx'.
* fix rest api depend on gremlin permission, updated to not depend on gremlin.
* fix expired time is inaccurate due to call now() before tx open()
* refactor edgesOfVertex() to unified entrance with EdgeStep

Change-Id: I0d8cfd3d4b7d8ccaf10721249f8d9f86b53b442e
fix: hugegraph-test-811, hugegraph-test-837, hugegraph-test-846