### PR TITLE
optimize schema cache perf through IntObjectMap(array)

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/Cache.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/Cache.java
@@ -55,4 +55,8 @@ public interface Cache<K, V> {
     public long hits();
 
     public long miss();
+
+    public <T> T attachment(T object);
+
+    public <T> T attachment();
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedSchemaTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedSchemaTransaction.java
@@ -153,8 +153,12 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
         if (this.idCache.size() >= this.idCache.capacity()) {
             LOG.warn("Schema cache reached capacity({}): {}",
                      this.idCache.capacity(), this.idCache.size());
-            this.arrayCaches.cachedTypes().clear();
+            this.cachedTypes().clear();
         }
+    }
+
+    private CachedTypes cachedTypes() {
+        return this.arrayCaches.cachedTypes();
     }
 
     private static Id generateId(HugeType type, Id id) {
@@ -257,8 +261,7 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
 
     @Override
     protected <T extends SchemaElement> List<T> getAllSchema(HugeType type) {
-        Boolean cachedAll = this.arrayCaches.cachedTypes()
-                                            .getOrDefault(type, false);
+        Boolean cachedAll = this.cachedTypes().getOrDefault(type, false);
         if (cachedAll) {
             List<T> results = new ArrayList<>();
             // Get from cache
@@ -282,7 +285,7 @@ public final class CachedSchemaTransaction extends SchemaTransaction {
                     Id prefixedName = generateId(schema.type(), schema.name());
                     this.nameCache.update(prefixedName, schema);
                 }
-                this.arrayCaches.cachedTypes().putIfAbsent(type, true);
+                this.cachedTypes().putIfAbsent(type, true);
             }
             return results;
         }

--- a/hugegraph-test/src/main/resources/hugegraph.properties
+++ b/hugegraph-test/src/main/resources/hugegraph.properties
@@ -17,6 +17,11 @@ query.batch_size=4
 query.page_size=2
 query.index_intersect_threshold=2
 
+#schema.cache_capacity=1000000
+#query.ramtable_enable=true
+#query.ramtable_vertices_capacity=1800
+#query.ramtable_edges_capacity=1200
+
 # cassandra backend config
 cassandra.host=127.0.0.1
 cassandra.port=9042


### PR DESCRIPTION
* optimize schema cache perf through IntObjectMap(array)
* let array_cache_size = schema_cache_size / 8

Change-Id: Id0cd9bda4085429181f96731a01fb2ee200225c9