### PR TITLE
implement RamTable

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeGraphParams.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/HugeGraphParams.java
@@ -23,6 +23,7 @@ import com.baidu.hugegraph.analyzer.Analyzer;
 import com.baidu.hugegraph.backend.serializer.AbstractSerializer;
 import com.baidu.hugegraph.backend.store.BackendFeatures;
 import com.baidu.hugegraph.backend.store.BackendStore;
+import com.baidu.hugegraph.backend.store.ram.RamTable;
 import com.baidu.hugegraph.backend.tx.GraphTransaction;
 import com.baidu.hugegraph.backend.tx.SchemaTransaction;
 import com.baidu.hugegraph.config.HugeConfig;
@@ -68,4 +69,5 @@ public interface HugeGraphParams {
     public Analyzer analyzer();
     public RateLimiter writeRateLimiter();
     public RateLimiter readRateLimiter();
+    public RamTable ramtable();
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
@@ -416,9 +416,13 @@ public class StandardHugeGraph implements HugeGraph {
     }
 
     protected void reloadRamtable() {
+        this.reloadRamtable(false);
+    }
+
+    protected void reloadRamtable(boolean loadFromFile) {
         // Expect triggered manually, like gremlin job
         if (this.ramtable != null) {
-            this.ramtable.reload();
+            this.ramtable.reload(loadFromFile, this.name);
         } else {
             LOG.warn("The ramtable feature is not enabled for graph {}", this);
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
@@ -144,13 +144,13 @@ public class StandardHugeGraph implements HugeGraph {
         this.readRateLimiter = readLimit > 0 ?
                                RateLimiter.create(readLimit) : null;
 
-        boolean ramtable = config.get(CoreOptions.QUERY_RAMTABLE_ENABLE);
-        if (!ramtable) {
-            this.ramtable = null;
-        } else {
+        boolean ramtableEnable = config.get(CoreOptions.QUERY_RAMTABLE_ENABLE);
+        if (ramtableEnable) {
             long vc = config.get(CoreOptions.QUERY_RAMTABLE_VERTICES_CAPACITY);
             int ec = config.get(CoreOptions.QUERY_RAMTABLE_EDGES_CAPACITY);
             this.ramtable = new RamTable(this, vc, ec);
+        } else {
+            this.ramtable = null;
         }
 
         this.taskManager = TaskManager.instance();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
@@ -34,6 +34,7 @@ import com.baidu.hugegraph.backend.query.Query;
 import com.baidu.hugegraph.backend.query.QueryResults;
 import com.baidu.hugegraph.backend.store.BackendMutation;
 import com.baidu.hugegraph.backend.store.BackendStore;
+import com.baidu.hugegraph.backend.store.ram.RamTable;
 import com.baidu.hugegraph.backend.tx.GraphTransaction;
 import com.baidu.hugegraph.config.CoreOptions;
 import com.baidu.hugegraph.config.HugeConfig;
@@ -226,6 +227,11 @@ public final class CachedGraphTransaction extends GraphTransaction {
 
     @Override
     protected final Iterator<HugeEdge> queryEdgesFromBackend(Query query) {
+        RamTable ramtable = this.params().ramtable();
+        if (ramtable != null && ramtable.matched(query)) {
+            return ramtable.query(query);
+        }
+
         if (query.empty() || query.paging() || query.bigCapacity()) {
             // Query all edges or query edges in paging, don't cache it
             return super.queryEdgesFromBackend(query);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntIntMap.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntIntMap.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.backend.store.ram;
+
+public final class IntIntMap {
+
+    // TODO: use com.carrotsearch.hppc.IntIntHashMap instead
+    private final int[] array;
+
+    public IntIntMap(int capacity) {
+        this.array = new int[capacity];
+    }
+
+    public void put(int key, int value) {
+        this.array[key] = value;
+    }
+
+    public int get(int key) {
+        return this.array[key];
+    }
+}

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntIntMap.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntIntMap.java
@@ -19,7 +19,14 @@
 
 package com.baidu.hugegraph.backend.store.ram;
 
-public final class IntIntMap {
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+import com.baidu.hugegraph.HugeException;
+
+public final class IntIntMap implements RamMap {
 
     // TODO: use com.carrotsearch.hppc.IntIntHashMap instead
     private final int[] array;
@@ -36,5 +43,36 @@ public final class IntIntMap {
     public int get(long key) {
         assert 0 <= key && key < Integer.MAX_VALUE;
         return this.array[(int) key];
+    }
+
+    @Override
+    public void clear() {
+        Arrays.fill(this.array, 0);
+    }
+
+    @Override
+    public long size() {
+        return this.array.length;
+    }
+
+    @Override
+    public void writeTo(DataOutputStream buffer) throws IOException {
+        buffer.writeInt(this.array.length);
+        for (int value : this.array) {
+            buffer.writeInt(value);
+        }
+    }
+
+    @Override
+    public void readFrom(DataInputStream buffer) throws IOException {
+        int size = buffer.readInt();
+        if (size > this.array.length) {
+            throw new HugeException("Invalid size %s, expect < %s",
+                                    size, this.array.length);
+        }
+        for (int i = 0; i < size; i++) {
+            int value = buffer.readInt();
+            this.array[i] = value;
+        }
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntIntMap.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntIntMap.java
@@ -28,11 +28,13 @@ public final class IntIntMap {
         this.array = new int[capacity];
     }
 
-    public void put(int key, int value) {
-        this.array[key] = value;
+    public void put(long key, int value) {
+        assert 0 <= key && key < Integer.MAX_VALUE;
+        this.array[(int) key] = value;
     }
 
-    public int get(int key) {
-        return this.array[key];
+    public int get(long key) {
+        assert 0 <= key && key < Integer.MAX_VALUE;
+        return this.array[(int) key];
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntLongMap.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntLongMap.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.backend.store.ram;
+
+import com.baidu.hugegraph.HugeException;
+
+public final class IntLongMap {
+
+    // TODO: use com.carrotsearch.hppc.IntLongHashMap instead
+    private final long[] array;
+    private int size;
+
+    public IntLongMap(int capacity) {
+        this.array = new long[capacity];
+        this.size = 0;
+    }
+
+    public void put(int key, long value) {
+        if (key >= this.size || key < 0) {
+            throw new HugeException("Invalid key %s", key);
+        }
+        this.array[key] = value;
+    }
+
+    public int add(long value) {
+        if (this.size == Integer.MAX_VALUE) {
+            throw new HugeException("Too many edges %s", this.size);
+        }
+        int index = this.size;
+        this.array[index] = value;
+        this.size++;
+        return index;
+    }
+
+    public long get(int key) {
+        if (key >= this.size || key < 0) {
+            throw new HugeException("Invalid key %s", key);
+        }
+        return this.array[key];
+    }
+
+    public long size() {
+        return this.size;
+    }
+}

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntLongMap.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntLongMap.java
@@ -19,9 +19,14 @@
 
 package com.baidu.hugegraph.backend.store.ram;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
 import com.baidu.hugegraph.HugeException;
 
-public final class IntLongMap {
+public final class IntLongMap implements RamMap {
 
     // TODO: use com.carrotsearch.hppc.IntLongHashMap instead
     private final long[] array;
@@ -56,7 +61,34 @@ public final class IntLongMap {
         return this.array[key];
     }
 
+    @Override
+    public void clear() {
+        Arrays.fill(this.array, 0L);
+    }
+
+    @Override
     public long size() {
         return this.size;
+    }
+
+    @Override
+    public void writeTo(DataOutputStream buffer) throws IOException {
+        buffer.writeInt(this.array.length);
+        for (long value : this.array) {
+            buffer.writeLong(value);
+        }
+    }
+
+    @Override
+    public void readFrom(DataInputStream buffer) throws IOException {
+        int size = buffer.readInt();
+        if (size > this.array.length) {
+            throw new HugeException("Invalid size %s, expect < %s",
+                                    size, this.array.length);
+        }
+        for (int i = 0; i < size; i++) {
+            long value = buffer.readLong();
+            this.array[i] = value;
+        }
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntObjectMap.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/IntObjectMap.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.backend.store.ram;
+
+import java.util.Arrays;
+
+public final class IntObjectMap<V> {
+
+    private final Object[] values;
+
+    public IntObjectMap(int size) {
+        this.values = new Object[size];
+    }
+
+    @SuppressWarnings("unchecked")
+    public V get(int key) {
+        return (V) this.values[key];
+    }
+
+    public void set(int key, V value) {
+        this.values[key] = value;
+    }
+
+    public void clear() {
+        Arrays.fill(this.values, null);
+    }
+}

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamMap.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamMap.java
@@ -22,44 +22,14 @@ package com.baidu.hugegraph.backend.store.ram;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
 
-import com.baidu.hugegraph.exception.NotSupportException;
+public interface RamMap {
 
-public final class IntObjectMap<V> implements RamMap {
+    public void clear();
 
-    private final Object[] array;
+    public long size();
 
-    public IntObjectMap(int size) {
-        this.array = new Object[size];
-    }
+    public void writeTo(DataOutputStream buffer) throws IOException;
 
-    @SuppressWarnings("unchecked")
-    public V get(int key) {
-        return (V) this.array[key];
-    }
-
-    public void set(int key, V value) {
-        this.array[key] = value;
-    }
-
-    @Override
-    public void clear() {
-        Arrays.fill(this.array, null);
-    }
-
-    @Override
-    public long size() {
-        return this.array.length;
-    }
-
-    @Override
-    public void writeTo(DataOutputStream buffer) throws IOException {
-        throw new NotSupportException("IntObjectMap.writeTo");
-    }
-
-    @Override
-    public void readFrom(DataInputStream buffer) throws IOException {
-        throw new NotSupportException("IntObjectMap.readFrom");
-    }
+    public void readFrom(DataInputStream buffer) throws IOException;
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamTable.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamTable.java
@@ -42,7 +42,6 @@ import com.baidu.hugegraph.backend.id.IdGenerator;
 import com.baidu.hugegraph.backend.query.Condition;
 import com.baidu.hugegraph.backend.query.ConditionQuery;
 import com.baidu.hugegraph.backend.query.Query;
-import com.baidu.hugegraph.job.algorithm.Consumers;
 import com.baidu.hugegraph.schema.EdgeLabel;
 import com.baidu.hugegraph.schema.VertexLabel;
 import com.baidu.hugegraph.structure.HugeEdge;
@@ -50,6 +49,7 @@ import com.baidu.hugegraph.structure.HugeVertex;
 import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.type.define.Directions;
 import com.baidu.hugegraph.type.define.HugeKeys;
+import com.baidu.hugegraph.util.Consumers;
 import com.baidu.hugegraph.util.Log;
 
 public final class RamTable {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamTable.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamTable.java
@@ -509,8 +509,13 @@ public final class RamTable {
             } catch (Throwable e) {
                 throw Consumers.wrapException(e);
             } finally {
-                consumers.await();
-                CloseableIterator.closeIterator(vertices);
+                try {
+                    consumers.await();
+                } catch (Throwable e) {
+                    throw Consumers.wrapException(e);
+                } finally {
+                    CloseableIterator.closeIterator(vertices);
+                }
             }
             this.addEdgesByBatch();
             return total;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamTable.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamTable.java
@@ -1,0 +1,501 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.backend.store.ram;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.CloseableIterator;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
+import org.slf4j.Logger;
+
+import com.baidu.hugegraph.HugeException;
+import com.baidu.hugegraph.HugeGraph;
+import com.baidu.hugegraph.backend.id.EdgeId;
+import com.baidu.hugegraph.backend.id.Id;
+import com.baidu.hugegraph.backend.id.IdGenerator;
+import com.baidu.hugegraph.backend.query.Condition;
+import com.baidu.hugegraph.backend.query.ConditionQuery;
+import com.baidu.hugegraph.backend.query.Query;
+import com.baidu.hugegraph.job.algorithm.Consumers;
+import com.baidu.hugegraph.schema.EdgeLabel;
+import com.baidu.hugegraph.schema.VertexLabel;
+import com.baidu.hugegraph.structure.HugeEdge;
+import com.baidu.hugegraph.structure.HugeVertex;
+import com.baidu.hugegraph.type.HugeType;
+import com.baidu.hugegraph.type.define.Directions;
+import com.baidu.hugegraph.type.define.HugeKeys;
+import com.baidu.hugegraph.util.Log;
+
+public final class RamTable {
+
+    private static final Logger LOG = Log.logger(RamTable.class);
+
+    // max vertices count, include non exists vertex, default 2.4 billion
+    private static final long VERTICES_CAPACITY = 2400000000L;
+    // max edges count, include OUT and IN edges, default 2.1 billion
+    private static final int EDGES_CAPACITY = 2100000000;
+
+    private static final int NULL = 0;
+
+    private static final Condition BOTH_COND = Condition.or(
+                         Condition.eq(HugeKeys.DIRECTION, Directions.OUT),
+                         Condition.eq(HugeKeys.DIRECTION, Directions.IN));
+
+    private final HugeGraph graph;
+    private final long verticesCapacity;
+    private final int verticesCapacityHalf;
+    private final int edgesCapacity;
+
+    private IntIntMap verticesLow;
+    private IntIntMap verticesHigh;
+    private IntLongMap edges;
+
+    private volatile boolean loading = false;
+
+    public RamTable(HugeGraph graph) {
+        this(graph, VERTICES_CAPACITY, EDGES_CAPACITY);
+    }
+
+    public RamTable(HugeGraph graph, long maxVertices, int maxEdges) {
+        this.graph = graph;
+        this.verticesCapacity = maxVertices + 2L;
+        this.verticesCapacityHalf = (int) (this.verticesCapacity / 2L);
+        this.edgesCapacity = maxEdges + 1;
+        this.reset();
+    }
+
+    private void reset() {
+        this.verticesLow = null;
+        this.verticesHigh = null;
+        this.edges = null;
+        this.verticesLow = new IntIntMap(this.verticesCapacityHalf);
+        this.verticesHigh = new IntIntMap(this.verticesCapacityHalf);
+        this.edges = new IntLongMap(this.edgesCapacity);
+        // Set the first element as null edge
+        this.edges.add(0L);
+    }
+
+    public void reload() {
+        if (this.loading) {
+            throw new HugeException("There is one loading task, " +
+                                    "please wait for it to complete");
+        }
+
+        this.loading = true;
+        try {
+            this.reset();
+            this.load();
+            LOG.info("Loaded {} edges", this.edgesSize());
+        } catch (Throwable e) {
+            this.reset();
+            throw new HugeException("Failed to load ramtable", e);
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    private void load() throws Exception {
+        Query query = new Query(HugeType.VERTEX);
+        query.capacity(this.verticesCapacityHalf * 2L);
+        query.limit(Query.NO_LIMIT);
+        Iterator<Vertex> vertices = this.graph.vertices(query);
+
+        // switch concurrent loading here
+        boolean concurrent = true;
+        if (concurrent) {
+            try (LoadTraverser traverser = new LoadTraverser()) {
+                traverser.load(vertices);
+            }
+            return;
+        }
+
+        Iterator<Edge> adjEdges;
+        Id lastId = IdGenerator.ZERO;
+        while (vertices.hasNext()) {
+            Id vertex = (Id) vertices.next().id();
+            if (vertex.compareTo(lastId) < 0) {
+                throw new HugeException("The ramtable feature is not " +
+                                        "supported by %s backend",
+                                        this.graph.backend());
+            }
+            if (!vertex.number()) {
+                throw new HugeException("Only number id is supported by " +
+                                        "ramtable, but got %s id '%s'",
+                                        vertex.type().name().toLowerCase(),
+                                        vertex);
+            }
+            lastId = vertex;
+
+            adjEdges = this.graph.adjacentEdges(vertex);
+            if (adjEdges.hasNext()) {
+                HugeEdge edge = (HugeEdge) adjEdges.next();
+                this.addEdge(true, edge);
+            }
+            while (adjEdges.hasNext()) {
+                HugeEdge edge = (HugeEdge) adjEdges.next();
+                this.addEdge(false, edge);
+            }
+        }
+    }
+
+    public void addEdge(boolean newVertex, HugeEdge edge) {
+        this.addEdge(newVertex,
+                     (int) edge.id().ownerVertexId().asLong(),
+                     (int) edge.id().otherVertexId().asLong(),
+                     edge.direction(),
+                     (int) edge.schemaLabel().id().asLong());
+    }
+
+    public void addEdge(boolean newVertex, int owner, int target,
+                        Directions direction, int label) {
+        long value = encode(target, direction, label);
+        this.addEdge(newVertex, owner, value);
+    }
+
+    public void addEdge(boolean newVertex, int owner, long value) {
+        int position = this.edges.add(value);
+        if (newVertex) {
+            assert this.vertexAdjPosition(owner) <= NULL : owner;
+            this.vertexAdjPosition(owner, position);
+        }
+        // maybe there is no edges of the next vertex, set -position first
+        this.vertexAdjPosition(owner + 1, -position);
+    }
+
+    public long edgesSize() {
+        // -1 means the first is NULL edge
+        return this.edges.size() - 1L;
+    }
+
+    public boolean matched(Query query) {
+        if (this.edgesSize() == 0L || this.loading) {
+            return false;
+        }
+        if (!query.resultType().isEdge() ||
+            !(query instanceof ConditionQuery)) {
+            return false;
+        }
+
+        ConditionQuery cq = (ConditionQuery) query;
+
+        int conditionsSize = cq.conditions().size();
+        Id owner = cq.condition(HugeKeys.OWNER_VERTEX);
+        Directions direction = cq.condition(HugeKeys.DIRECTION);
+        Id label = cq.condition(HugeKeys.LABEL);
+
+        if (direction == null && conditionsSize > 1) {
+            for (Condition cond : cq.conditions()) {
+                if (cond.equals(BOTH_COND)) {
+                    direction = Directions.BOTH;
+                }
+            }
+        }
+
+        int matchedConds = 0;
+        if (owner != null) {
+            matchedConds++;
+        } else {
+            return false;
+        }
+        if (direction != null) {
+            matchedConds++;
+        }
+        if (label != null) {
+            matchedConds++;
+        }
+        return matchedConds == cq.conditions().size();
+    }
+
+    public Iterator<HugeEdge> query(Query query) {
+        assert this.matched(query);
+        assert this.edgesSize() > 0;
+
+        ConditionQuery cq = (ConditionQuery) query;
+        Id owner = cq.condition(HugeKeys.OWNER_VERTEX);
+        assert owner != null;
+        Directions dir = cq.condition(HugeKeys.DIRECTION);
+        if (dir == null) {
+            dir = Directions.BOTH;
+        }
+        Id label = cq.condition(HugeKeys.LABEL);
+        if (label == null) {
+            label = IdGenerator.ZERO;
+        }
+        return this.query((int) owner.asLong(), dir, (int) label.asLong());
+    }
+
+    public Iterator<HugeEdge> query(int owner, Directions dir, int label) {
+        if (this.loading) {
+            // don't query when loading
+            return Collections.emptyIterator();
+        }
+
+        int start = this.vertexAdjPosition(owner);
+        if (start <= NULL) {
+            return Collections.emptyIterator();
+        }
+        int end = this.vertexAdjPosition(owner + 1);
+        assert start != NULL;
+        if (end < NULL) {
+            // The next vertex does not exist edges
+            end = 1 - end;
+        }
+        return new EdgeRangeIterator(start, end, dir, label, owner);
+    }
+
+    private void vertexAdjPosition(int vertex, int position) {
+        if (vertex < this.verticesCapacityHalf) {
+            this.verticesLow.put(vertex, position);
+        } else if (vertex < this.verticesCapacity) {
+            vertex -= this.verticesCapacityHalf;
+            this.verticesHigh.put(vertex, position);
+        } else {
+            throw new HugeException("Out of vertices capaticy %s",
+                                    this.verticesCapacity);
+        }
+    }
+
+    private int vertexAdjPosition(int vertex) {
+        if (vertex < this.verticesCapacityHalf) {
+            return this.verticesLow.get(vertex);
+        } else if (vertex < this.verticesCapacity) {
+            vertex -= this.verticesCapacityHalf;
+            return this.verticesHigh.get(vertex);
+        } else {
+            throw new HugeException("Out of vertices capaticy %s",
+                                    this.verticesCapacity);
+        }
+    }
+
+    private static long encode(int target, Directions direction, int label) {
+        // TODO: support property
+        assert (label & 0x0fffffff) == label;
+        long value = target;
+        long dir = direction == Directions.OUT ?
+                   0x00000000L : 0x80000000L;
+        value = (value << 32) | (dir | label);
+        return value;
+    }
+
+    private class EdgeRangeIterator implements Iterator<HugeEdge> {
+
+        private final int end;
+        private final Directions dir;
+        private final int label;
+        private final Id owner;
+        private int current;
+        private HugeEdge currentEdge;
+
+        public EdgeRangeIterator(int start, int end,
+                                 Directions dir, int label, int owner) {
+            assert 0 < start && start < end;
+            this.end = end;
+            this.dir = dir;
+            this.label = label;
+            this.owner = IdGenerator.of(owner);
+
+            this.current = start;
+            this.currentEdge = null;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (this.currentEdge != null) {
+                return true;
+            }
+            while (this.current < this.end) {
+                this.currentEdge = this.fetch();
+                if (this.currentEdge != null) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public HugeEdge next() {
+            if (!this.hasNext()) {
+                throw new NoSuchElementException();
+            }
+            assert this.currentEdge != null;
+            HugeEdge edge = this.currentEdge;
+            this.currentEdge = null;
+            return edge;
+        }
+
+        private HugeEdge fetch() {
+            if (this.current >= this.end) {
+                return null;
+            }
+            long value = RamTable.this.edges.get(this.current++);
+            long target = value >> 32;
+            Directions actualDir = (value & 0x80000000L) == 0L ?
+                                   Directions.OUT : Directions.IN;
+            int label = (int) value & 0x7fffffff;
+
+            if (this.dir != actualDir && this.dir != Directions.BOTH) {
+                return null;
+            }
+            if (this.label != label && this.label != 0) {
+                return null;
+            }
+
+            Id labelId = IdGenerator.of(label);
+            Id targetId = IdGenerator.of(target);
+            EdgeId id = new EdgeId(this.owner, actualDir, labelId,
+                                   "", targetId);
+            HugeGraph graph = RamTable.this.graph;
+            EdgeLabel edgeLabel = graph.edgeLabel(labelId);
+            VertexLabel srcLabel = graph.vertexLabelOrNone(
+                                   edgeLabel.sourceLabel());
+            VertexLabel tgtLabel = graph.vertexLabelOrNone(
+                                   edgeLabel.targetLabel());
+
+            HugeEdge edge = new HugeEdge(graph, id, edgeLabel);
+            if (actualDir == Directions.OUT) {
+                HugeVertex owner = new HugeVertex(graph, this.owner, srcLabel);
+                HugeVertex other = new HugeVertex(graph, targetId, tgtLabel);
+                edge.vertices(true, owner, other);
+            } else {
+                HugeVertex owner = new HugeVertex(graph, this.owner, tgtLabel);
+                HugeVertex other = new HugeVertex(graph, targetId, srcLabel);
+                edge.vertices(false, owner, other);
+            }
+            edge.propNotLoaded();
+            return edge;
+        }
+    }
+
+    private class LoadTraverser implements AutoCloseable {
+
+        private final HugeGraph graph;
+        private final ExecutorService executor;
+        private final List<Id> vertices;
+        private final Map<Id, List<Edge>> edges;
+
+        private static final int ADD_BATCH = Consumers.QUEUE_WORKER_SIZE;
+
+        public LoadTraverser() {
+            this.graph = RamTable.this.graph;
+            this.executor = Consumers.newThreadPool("ramtable-load",
+                                                    Consumers.THREADS);
+            this.vertices = new ArrayList<>(ADD_BATCH);
+            this.edges = new ConcurrentHashMap<>();
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (this.executor != null) {
+                this.executor.shutdown();
+            }
+        }
+
+        protected long load(Iterator<Vertex> vertices) {
+            Consumers<Id> consumers = new Consumers<>(this.executor, vertex -> {
+                Iterator<Edge> adjEdges = this.graph.adjacentEdges(vertex);
+                this.edges.put(vertex, IteratorUtils.list(adjEdges));
+            }, null);
+
+            consumers.start("ramtable-loading");
+
+            long total = 0L;
+            try {
+                while (vertices.hasNext()) {
+                    if (++total % 10000000 == 0) {
+                        LOG.info("Loaded {} vertices", total);
+                    }
+
+                    Id vertex = (Id) vertices.next().id();
+                    this.addVertex(vertex);
+
+                    consumers.provide(vertex);
+                }
+            } catch (Consumers.StopExecution e) {
+                // pass
+            } catch (Throwable e) {
+                throw Consumers.wrapException(e);
+            } finally {
+                consumers.await();
+                CloseableIterator.closeIterator(vertices);
+            }
+            this.addEdgesByBatch();
+            return total;
+        }
+
+        private void addVertex(Id vertex) {
+            Id lastId = IdGenerator.ZERO;
+            if (this.vertices.size() > 0) {
+                lastId = this.vertices.get(this.vertices.size() - 1);
+            }
+            if (vertex.compareTo(lastId) < 0) {
+                throw new HugeException("The ramtable feature is not " +
+                                        "supported by %s backend",
+                                        this.graph.backend());
+            }
+            if (!vertex.number()) {
+                throw new HugeException("Only number id is supported " +
+                                        "by ramtable, but got %s id '%s'",
+                                        vertex.type().name().toLowerCase(),
+                                        vertex);
+            }
+
+            if (this.vertices.size() >= ADD_BATCH) {
+                this.addEdgesByBatch();
+            }
+            this.vertices.add(vertex);
+        }
+
+        private void addEdgesByBatch() {
+            int waitTimes = 0;
+            for (Id vertex : this.vertices) {
+                List<Edge> adjEdges = this.edges.remove(vertex);
+                while (adjEdges == null) {
+                    waitTimes++;
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException ignored) {
+                        // pass
+                    }
+                    adjEdges = this.edges.remove(vertex);
+                }
+                for (int i = 0; i < adjEdges.size(); i++) {
+                    HugeEdge edge = (HugeEdge) adjEdges.get(i);
+                    assert edge.id().ownerVertexId().equals(vertex);
+                    addEdge(i == 0, edge);
+                }
+            }
+
+            if (waitTimes > this.vertices.size()) {
+                LOG.info("Loading wait times is {}", waitTimes);
+            }
+
+            this.vertices.clear();
+        }
+    }
+}

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamTable.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamTable.java
@@ -386,10 +386,14 @@ public final class RamTable {
             if (actualDir == Directions.OUT) {
                 HugeVertex owner = new HugeVertex(graph, this.owner, srcLabel);
                 HugeVertex other = new HugeVertex(graph, targetId, tgtLabel);
+                owner.propNotLoaded();
+                other.propNotLoaded();
                 edge.vertices(true, owner, other);
             } else {
                 HugeVertex owner = new HugeVertex(graph, this.owner, tgtLabel);
                 HugeVertex other = new HugeVertex(graph, targetId, srcLabel);
+                owner.propNotLoaded();
+                other.propNotLoaded();
                 edge.vertices(false, owner, other);
             }
             edge.propNotLoaded();

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/config/CoreOptions.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/config/CoreOptions.java
@@ -309,6 +309,32 @@ public class CoreOptions extends OptionHolder {
                     1000
             );
 
+    public static final ConfigOption<Boolean> QUERY_RAMTABLE_ENABLE =
+            new ConfigOption<>(
+                    "query.ramtable_enable",
+                    "Whether to enable ramtable for query of adjacent edges.",
+                    disallowEmpty(),
+                    false
+            );
+
+    public static final ConfigOption<Long> QUERY_RAMTABLE_VERTICES_CAPACITY =
+            new ConfigOption<>(
+                    "query.ramtable_vertices_capacity",
+                    "The maximum number of vertices in ramtable, " +
+                    "generally the largest vertex id is used as capacity.",
+                    rangeInt(1L, Integer.MAX_VALUE * 2L),
+                    10000000L
+            );
+
+    public static final ConfigOption<Integer> QUERY_RAMTABLE_EDGES_CAPACITY =
+            new ConfigOption<>(
+                    "query.ramtable_edges_capacity",
+                    "The maximum number of edges in ramtable, " +
+                    "include OUT and IN edges.",
+                    rangeInt(1, Integer.MAX_VALUE),
+                    20000000
+            );
+
     public static final ConfigOption<Integer> VERTEX_TX_CAPACITY =
             new ConfigOption<>(
                     "vertex.tx_capacity",

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeEdge.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeEdge.java
@@ -476,11 +476,11 @@ public class HugeEdge extends HugeElement implements Edge, Cloneable {
         return StringFactory.edgeString(this);
     }
 
-    public static final Id getIdValue(Object idValue,
-                                      boolean returnNullIfError) {
+    public static final EdgeId getIdValue(Object idValue,
+                                          boolean returnNullIfError) {
         Id id = HugeElement.getIdValue(idValue);
         if (id == null || id instanceof EdgeId) {
-            return id;
+            return (EdgeId) id;
         }
         return EdgeId.parse(id.asString(), returnNullIfError);
     }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/util/Consumers.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/util/Consumers.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.util;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+
+import com.baidu.hugegraph.HugeException;
+import com.baidu.hugegraph.task.TaskManager.ContextCallable;
+import com.baidu.hugegraph.util.ExecutorUtil;
+import com.baidu.hugegraph.util.Log;
+
+public class Consumers<V> {
+
+    public static final int CPUS = Runtime.getRuntime().availableProcessors();
+    public static final int THREADS = 4 + CPUS / 4;
+    public static final int QUEUE_WORKER_SIZE = 1000;
+
+    private static final Logger LOG = Log.logger(Consumers.class);
+
+    private final ExecutorService executor;
+    private final Consumer<V> consumer;
+    private final Runnable done;
+
+    private final int workers;
+    private final int queueSize;
+    private final CountDownLatch latch;
+    private final BlockingQueue<V> queue;
+
+    private volatile boolean ending = false;
+    private volatile Throwable exception = null;
+
+    public Consumers(ExecutorService executor, Consumer<V> consumer) {
+        this(executor, consumer, null);
+    }
+
+    public Consumers(ExecutorService executor,
+                     Consumer<V> consumer, Runnable done) {
+        this.executor = executor;
+        this.consumer = consumer;
+        this.done = done;
+
+        int workers = THREADS;
+        if (this.executor instanceof ThreadPoolExecutor) {
+            workers = ((ThreadPoolExecutor) this.executor).getCorePoolSize();
+        }
+        this.workers = workers;
+        this.queueSize = QUEUE_WORKER_SIZE * workers;
+        this.latch = new CountDownLatch(workers);
+        this.queue = new ArrayBlockingQueue<>(this.queueSize);
+    }
+
+    public void start(String name) {
+        this.ending = false;
+        this.exception = null;
+        if (this.executor == null) {
+            return;
+        }
+        LOG.info("Starting {} workers[{}] with queue size {}...",
+                 this.workers, name, this.queueSize);
+        for (int i = 0; i < this.workers; i++) {
+            this.executor.submit(new ContextCallable<>(this::runAndDone));
+        }
+    }
+
+    private Void runAndDone() {
+        try {
+            this.run();
+            this.done();
+        } catch (Throwable e) {
+            // Only the first exception of one thread can be stored
+            this.exception = e;
+            if (!(e instanceof StopExecution)) {
+                LOG.error("Error when running task", e);
+            }
+            this.done();
+        } finally {
+            this.latch.countDown();
+        }
+        return null;
+    }
+
+    private void run() {
+        LOG.debug("Start to work...");
+        while (!this.ending) {
+            this.consume();
+        }
+        assert this.ending;
+        while (this.consume());
+
+        LOG.debug("Worker finished");
+    }
+
+    private boolean consume() {
+        V elem;
+        try {
+            elem = this.queue.poll(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            // ignore
+            return true;
+        }
+        if (elem == null) {
+            return false;
+        }
+        // do job
+        this.consumer.accept(elem);
+        return true;
+    }
+
+    private void done() {
+        if (this.done != null) {
+            this.done.run();
+        }
+    }
+
+    public void provide(V v) throws Throwable {
+        if (this.executor == null) {
+            assert this.exception == null;
+            // do job directly if without thread pool
+            this.consumer.accept(v);
+        } else if (this.exception != null) {
+            throw this.exception;
+        } else {
+            try {
+                this.queue.put(v);
+            } catch (InterruptedException e) {
+                LOG.warn("Interrupted", e);;
+            }
+        }
+    }
+
+    public void await() {
+        this.ending = true;
+        if (this.executor == null) {
+            // call done() directly if without thread pool
+            this.done();
+        } else {
+            try {
+                this.latch.await();
+            } catch (InterruptedException e) {
+                LOG.warn("Interrupted", e);
+            }
+        }
+    }
+
+    public static ExecutorService newThreadPool(String prefix, int workers) {
+        if (workers == 0) {
+            return null;
+        } else {
+            if (workers < 0) {
+                assert workers == -1;
+                workers = Consumers.THREADS;
+            } else if (workers > Consumers.CPUS * 2) {
+                workers = Consumers.CPUS * 2;
+            }
+            String name = prefix + "-worker-%d";
+            return ExecutorUtil.newFixedThreadPool(workers, name);
+        }
+    }
+
+    public static RuntimeException wrapException(Throwable e) {
+        if (e instanceof RuntimeException) {
+            throw (RuntimeException) e;
+        }
+        throw new HugeException("Error when running task: %s",
+                                HugeException.rootCause(e).getMessage(), e);
+    }
+
+    public static class StopExecution extends HugeException {
+
+        private static final long serialVersionUID = -371829356182454517L;
+
+        public StopExecution(String message) {
+            super(message);
+        }
+
+        public StopExecution(String message, Object... args) {
+            super(message, args);
+        }
+    }
+}

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/CoreTestSuite.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/CoreTestSuite.java
@@ -48,7 +48,8 @@ import com.baidu.hugegraph.util.Log;
     RestoreCoreTest.class,
     TaskCoreTest.class,
     UsersTest.class,
-    MultiGraphsTest.class
+    MultiGraphsTest.class,
+    RamTableTest.class
 })
 public class CoreTestSuite {
 

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/RamTableTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/RamTableTest.java
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.core;
+
+import java.util.Iterator;
+
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.baidu.hugegraph.HugeGraph;
+import com.baidu.hugegraph.backend.id.Id;
+import com.baidu.hugegraph.backend.id.IdGenerator;
+import com.baidu.hugegraph.backend.query.Query;
+import com.baidu.hugegraph.backend.store.ram.RamTable;
+import com.baidu.hugegraph.backend.tx.GraphTransaction;
+import com.baidu.hugegraph.structure.HugeEdge;
+import com.baidu.hugegraph.testutil.Assert;
+import com.baidu.hugegraph.testutil.Whitebox;
+import com.baidu.hugegraph.type.define.Directions;
+
+public class RamTableTest extends BaseCoreTest {
+
+    // max value is 4 billion
+    private static final int VERTEX_SIZE = 10000000;
+    private static final int EDGE_SIZE = 20000000;
+
+    @Before
+    public void initSchema() {
+        HugeGraph graph = this.graph();
+
+        graph.schema().vertexLabel("vl1").useCustomizeNumberId().create();
+        graph.schema().vertexLabel("vl2").useCustomizeNumberId().create();
+        graph.schema().edgeLabel("el1")
+                      .sourceLabel("vl1")
+                      .targetLabel("vl1")
+                      .create();
+        graph.schema().edgeLabel("el2")
+                      .sourceLabel("vl2")
+                      .targetLabel("vl2")
+                      .create();
+    }
+
+    @Test
+    public void testAddAndQuery() throws Exception {
+        HugeGraph graph = this.graph();
+        int el1 = (int) graph.edgeLabel("el1").id().asLong();
+        int el2 = (int) graph.edgeLabel("el2").id().asLong();
+
+        RamTable table = new RamTable(graph, VERTEX_SIZE, EDGE_SIZE);
+        long oldSize = table.edgesSize();
+        // insert edges
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            table.addEdge(true, i, i, Directions.OUT, el1);
+            Assert.assertEquals(oldSize + 2 * i + 1, table.edgesSize());
+
+            table.addEdge(false, i, i + 1, Directions.IN, el2);
+            Assert.assertEquals(oldSize + 2 * i + 2, table.edgesSize());
+        }
+
+        // query by BOTH
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.BOTH, 0);
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge1.direction());
+            Assert.assertEquals("el1", edge1.label());
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge2 = edges.next();
+            Assert.assertEquals(i, edge2.id().ownerVertexId().asLong());
+            Assert.assertEquals(i + 1L, edge2.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.IN, edge2.direction());
+            Assert.assertEquals("el2", edge2.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        // query by OUT
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.OUT, el1);
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge1.direction());
+            Assert.assertEquals("el1", edge1.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        // query by IN
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.IN, el2);
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i + 1L, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.IN, edge1.direction());
+            Assert.assertEquals("el2", edge1.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+
+        // query by BOTH & label 1
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.BOTH, el1);
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge1.direction());
+            Assert.assertEquals("el1", edge1.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        // query by BOTH & label 2
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.BOTH, el2);
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i + 1L, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.IN, edge1.direction());
+            Assert.assertEquals("el2", edge1.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+
+        // query non-exist vertex
+        Iterator<HugeEdge> edges = table.query(VERTEX_SIZE, Directions.BOTH, 0);
+        Assert.assertFalse(edges.hasNext());
+    }
+
+    @Test
+    public void testAddAndQueryWithoutAdjEdges() throws Exception {
+        HugeGraph graph = this.graph();
+        int el1 = (int) graph.edgeLabel("el1").id().asLong();
+        int el2 = (int) graph.edgeLabel("el2").id().asLong();
+
+        RamTable table = new RamTable(graph, VERTEX_SIZE, EDGE_SIZE);
+        long oldSize = table.edgesSize();
+        // insert edges
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            if (i % 3 != 0) {
+                // don't insert edges for 2/3 vertices
+                continue;
+            }
+
+            table.addEdge(true, i, i, Directions.OUT, el1);
+            Assert.assertEquals(oldSize + i + 1, table.edgesSize());
+
+            table.addEdge(false, i, i, Directions.OUT, el2);
+            Assert.assertEquals(oldSize + i + 2, table.edgesSize());
+
+            table.addEdge(false, i, i + 1, Directions.IN, el2);
+            Assert.assertEquals(oldSize + i + 3, table.edgesSize());
+        }
+
+        // query by BOTH
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.BOTH, 0);
+
+            if (i % 3 != 0) {
+                Assert.assertFalse(edges.hasNext());
+                continue;
+            }
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge1.direction());
+            Assert.assertEquals("el1", edge1.label());
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge2 = edges.next();
+            Assert.assertEquals(i, edge2.id().ownerVertexId().asLong());
+            Assert.assertEquals(i, edge2.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge2.direction());
+            Assert.assertEquals("el2", edge2.label());
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge3 = edges.next();
+            Assert.assertEquals(i, edge3.id().ownerVertexId().asLong());
+            Assert.assertEquals(i + 1L, edge3.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.IN, edge3.direction());
+            Assert.assertEquals("el2", edge3.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+    }
+
+    @Test
+    public void testReloadAndQuery() throws Exception {
+        HugeGraph graph = this.graph();
+
+        // insert vertices and edges
+        for (int i = 0; i < 100; i++) {
+            Vertex v1 = graph.addVertex(T.label, "vl1", T.id, i);
+            Vertex v2 = graph.addVertex(T.label, "vl1", T.id, i + 100);
+            v1.addEdge("el1", v2);
+        }
+        graph.tx().commit();
+
+        for (int i = 1000; i < 1100; i++) {
+            Vertex v1 = graph.addVertex(T.label, "vl2", T.id, i);
+            Vertex v2 = graph.addVertex(T.label, "vl2", T.id, i + 100);
+            v1.addEdge("el2", v2);
+        }
+        graph.tx().commit();
+
+        // reload ramtable
+        Whitebox.invoke(graph.getClass(), "reloadRamtable", graph);
+
+        // query edges
+        for (int i = 0; i < 100; i++) {
+            Iterator<Edge> edges = this.edgesOfVertex(IdGenerator.of(i),
+                                                      Directions.OUT, null);
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 100, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge.direction());
+            Assert.assertEquals("el1", edge.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        for (int i = 1000; i < 1100; i++) {
+            Iterator<Edge> edges = this.edgesOfVertex(IdGenerator.of(i),
+                                                      Directions.OUT, null);
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 100, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge.direction());
+            Assert.assertEquals("el2", edge.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+    }
+
+    @Test
+    public void testReloadAndQueryWithMultiEdges() throws Exception {
+        HugeGraph graph = this.graph();
+
+        // insert vertices and edges
+        for (int i = 0; i < 100; i++) {
+            Vertex v1 = graph.addVertex(T.label, "vl1", T.id, i);
+            Vertex v2 = graph.addVertex(T.label, "vl1", T.id, i + 100);
+            Vertex v3 = graph.addVertex(T.label, "vl1", T.id, i + 200);
+            v1.addEdge("el1", v2);
+            v1.addEdge("el1", v3);
+            v3.addEdge("el1", v1);
+        }
+        graph.tx().commit();
+
+        for (int i = 1000; i < 1100; i++) {
+            Vertex v1 = graph.addVertex(T.label, "vl2", T.id, i);
+            Vertex v2 = graph.addVertex(T.label, "vl2", T.id, i + 100);
+            Vertex v3 = graph.addVertex(T.label, "vl2", T.id, i + 200);
+            v1.addEdge("el2", v2);
+            v1.addEdge("el2", v3);
+            v2.addEdge("el2", v3);
+        }
+        graph.tx().commit();
+
+        // reload ramtable
+        Whitebox.invoke(graph.getClass(), "reloadRamtable", graph);
+
+        // query edges by OUT
+        for (int i = 0; i < 100; i++) {
+            Iterator<Edge> edges = this.edgesOfVertex(IdGenerator.of(i),
+                                                      Directions.OUT, null);
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 100, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge.direction());
+            Assert.assertEquals("el1", edge.label());
+
+            Assert.assertTrue(edges.hasNext());
+            edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 200, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge.direction());
+            Assert.assertEquals("el1", edge.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        // query edges by BOTH
+        for (int i = 0; i < 100; i++) {
+            Iterator<Edge> edges = this.edgesOfVertex(IdGenerator.of(i),
+                                                      Directions.BOTH, null);
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 100, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge.direction());
+            Assert.assertEquals("el1", edge.label());
+
+            Assert.assertTrue(edges.hasNext());
+            edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 200, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge.direction());
+            Assert.assertEquals("el1", edge.label());
+
+            Assert.assertTrue(edges.hasNext());
+            edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 200, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.IN, edge.direction());
+            Assert.assertEquals("el1", edge.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        // query edges by IN
+        for (int i = 0; i < 100; i++) {
+            Iterator<Edge> edges = this.edgesOfVertex(IdGenerator.of(i),
+                                                      Directions.IN, null);
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 200, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.IN, edge.direction());
+            Assert.assertEquals("el1", edge.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+
+        // query edges by OUT
+        for (int i = 1000; i < 1100; i++) {
+            Iterator<Edge> edges = this.edgesOfVertex(IdGenerator.of(i),
+                                                      Directions.OUT, null);
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 100, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge.direction());
+            Assert.assertEquals("el2", edge.label());
+
+            Assert.assertTrue(edges.hasNext());
+            edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 200, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge.direction());
+            Assert.assertEquals("el2", edge.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        // query edges by BOTH
+        for (int i = 1000; i < 1100; i++) {
+            Iterator<Edge> edges = this.edgesOfVertex(IdGenerator.of(i),
+                                                      Directions.BOTH, null);
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 100, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge.direction());
+            Assert.assertEquals("el2", edge.label());
+
+            Assert.assertTrue(edges.hasNext());
+            edge = (HugeEdge) edges.next();
+            Assert.assertEquals(i + 200, edge.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge.direction());
+            Assert.assertEquals("el2", edge.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        // query edges by IN
+        for (int i = 1000; i < 1100; i++) {
+            Iterator<Edge> edges = this.edgesOfVertex(IdGenerator.of(i),
+                                                      Directions.IN, null);
+            Assert.assertFalse(edges.hasNext());
+        }
+    }
+
+    private Iterator<Edge> edgesOfVertex(Id source, Directions dir, Id label) {
+        Id[] labels = {};
+        if (label != null) {
+            labels = new Id[]{label};
+        }
+
+        Query query = GraphTransaction.constructEdgesQuery(source, dir, labels);
+        return this.graph().edges(query);
+    }
+}

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/UnitTestSuite.java
@@ -26,6 +26,7 @@ import com.baidu.hugegraph.unit.cache.CacheManagerTest;
 import com.baidu.hugegraph.unit.cache.CacheTest;
 import com.baidu.hugegraph.unit.cache.CachedGraphTransactionTest;
 import com.baidu.hugegraph.unit.cache.CachedSchemaTransactionTest;
+import com.baidu.hugegraph.unit.cache.RamTableTest;
 import com.baidu.hugegraph.unit.cassandra.CassandraTest;
 import com.baidu.hugegraph.unit.core.AnalyzerTest;
 import com.baidu.hugegraph.unit.core.BackendMutationTest;
@@ -49,12 +50,12 @@ import com.baidu.hugegraph.unit.mysql.MysqlUtilTest;
 import com.baidu.hugegraph.unit.mysql.WhereBuilderTest;
 import com.baidu.hugegraph.unit.rocksdb.RocksDBCountersTest;
 import com.baidu.hugegraph.unit.rocksdb.RocksDBSessionsTest;
-import com.baidu.hugegraph.unit.serializer.StoreSerializerTest;
 import com.baidu.hugegraph.unit.serializer.BinaryBackendEntryTest;
 import com.baidu.hugegraph.unit.serializer.BinaryScatterSerializerTest;
 import com.baidu.hugegraph.unit.serializer.BinarySerializerTest;
 import com.baidu.hugegraph.unit.serializer.BytesBufferTest;
 import com.baidu.hugegraph.unit.serializer.SerializerFactoryTest;
+import com.baidu.hugegraph.unit.serializer.StoreSerializerTest;
 import com.baidu.hugegraph.unit.serializer.TableBackendEntryTest;
 import com.baidu.hugegraph.unit.serializer.TextBackendEntryTest;
 import com.baidu.hugegraph.unit.util.JsonUtilTest;
@@ -70,6 +71,7 @@ import com.baidu.hugegraph.unit.util.VersionTest;
     CachedSchemaTransactionTest.class,
     CachedGraphTransactionTest.class,
     CacheManagerTest.class,
+    RamTableTest.class,
 
     /* types */
     DataTypeTest.class,

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedSchemaTransactionTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedSchemaTransactionTest.java
@@ -174,28 +174,33 @@ public class CachedSchemaTransactionTest extends BaseUnitTest {
     public void testResetCachedAllIfReachedCapacity() throws Exception {
         CachedSchemaTransaction cache = this.cache();
 
+        Object old = Whitebox.getInternalState(cache, "idCache.capacity");
         Whitebox.setInternalState(cache, "idCache.capacity", 2);
-        Assert.assertEquals(0L, Whitebox.invoke(cache, "idCache", "size"));
+        try {
+            Assert.assertEquals(0L, Whitebox.invoke(cache, "idCache", "size"));
 
-        FakeObjects objects = new FakeObjects("unit-test");
-        cache.addPropertyKey(objects.newPropertyKey(IdGenerator.of(1),
-                                                    "fake-pk-1"));
-        Assert.assertEquals(1L, Whitebox.invoke(cache, "idCache", "size"));
-        Assert.assertEquals(1, cache.getPropertyKeys().size());
-        Whitebox.invoke(CachedSchemaTransaction.class, "cachedTypes", cache);
-        Assert.assertEquals(ImmutableMap.of(HugeType.PROPERTY_KEY, true),
-                            Whitebox.invoke(CachedSchemaTransaction.class,
-                                            "cachedTypes", cache));
+            FakeObjects objects = new FakeObjects("unit-test");
+            cache.addPropertyKey(objects.newPropertyKey(IdGenerator.of(1),
+                                                        "fake-pk-1"));
+            Assert.assertEquals(1L, Whitebox.invoke(cache, "idCache", "size"));
+            Assert.assertEquals(1, cache.getPropertyKeys().size());
+            Whitebox.invoke(CachedSchemaTransaction.class, "cachedTypes", cache);
+            Assert.assertEquals(ImmutableMap.of(HugeType.PROPERTY_KEY, true),
+                                Whitebox.invoke(CachedSchemaTransaction.class,
+                                                "cachedTypes", cache));
 
-        cache.addPropertyKey(objects.newPropertyKey(IdGenerator.of(3),
-                                                    "fake-pk-2"));
-        cache.addPropertyKey(objects.newPropertyKey(IdGenerator.of(2),
-                                                    "fake-pk-3"));
+            cache.addPropertyKey(objects.newPropertyKey(IdGenerator.of(3),
+                                                        "fake-pk-2"));
+            cache.addPropertyKey(objects.newPropertyKey(IdGenerator.of(2),
+                                                        "fake-pk-3"));
 
-        Assert.assertEquals(2L, Whitebox.invoke(cache, "idCache", "size"));
-        Assert.assertEquals(3, cache.getPropertyKeys().size());
-        Assert.assertEquals(ImmutableMap.of(),
-                            Whitebox.invoke(CachedSchemaTransaction.class,
-                                            "cachedTypes", cache));
+            Assert.assertEquals(2L, Whitebox.invoke(cache, "idCache", "size"));
+            Assert.assertEquals(3, cache.getPropertyKeys().size());
+            Assert.assertEquals(ImmutableMap.of(),
+                                Whitebox.invoke(CachedSchemaTransaction.class,
+                                                "cachedTypes", cache));
+        } finally {
+            Whitebox.setInternalState(cache, "idCache.capacity", old);
+        }
     }
 }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/RamTableTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/RamTableTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.unit.cache;
+
+import java.util.Iterator;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.baidu.hugegraph.HugeFactory;
+import com.baidu.hugegraph.HugeGraph;
+import com.baidu.hugegraph.backend.store.ram.RamTable;
+import com.baidu.hugegraph.structure.HugeEdge;
+import com.baidu.hugegraph.testutil.Assert;
+import com.baidu.hugegraph.type.define.Directions;
+import com.baidu.hugegraph.unit.FakeObjects;
+
+public class RamTableTest {
+
+    // max value is 4 billion
+    private static final int VERTEX_SIZE = 10000000;
+    private static final int EDGE_SIZE = 20000000;
+
+    private HugeGraph graph;
+
+    @Before
+    public void setup() {
+        this.graph = HugeFactory.open(FakeObjects.newConfig());
+        this.graph.schema().vertexLabel("vl1").create();
+        this.graph.schema().vertexLabel("vl2").create();
+        this.graph.schema().edgeLabel("el1")
+                           .sourceLabel("vl1")
+                           .targetLabel("vl1")
+                           .create();
+        this.graph.schema().edgeLabel("el2")
+                           .sourceLabel("vl2")
+                           .targetLabel("vl2")
+                           .create();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        this.graph.close();
+    }
+
+    private HugeGraph graph() {
+        return this.graph;
+    }
+
+    @Test
+    public void testAddAndQuery() throws Exception {
+        HugeGraph graph = this.graph();
+        int el1 = (int) graph.edgeLabel("el1").id().asLong();
+        int el2 = (int) graph.edgeLabel("el2").id().asLong();
+
+        RamTable table = new RamTable(graph, VERTEX_SIZE, EDGE_SIZE);
+        long oldSize = table.edgesSize();
+        // insert edges
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            table.addEdge(true, i, i, Directions.OUT, el1);
+            Assert.assertEquals(oldSize + 2 * i + 1, table.edgesSize());
+
+            table.addEdge(false, i, i + 1, Directions.IN, el2);
+            Assert.assertEquals(oldSize + 2 * i + 2, table.edgesSize());
+        }
+
+        // query by BOTH
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.BOTH, 0);
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge1.direction());
+            Assert.assertEquals("el1", edge1.label());
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge2 = edges.next();
+            Assert.assertEquals(i, edge2.id().ownerVertexId().asLong());
+            Assert.assertEquals(i + 1L, edge2.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.IN, edge2.direction());
+            Assert.assertEquals("el2", edge2.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        // query by OUT
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.OUT, el1);
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge1.direction());
+            Assert.assertEquals("el1", edge1.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        // query by IN
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.IN, el2);
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i + 1L, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.IN, edge1.direction());
+            Assert.assertEquals("el2", edge1.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+
+        // query by BOTH & label 1
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.BOTH, el1);
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge1.direction());
+            Assert.assertEquals("el1", edge1.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+        // query by BOTH & label 2
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.BOTH, el2);
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i + 1L, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.IN, edge1.direction());
+            Assert.assertEquals("el2", edge1.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+
+        // query non-exist vertex
+        Iterator<HugeEdge> edges = table.query(VERTEX_SIZE, Directions.BOTH, 0);
+        Assert.assertFalse(edges.hasNext());
+    }
+
+    @Test
+    public void testAddAndQueryWithoutAdjEdges() throws Exception {
+        HugeGraph graph = this.graph();
+        int el1 = (int) graph.edgeLabel("el1").id().asLong();
+        int el2 = (int) graph.edgeLabel("el2").id().asLong();
+
+        RamTable table = new RamTable(graph, VERTEX_SIZE, EDGE_SIZE);
+        long oldSize = table.edgesSize();
+        // insert edges
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            if (i % 3 != 0) {
+                // don't insert edges for 2/3 vertices
+                continue;
+            }
+
+            table.addEdge(true, i, i, Directions.OUT, el1);
+            Assert.assertEquals(oldSize + i + 1, table.edgesSize());
+
+            table.addEdge(false, i, i, Directions.OUT, el2);
+            Assert.assertEquals(oldSize + i + 2, table.edgesSize());
+
+            table.addEdge(false, i, i + 1, Directions.IN, el2);
+            Assert.assertEquals(oldSize + i + 3, table.edgesSize());
+        }
+
+        // query by BOTH
+        for (int i = 0; i < VERTEX_SIZE; i++) {
+            Iterator<HugeEdge> edges = table.query(i, Directions.BOTH, 0);
+
+            if (i % 3 != 0) {
+                Assert.assertFalse(edges.hasNext());
+                continue;
+            }
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge1 = edges.next();
+            Assert.assertEquals(i, edge1.id().ownerVertexId().asLong());
+            Assert.assertEquals(i, edge1.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge1.direction());
+            Assert.assertEquals("el1", edge1.label());
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge2 = edges.next();
+            Assert.assertEquals(i, edge2.id().ownerVertexId().asLong());
+            Assert.assertEquals(i, edge2.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.OUT, edge2.direction());
+            Assert.assertEquals("el2", edge2.label());
+
+            Assert.assertTrue(edges.hasNext());
+            HugeEdge edge3 = edges.next();
+            Assert.assertEquals(i, edge3.id().ownerVertexId().asLong());
+            Assert.assertEquals(i + 1L, edge3.id().otherVertexId().asLong());
+            Assert.assertEquals(Directions.IN, edge3.direction());
+            Assert.assertEquals("el2", edge3.label());
+
+            Assert.assertFalse(edges.hasNext());
+        }
+    }
+}


### PR DESCRIPTION
* implement RamTable
* plugin ramtable to StandardHugeGrap.edges(query)
* plugin ramtable to GraphTransaction.queryEdgesFromBackend(Query query)
* allow config vertices/edges capacity of ramtable
* tiny improve: remove empty line and delete IntLongMap
* support concurrent loading
* fix edge direction of result is set to BOTH when query with BOTH
* add Consumers class to util package 
* fix ramtable missing some edges if vertex id is big long number(overflow int)
* fix ramtable edge id(direction IN) does not exist and adjacent vertex without props
* support load from file and export to file

Change-Id: I4e1a5c06bd331dc29a92dcb76843990863dfe6ca