### PR TITLE
Adapt jraft 1.3.5

### DIFF
--- a/hugegraph-core/pom.xml
+++ b/hugegraph-core/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>jraft-core</artifactId>
-            <version>1.3.3</version>
+            <version>1.3.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/raft/RaftSharedContext.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/raft/RaftSharedContext.java
@@ -40,7 +40,6 @@ import com.alipay.sofa.jraft.option.NodeOptions;
 import com.alipay.sofa.jraft.option.RaftOptions;
 import com.alipay.sofa.jraft.rpc.RaftRpcServerFactory;
 import com.alipay.sofa.jraft.rpc.RpcServer;
-import com.alipay.sofa.jraft.rpc.impl.BoltRaftRpcFactory;
 import com.alipay.sofa.jraft.util.NamedThreadFactory;
 import com.alipay.sofa.jraft.util.ThreadPoolUtil;
 import com.baidu.hugegraph.HugeException;
@@ -55,7 +54,6 @@ import com.baidu.hugegraph.backend.store.raft.rpc.StoreCommandProcessor;
 import com.baidu.hugegraph.config.CoreOptions;
 import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.event.EventHub;
-import com.baidu.hugegraph.testutil.Whitebox;
 import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.type.define.GraphMode;
 import com.baidu.hugegraph.util.E;
@@ -314,12 +312,14 @@ public final class RaftSharedContext {
     }
 
     private RpcServer initAndStartRpcServer() {
-        Whitebox.setInternalState(
-                 BoltRaftRpcFactory.class, "CHANNEL_WRITE_BUF_LOW_WATER_MARK",
-                 this.config().get(CoreOptions.RAFT_RPC_BUF_LOW_WATER_MARK));
-        Whitebox.setInternalState(
-                 BoltRaftRpcFactory.class, "CHANNEL_WRITE_BUF_HIGH_WATER_MARK",
-                 this.config().get(CoreOptions.RAFT_RPC_BUF_HIGH_WATER_MARK));
+        Integer lowWaterMark = this.config().get(
+                               CoreOptions.RAFT_RPC_BUF_LOW_WATER_MARK);
+        System.setProperty("bolt.channel_write_buf_low_water_mark",
+                           String.valueOf(lowWaterMark));
+        Integer highWaterMark = this.config().get(
+                                CoreOptions.RAFT_RPC_BUF_HIGH_WATER_MARK);
+        System.setProperty("bolt.channel_write_buf_high_water_mark",
+                           String.valueOf(highWaterMark));
 
         PeerId serverId = new PeerId();
         serverId.parse(this.config().get(CoreOptions.RAFT_ENDPOINT));

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStdSessions.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStdSessions.java
@@ -684,17 +684,11 @@ public class RocksDBStdSessions extends RocksDBSessions {
         private WriteOptions writeOptions;
 
         public StdSession(HugeConfig conf) {
-            boolean raftMode = conf.get(CoreOptions.RAFT_MODE);
+            boolean bulkload = conf.get(RocksDBOptions.BULKLOAD_MODE);
             this.batch = new WriteBatch();
             this.writeOptions = new WriteOptions();
-            /*
-             * When work under raft mode. if store crashed, the state-machine
-             * can restore by snapshot + raft log, doesn't need wal and sync
-             */
-            if (raftMode) {
-                this.writeOptions.setDisableWAL(true);
-                this.writeOptions.setSync(false);
-            }
+            this.writeOptions.setDisableWAL(bulkload);
+            //this.writeOptions.setSync(false);
         }
 
         @Override

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStdSessions.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStdSessions.java
@@ -65,7 +65,6 @@ import com.baidu.hugegraph.backend.serializer.BinarySerializer;
 import com.baidu.hugegraph.backend.store.BackendEntry.BackendColumn;
 import com.baidu.hugegraph.backend.store.BackendEntry.BackendColumnIterator;
 import com.baidu.hugegraph.backend.store.BackendEntryIterator;
-import com.baidu.hugegraph.config.CoreOptions;
 import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.util.Bytes;
 import com.baidu.hugegraph.util.E;


### PR DESCRIPTION
NOTE: In fact, it still cann't fully adapt to the community version of jraft,
because it's different from the rocksdb version that hugegraph relies on

Change-Id: I83079e799df4d332e968694c7aea0ff11bbcdb81