### PR TITLE
auth fix: creator is null in toString() called by consistent-hash LB when verifying permission

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/auth/HugeGraphAuthProxy.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/auth/HugeGraphAuthProxy.java
@@ -1271,15 +1271,15 @@ public final class HugeGraphAuthProxy implements HugeGraph {
 
         @Override
         public Id createAccess(HugeAccess access) {
-            verifyUserPermission(HugePermission.WRITE, access);
             this.updateCreator(access);
+            verifyUserPermission(HugePermission.WRITE, access);
             return this.authManager.createAccess(access);
         }
 
         @Override
         public Id updateAccess(HugeAccess access) {
-            verifyUserPermission(HugePermission.WRITE, access);
             this.updateCreator(access);
+            verifyUserPermission(HugePermission.WRITE, access);
             return this.authManager.updateAccess(access);
         }
 


### PR DESCRIPTION
…reator of auth element  is null by tostring method.