### PR TITLE
oltp concurrent requests share multi executors instead of one executor

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -516,6 +516,11 @@ public class HugeTraverser {
             return Objects.equals(this.id, other.id) &&
                    Objects.equals(this.parent, other.parent);
         }
+
+        @Override
+        public String toString() {
+            return this.id.toString();
+        }
     }
 
     public static class KNode extends Node {


### PR DESCRIPTION
also reduce the wake-up period of consumers from 1s to 1ms

Change-Id: I2631e03cd4c60fce5a337c138f6921a59beaa24d