### PR TITLE
fix: shell parameters are not counted correctly

### DIFF
--- a/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
+++ b/hugegraph-dist/src/assembly/static/bin/start-hugegraph.sh
@@ -57,10 +57,10 @@ check_port "$REST_SERVER_URL"
 echo "Starting HugeGraphServer..."
 if [ -n "$VERBOSE" ]; then
     "$BIN"/hugegraph-server.sh "$TOP"/conf/gremlin-server.yaml \
-    "$TOP"/conf/rest-server.properties "$OPEN_SECURITY_CHECK" $USER_OPTION $GC_OPTION &
+    "$TOP"/conf/rest-server.properties "$OPEN_SECURITY_CHECK" "$USER_OPTION" "$GC_OPTION" &
 else
     "$BIN"/hugegraph-server.sh "$TOP"/conf/gremlin-server.yaml \
-    "$TOP"/conf/rest-server.properties "$OPEN_SECURITY_CHECK" $USER_OPTION $GC_OPTION >/dev/null 2>&1 &
+    "$TOP"/conf/rest-server.properties "$OPEN_SECURITY_CHECK" "$USER_OPTION" "$GC_OPTION" >/dev/null 2>&1 &
 fi
 
 PID="$!"


### PR DESCRIPTION
Fix #1172  ,due to the lack of "", the empty param is not considered a legal parameter

**PS:** After the modification, it seems there are at least **5 params**. Should also adjust the logic in `hugegraph-server.sh`? Keep it unchanged now, maybe adjust them on `master/0.11` branch is better.