### PR TITLE
bump netty-all from 4.1.13.Final to 4.1.42.Final

### DIFF
--- a/hugegraph-cassandra/pom.xml
+++ b/hugegraph-cassandra/pom.xml
@@ -56,17 +56,18 @@
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <version>3.6.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
+            <!-- netty-all contain netty-transport-native-epoll, https://github.com/netty/netty/issues/8714 -->
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.13.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.13.Final</version>
-            <classifier>linux-x86_64</classifier>
+            <version>4.1.42.Final</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
related: https://github.com/hugegraph/hugegraph/commit/bd06f1a445ed32cfc7785ece2d5f960e06d4adbe
related: https://github.com/hugegraph/hugegraph/commit/accc27fc9bc985235d3ba09767ac2acbd5e731c4

Change-Id: I1893ec67371712b091f35b085611959dd9d429cc