### PR TITLE
support hbase enable kerberos authentication

### DIFF
--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseOptions.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseOptions.java
@@ -97,4 +97,36 @@ public class HbaseOptions extends OptionHolder {
                     positiveInt(),
                     12 * 60 * 60L
             );
+
+    public static final ConfigOption<Boolean> HBASE_KERBEROS_ENABLE =
+            new ConfigOption<>(
+                    "hbase.kerberos.enable",
+                    "Is Kerberos authentication enabled for HBase.",
+                    disallowEmpty(),
+                    false
+            );
+
+    public static final ConfigOption<String> HBASE_KRB5_CONF =
+            new ConfigOption<>(
+                    "hbase.krb5.conf",
+                    "Krb5.conf configuration file.",
+                    null,
+                    "/etc/krb5.conf"
+            );
+
+    public static final ConfigOption<String> HBASE_KERBEROS_PRINCIPAL =
+            new ConfigOption<>(
+                    "hbase.kerberos.principal",
+                    "The HBase's principal for kerberos authentication.",
+                    null,
+                    ""
+            );
+
+    public static final ConfigOption<String> HBASE_KERBEROS_KEYTAB =
+            new ConfigOption<>(
+                    "hbase.kerberos.keytab",
+                    "The HBase's key tab file for kerberos authentication.",
+                    null,
+                    ""
+            );
 }

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseOptions.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseOptions.java
@@ -100,7 +100,7 @@ public class HbaseOptions extends OptionHolder {
 
     public static final ConfigOption<Boolean> HBASE_KERBEROS_ENABLE =
             new ConfigOption<>(
-                    "hbase.kerberos.enable",
+                    "hbase.kerberos_enable",
                     "Is Kerberos authentication enabled for HBase.",
                     disallowEmpty(),
                     false
@@ -108,15 +108,15 @@ public class HbaseOptions extends OptionHolder {
 
     public static final ConfigOption<String> HBASE_KRB5_CONF =
             new ConfigOption<>(
-                    "hbase.krb5.conf",
-                    "Krb5.conf configuration file.",
+                    "hbase.krb5_conf",
+                    "Kerberos configuration file, including KDC IP, default realm, etc.",
                     null,
                     "/etc/krb5.conf"
             );
 
     public static final ConfigOption<String> HBASE_KERBEROS_PRINCIPAL =
             new ConfigOption<>(
-                    "hbase.kerberos.principal",
+                    "hbase.kerberos_principal",
                     "The HBase's principal for kerberos authentication.",
                     null,
                     ""
@@ -124,7 +124,7 @@ public class HbaseOptions extends OptionHolder {
 
     public static final ConfigOption<String> HBASE_KERBEROS_KEYTAB =
             new ConfigOption<>(
-                    "hbase.kerberos.keytab",
+                    "hbase.kerberos_keytab",
                     "The HBase's key tab file for kerberos authentication.",
                     null,
                     ""

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
@@ -123,44 +123,30 @@ public class HbaseSessions extends BackendSessionPool {
         int port = config.get(HbaseOptions.HBASE_PORT);
         String znodeParent = config.get(HbaseOptions.HBASE_ZNODE_PARENT);
         boolean isEnableKerberos = config.get(HbaseOptions.HBASE_KERBEROS_ENABLE);
-        Configuration hConfig = null;
+        Configuration hConfig = HBaseConfiguration.create();
+        hConfig.set(HConstants.ZOOKEEPER_QUORUM, hosts);
+        hConfig.set(HConstants.ZOOKEEPER_CLIENT_PORT, String.valueOf(port));
+        hConfig.set(HConstants.ZOOKEEPER_ZNODE_PARENT, znodeParent);
+
+        hConfig.setInt("zookeeper.recovery.retry",
+                       config.get(HbaseOptions.HBASE_ZK_RETRY));
+
+        // Set hbase.hconnection.threads.max 64 to avoid OOM(default value: 256)
+        hConfig.setInt("hbase.hconnection.threads.max",
+                       config.get(HbaseOptions.HBASE_THREADS_MAX));
+
         if(isEnableKerberos) {
             String krb5Conf = config.get(HbaseOptions.HBASE_KRB5_CONF);
             System.setProperty("java.security.krb5.conf", krb5Conf);
-            hConfig = HBaseConfiguration.create();
             String principal = config.get(HbaseOptions.HBASE_KERBEROS_PRINCIPAL);
             String keyTab = config.get(HbaseOptions.HBASE_KERBEROS_KEYTAB);
             hConfig.set("hadoop.security.authentication", "kerberos");
-            hConfig.set("hbase.security.authentication","kerberos");
+            hConfig.set("hbase.security.authentication", "kerberos");
 
-            hConfig.set(HConstants.ZOOKEEPER_QUORUM, hosts);
-            hConfig.set(HConstants.ZOOKEEPER_CLIENT_PORT, String.valueOf(port));
-            hConfig.set(HConstants.ZOOKEEPER_ZNODE_PARENT, znodeParent);
-
-            hConfig.setInt("zookeeper.recovery.retry",
-                           config.get(HbaseOptions.HBASE_ZK_RETRY));
-
-            // Set hbase.hconnection.threads.max 64 to avoid OOM(default value: 256)
-            hConfig.setInt("hbase.hconnection.threads.max",
-                           config.get(HbaseOptions.HBASE_THREADS_MAX));
-
+            //  login/authenticate using keytab
             UserGroupInformation.setConfiguration(hConfig);
             UserGroupInformation.loginUserFromKeytab(principal, keyTab);
-        } else {
-            hConfig = HBaseConfiguration.create();
-
-            hConfig.set(HConstants.ZOOKEEPER_QUORUM, hosts);
-            hConfig.set(HConstants.ZOOKEEPER_CLIENT_PORT, String.valueOf(port));
-            hConfig.set(HConstants.ZOOKEEPER_ZNODE_PARENT, znodeParent);
-
-            hConfig.setInt("zookeeper.recovery.retry",
-                           config.get(HbaseOptions.HBASE_ZK_RETRY));
-
-            // Set hbase.hconnection.threads.max 64 to avoid OOM(default value: 256)
-            hConfig.setInt("hbase.hconnection.threads.max",
-                           config.get(HbaseOptions.HBASE_THREADS_MAX));
         }
-
         this.hbase = ConnectionFactory.createConnection(hConfig);
     }
 


### PR DESCRIPTION
support hbase enable kerberos authentication.

add configs as follows:
- hbase.kerberos.enable, default value:false
- hbase.krb5.conf,default value:/etc/krb5.conf
- hbase.kerberos.principal,default value:""
- hbase.kerberos.keytab,default value:""