### PR TITLE
support P.textcontains() for rest-api query

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/query/Condition.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/query/Condition.java
@@ -382,6 +382,10 @@ public abstract class Condition {
         return new UserpropRelation(key, RelationType.TEXT_CONTAINS_ANY, words);
     }
 
+    public static Condition contains(Id key, Object value) {
+        return new UserpropRelation(key, RelationType.CONTAINS, value);
+    }
+
     /**
      * Condition defines
      */

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphIndexTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphIndexTransaction.java
@@ -86,7 +86,6 @@ import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.type.define.Action;
 import com.baidu.hugegraph.type.define.HugeKeys;
 import com.baidu.hugegraph.type.define.IndexType;
-import com.baidu.hugegraph.type.define.SchemaStatus;
 import com.baidu.hugegraph.util.CollectionUtil;
 import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.InsertionOrderUtil;
@@ -1346,6 +1345,9 @@ public class GraphIndexTransaction extends AbstractTransaction {
         }
         if (query.hasNeqCondition()) {
             mismatched.add("not-equal");
+        }
+        if (mismatched.isEmpty()) {
+            mismatched.add(query.relations().toString());
         }
         return new NoIndexException("Don't accept query based on properties " +
                                     "%s that are not indexed in %s, " +

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/ConditionP.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/ConditionP.java
@@ -34,7 +34,7 @@ public class ConditionP extends P<Object> {
         super(predicate, value);
     }
 
-    public static ConditionP textContains(String value) {
+    public static ConditionP textContains(Object value) {
         return new ConditionP(RelationType.TEXT_CONTAINS, value);
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/TraversalUtil.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/optimize/TraversalUtil.java
@@ -806,6 +806,8 @@ public final class TraversalUtil {
                 return P.outside(params[0], params[1]);
             case "within":
                 return P.within(predicateArgs(value));
+            case "textcontains":
+                return ConditionP.textContains(predicateArg(value));
             case "contains":
                 // Just for inner use case like auth filter
                 return ConditionP.contains(predicateArg(value));
@@ -868,6 +870,12 @@ public final class TraversalUtil {
                     validValues.add(validPropertyValue(v, pk));
                 }
                 return Condition.in(pk.id(), validValues);
+            case "textcontains":
+                validValue = validPropertyValue(value, pk);
+                return Condition.textContains(pk.id(), (String) validValue);
+            case "contains":
+                validValue = validPropertyValue(value, pk);
+                return Condition.contains(pk.id(), validValue);
             default:
                 throw new NotSupportException("predicate '%s'", method);
         }


### PR DESCRIPTION
how to use:
/graphs/hugegraph/graph/vertices?properties={"city":"P.textcontains(\"shanghai\")"}

improve: #1309
Change-Id: I2d7c0b8c58c6ac53cd6b99414859cb0510393f6c