### PR TITLE
refact: unify naming of degree for oltp algorithms

### DIFF
--- a/hugegraph-api/pom.xml
+++ b/hugegraph-api/pom.xml
@@ -153,7 +153,7 @@
                             </addDefaultSpecificationEntries>
                         </manifest>
                         <manifestEntries>
-                            <Implementation-Version>0.60.0.0</Implementation-Version>
+                            <Implementation-Version>0.61.0.0</Implementation-Version>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/AllShortestPathsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/AllShortestPathsAPI.java
@@ -22,7 +22,7 @@ package com.baidu.hugegraph.api.traversers;
 import java.util.List;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
 import javax.inject.Singleton;
 import javax.ws.rs.DefaultValue;
@@ -66,7 +66,7 @@ public class AllShortestPathsAPI extends API {
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("max_depth") int depth,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("skip_degree")
                       @DefaultValue("0") long skipDegree,
                       @QueryParam("capacity")
@@ -75,7 +75,7 @@ public class AllShortestPathsAPI extends API {
                   "direction {}, edge label {}, max depth '{}', " +
                   "max degree '{}', skipped degree '{}' and capacity '{}'",
                   graph, source, target, direction, edgeLabel, depth,
-                  degree, skipDegree, capacity);
+                  maxDegree, skipDegree, capacity);
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
@@ -88,7 +88,7 @@ public class AllShortestPathsAPI extends API {
                                   ImmutableList.of(edgeLabel);
         HugeTraverser.PathSet paths = traverser.allShortestPaths(
                                       sourceId, targetId, dir, edgeLabels,
-                                      depth, degree, skipDegree, capacity);
+                                      depth, maxDegree, skipDegree, capacity);
         return manager.serializer(g).writePaths("paths", paths, false);
     }
 }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CountAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CountAPI.java
@@ -19,7 +19,7 @@
 
 package com.baidu.hugegraph.api.traversers;
 
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_SKIP_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
 
@@ -109,7 +109,7 @@ public class CountAPI extends API {
         @Override
         public String toString() {
             return String.format("CountRequest{source=%s,steps=%s," +
-                                 "contains_traversed=%s,dedupSize=%s}",
+                                 "containsTraversed=%s,dedupSize=%s}",
                                  this.source, this.steps,
                                  this.containsTraversed, this.dedupSize);
         }
@@ -123,22 +123,22 @@ public class CountAPI extends API {
         public List<String> labels;
         @JsonProperty("properties")
         public Map<String, Object> properties;
-        @JsonProperty("degree")
-        public long degree = Long.valueOf(DEFAULT_DEGREE);
+        @JsonProperty("max_degree")
+        public long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")
         public long skipDegree = Long.valueOf(DEFAULT_SKIP_DEGREE);
 
         @Override
         public String toString() {
             return String.format("Step{direction=%s,labels=%s,properties=%s" +
-                                 "degree=%s,skipDegree=%s}",
+                                 "maxDegree=%s,skipDegree=%s}",
                                  this.direction, this.labels, this.properties,
-                                 this.degree, this.skipDegree);
+                                 this.maxDegree, this.skipDegree);
         }
 
         private EdgeStep jsonToStep(HugeGraph graph) {
             return new EdgeStep(graph, this.direction, this.labels,
-                                this.properties, this.degree, this.skipDegree);
+                                this.properties, this.maxDegree, this.skipDegree);
         }
     }
 }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CountAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CountAPI.java
@@ -48,6 +48,7 @@ import com.baidu.hugegraph.type.define.Directions;
 import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.Log;
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
@@ -123,6 +124,7 @@ public class CountAPI extends API {
         public List<String> labels;
         @JsonProperty("properties")
         public Map<String, Object> properties;
+        @JsonAlias("degree")
         @JsonProperty("max_degree")
         public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CountAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CountAPI.java
@@ -124,9 +124,9 @@ public class CountAPI extends API {
         @JsonProperty("properties")
         public Map<String, Object> properties;
         @JsonProperty("max_degree")
-        public long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
+        public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")
-        public long skipDegree = Long.valueOf(DEFAULT_SKIP_DEGREE);
+        public long skipDegree = Long.parseLong(DEFAULT_SKIP_DEGREE);
 
         @Override
         public String toString() {

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CrosspointsAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
 import javax.inject.Singleton;
@@ -64,7 +64,7 @@ public class CrosspointsAPI extends API {
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("max_depth") int depth,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity,
                       @QueryParam("limit")
@@ -73,7 +73,7 @@ public class CrosspointsAPI extends API {
                   "with direction '{}', edge label '{}', max depth '{}', " +
                   "max degree '{}', capacity '{}' and limit '{}'",
                   graph, source, target, direction, edgeLabel,
-                  depth, degree, capacity, limit);
+                  depth, maxDegree, capacity, limit);
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
@@ -83,7 +83,7 @@ public class CrosspointsAPI extends API {
         PathsTraverser traverser = new PathsTraverser(g);
         HugeTraverser.PathSet paths = traverser.paths(sourceId, dir, targetId,
                                                       dir, edgeLabel, depth,
-                                                      degree, capacity, limit);
+                                                      maxDegree, capacity, limit);
         return manager.serializer(g).writePaths("crosspoints", paths, true);
     }
 }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
@@ -136,9 +136,9 @@ public class CustomizedCrosspointsAPI extends API {
         @JsonProperty("path_patterns")
         public List<PathPattern> pathPatterns;
         @JsonProperty("capacity")
-        public long capacity = Long.valueOf(DEFAULT_CAPACITY);
+        public long capacity = Long.parseLong(DEFAULT_CAPACITY);
         @JsonProperty("limit")
-        public long limit = Long.valueOf(DEFAULT_PATHS_LIMIT);
+        public long limit = Long.parseLong(DEFAULT_PATHS_LIMIT);
         @JsonProperty("with_path")
         public boolean withPath = false;
         @JsonProperty("with_vertex")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
 import java.util.ArrayList;
@@ -173,24 +173,24 @@ public class CustomizedCrosspointsAPI extends API {
         public List<String> labels;
         @JsonProperty("properties")
         public Map<String, Object> properties;
-        @JsonProperty("degree")
-        public long degree = Long.valueOf(DEFAULT_DEGREE);
+        @JsonProperty("max_degree")
+        public long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")
         public long skipDegree = 0L;
 
         @Override
         public String toString() {
             return String.format("Step{direction=%s,labels=%s,properties=%s," +
-                                 "degree=%s,skipDegree=%s}",
+                                 "maxDegree=%s,skipDegree=%s}",
                                  this.direction, this.labels, this.properties,
-                                 this.degree, this.skipDegree);
+                                 this.maxDegree, this.skipDegree);
         }
 
         private CustomizedCrosspointsTraverser.Step jsonToStep(HugeGraph g) {
             return new CustomizedCrosspointsTraverser.Step(g, this.direction,
                                                            this.labels,
                                                            this.properties,
-                                                           this.degree,
+                                                           this.maxDegree,
                                                            this.skipDegree);
         }
     }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
@@ -53,6 +53,7 @@ import com.baidu.hugegraph.type.define.Directions;
 import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.Log;
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Path("graphs/{graph}/traversers/customizedcrosspoints")
@@ -173,6 +174,7 @@ public class CustomizedCrosspointsAPI extends API {
         public List<String> labels;
         @JsonProperty("properties")
         public Map<String, Object> properties;
+        @JsonAlias("degree")
         @JsonProperty("max_degree")
         public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedCrosspointsAPI.java
@@ -174,7 +174,7 @@ public class CustomizedCrosspointsAPI extends API {
         @JsonProperty("properties")
         public Map<String, Object> properties;
         @JsonProperty("max_degree")
-        public long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
+        public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")
         public long skipDegree = 0L;
 

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedPathsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedPathsAPI.java
@@ -136,9 +136,9 @@ public class CustomizedPathsAPI extends API {
         @JsonProperty("sort_by")
         public SortBy sortBy;
         @JsonProperty("capacity")
-        public long capacity = Long.valueOf(DEFAULT_CAPACITY);
+        public long capacity = Long.parseLong(DEFAULT_CAPACITY);
         @JsonProperty("limit")
-        public long limit = Long.valueOf(DEFAULT_PATHS_LIMIT);
+        public long limit = Long.parseLong(DEFAULT_PATHS_LIMIT);
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
 
@@ -161,15 +161,15 @@ public class CustomizedPathsAPI extends API {
         @JsonProperty("properties")
         public Map<String, Object> properties;
         @JsonProperty("max_degree")
-        public long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
+        public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")
         public long skipDegree = 0L;
         @JsonProperty("weight_by")
         public String weightBy;
         @JsonProperty("default_weight")
-        public double defaultWeight = Double.valueOf(DEFAULT_WEIGHT);
+        public double defaultWeight = Double.parseDouble(DEFAULT_WEIGHT);
         @JsonProperty("sample")
-        public long sample = Long.valueOf(DEFAULT_SAMPLE);
+        public long sample = Long.parseLong(DEFAULT_SAMPLE);
 
         @Override
         public String toString() {

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedPathsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedPathsAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_SAMPLE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_WEIGHT;
@@ -160,8 +160,8 @@ public class CustomizedPathsAPI extends API {
         public List<String> labels;
         @JsonProperty("properties")
         public Map<String, Object> properties;
-        @JsonProperty("degree")
-        public long degree = Long.valueOf(DEFAULT_DEGREE);
+        @JsonProperty("max_degree")
+        public long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")
         public long skipDegree = 0L;
         @JsonProperty("weight_by")
@@ -174,17 +174,17 @@ public class CustomizedPathsAPI extends API {
         @Override
         public String toString() {
             return String.format("Step{direction=%s,labels=%s,properties=%s," +
-                                 "degree=%s,skipDegree=%s," +
+                                 "maxDegree=%s,skipDegree=%s," +
                                  "weightBy=%s,defaultWeight=%s,sample=%s}",
                                  this.direction, this.labels, this.properties,
-                                 this.degree, this.skipDegree,
+                                 this.maxDegree, this.skipDegree,
                                  this.weightBy, this.defaultWeight,
                                  this.sample);
         }
 
         private WeightedEdgeStep jsonToStep(HugeGraph g) {
             return new WeightedEdgeStep(g, this.direction, this.labels,
-                                        this.properties, this.degree,
+                                        this.properties, this.maxDegree,
                                         this.skipDegree, this.weightBy,
                                         this.defaultWeight, this.sample);
         }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedPathsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/CustomizedPathsAPI.java
@@ -56,6 +56,7 @@ import com.baidu.hugegraph.type.define.Directions;
 import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.Log;
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Path("graphs/{graph}/traversers/customizedpaths")
@@ -160,6 +161,7 @@ public class CustomizedPathsAPI extends API {
         public List<String> labels;
         @JsonProperty("properties")
         public Map<String, Object> properties;
+        @JsonAlias("degree")
         @JsonProperty("max_degree")
         public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/FusiformSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/FusiformSimilarityAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
 
@@ -75,9 +75,9 @@ public class FusiformSimilarityAPI extends API {
         E.checkArgument(request.minNeighbors > 0,
                         "The min neighbor count must be > 0, but got: %s",
                         request.minNeighbors);
-        E.checkArgument(request.degree > 0 || request.degree == NO_LIMIT,
-                        "The degree of request must be > 0, but got: %s",
-                        request.degree);
+        E.checkArgument(request.maxDegree > 0 || request.maxDegree == NO_LIMIT,
+                        "The maxDegree of request must be > 0, but got: %s",
+                        request.maxDegree);
         E.checkArgument(request.alpha > 0 && request.alpha <= 1.0,
                         "The alpha of request must be in range (0, 1], " +
                         "but got '%s'", request.alpha);
@@ -107,8 +107,8 @@ public class FusiformSimilarityAPI extends API {
                              request.minNeighbors, request.alpha,
                              request.minSimilars, request.top,
                              request.groupProperty, request.minGroups,
-                             request.degree, request.capacity, request.limit,
-                             request.withIntermediary);
+                             request.maxDegree, request.capacity,
+                             request.limit, request.withIntermediary);
 
         CloseableIterator.closeIterator(sources);
 
@@ -140,7 +140,7 @@ public class FusiformSimilarityAPI extends API {
         @JsonProperty("min_groups")
         public int minGroups;
         @JsonProperty("max_degree")
-        public long degree = Long.valueOf(DEFAULT_DEGREE);
+        public long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
         @JsonProperty("capacity")
         public long capacity = Long.valueOf(DEFAULT_CAPACITY);
         @JsonProperty("limit")
@@ -156,13 +156,13 @@ public class FusiformSimilarityAPI extends API {
                                  "label=%s,direction=%s,minNeighbors=%s," +
                                  "alpha=%s,minSimilars=%s,top=%s," +
                                  "groupProperty=%s,minGroups=%s," +
-                                 "degree=%s,capacity=%s,limit=%s," +
+                                 "maxDegree=%s,capacity=%s,limit=%s," +
                                  "withIntermediary=%s,withVertex=%s}",
                                  this.sources, this.label, this.direction,
                                  this.minNeighbors, this.alpha,
                                  this.minSimilars, this.top,
                                  this.groupProperty, this.minGroups,
-                                 this.degree, this.capacity, this.limit,
+                                 this.maxDegree, this.capacity, this.limit,
                                  this.withIntermediary, this.withVertex);
         }
     }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/FusiformSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/FusiformSimilarityAPI.java
@@ -140,11 +140,11 @@ public class FusiformSimilarityAPI extends API {
         @JsonProperty("min_groups")
         public int minGroups;
         @JsonProperty("max_degree")
-        public long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
+        public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("capacity")
-        public long capacity = Long.valueOf(DEFAULT_CAPACITY);
+        public long capacity = Long.parseLong(DEFAULT_CAPACITY);
         @JsonProperty("limit")
-        public long limit = Long.valueOf(DEFAULT_PATHS_LIMIT);
+        public long limit = Long.parseLong(DEFAULT_PATHS_LIMIT);
         @JsonProperty("with_intermediary")
         public boolean withIntermediary = false;
         @JsonProperty("with_vertex")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/FusiformSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/FusiformSimilarityAPI.java
@@ -75,8 +75,8 @@ public class FusiformSimilarityAPI extends API {
         E.checkArgument(request.minNeighbors > 0,
                         "The min neighbor count must be > 0, but got: %s",
                         request.minNeighbors);
-        E.checkArgument(request.maxDegree > 0 || request.maxDegree == NO_LIMIT,
-                        "The maxDegree of request must be > 0, but got: %s",
+        E.checkArgument(request.maxDegree > 0L || request.maxDegree == NO_LIMIT,
+                        "The max_degree of request must be > 0, but got: %s",
                         request.maxDegree);
         E.checkArgument(request.alpha > 0 && request.alpha <= 1.0,
                         "The alpha of request must be in range (0, 1], " +

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/JaccardSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/JaccardSimilarityAPI.java
@@ -132,9 +132,9 @@ public class JaccardSimilarityAPI extends TraverserAPI {
         @JsonProperty("step")
         public TraverserAPI.Step step;
         @JsonProperty("top")
-        public int top = Integer.valueOf(DEFAULT_LIMIT);
+        public int top = Integer.parseInt(DEFAULT_LIMIT);
         @JsonProperty("capacity")
-        public long capacity = Long.valueOf(DEFAULT_CAPACITY);
+        public long capacity = Long.parseLong(DEFAULT_CAPACITY);
 
         @Override
         public String toString() {

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/JaccardSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/JaccardSimilarityAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_LIMIT;
 
 import java.util.Map;
@@ -71,10 +71,10 @@ public class JaccardSimilarityAPI extends TraverserAPI {
                       @QueryParam("direction") String direction,
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree) {
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree) {
         LOG.debug("Graph [{}] get jaccard similarity between '{}' and '{}' " +
                   "with direction {}, edge label {} and max degree '{}'",
-                  graph, vertex, other, direction, edgeLabel, degree);
+                  graph, vertex, other, direction, edgeLabel, maxDegree);
 
         Id sourceId = VertexAPI.checkAndParseVertexId(vertex);
         Id targetId = VertexAPI.checkAndParseVertexId(other);
@@ -84,8 +84,8 @@ public class JaccardSimilarityAPI extends TraverserAPI {
         double similarity;
         try (JaccardSimilarTraverser traverser =
                                      new JaccardSimilarTraverser(g)) {
-             similarity = traverser.jaccardSimilarity(sourceId, targetId,
-                                                      dir, edgeLabel, degree);
+             similarity = traverser.jaccardSimilarity(sourceId, targetId, dir,
+                                                      edgeLabel, maxDegree);
         }
         return JsonUtil.toJson(ImmutableMap.of("jaccard_similarity",
                                                similarity));

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KneighborAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KneighborAPI.java
@@ -171,7 +171,7 @@ public class KneighborAPI extends TraverserAPI {
         @JsonProperty("max_depth")
         public int maxDepth;
         @JsonProperty("limit")
-        public long limit = Long.parseLong(DEFAULT_PATHS_LIMIT);
+        public long limit = Long.parseLong(DEFAULT_ELEMENTS_LIMIT);
         @JsonProperty("count_only")
         public boolean countOnly = false;
         @JsonProperty("with_vertex")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KneighborAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KneighborAPI.java
@@ -171,7 +171,7 @@ public class KneighborAPI extends TraverserAPI {
         @JsonProperty("max_depth")
         public int maxDepth;
         @JsonProperty("limit")
-        public long limit = Long.valueOf(DEFAULT_PATHS_LIMIT);
+        public long limit = Long.parseLong(DEFAULT_PATHS_LIMIT);
         @JsonProperty("count_only")
         public boolean countOnly = false;
         @JsonProperty("with_vertex")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KneighborAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KneighborAPI.java
@@ -19,7 +19,7 @@
 
 package com.baidu.hugegraph.api.traversers;
 
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_ELEMENTS_LIMIT;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
@@ -76,14 +76,14 @@ public class KneighborAPI extends TraverserAPI {
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("max_depth") int depth,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("limit")
                       @DefaultValue(DEFAULT_ELEMENTS_LIMIT) long limit) {
         LOG.debug("Graph [{}] get k-neighbor from '{}' with " +
                   "direction '{}', edge label '{}', max depth '{}', " +
                   "max degree '{}' and limit '{}'",
                   graph, sourceV, direction, edgeLabel, depth,
-                  degree, limit);
+                  maxDegree, limit);
 
         Id source = VertexAPI.checkAndParseVertexId(sourceV);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -93,7 +93,7 @@ public class KneighborAPI extends TraverserAPI {
         Set<Id> ids;
         try (KneighborTraverser traverser = new KneighborTraverser(g)) {
             ids = traverser.kneighbor(source, dir, edgeLabel,
-                                      depth, degree, limit);
+                                      depth, maxDegree, limit);
         }
         return manager.serializer(g).writeList("vertices", ids);
     }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KoutAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_ELEMENTS_LIMIT;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
@@ -80,7 +80,7 @@ public class KoutAPI extends TraverserAPI {
                       @QueryParam("nearest")
                       @DefaultValue("true")  boolean nearest,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity,
                       @QueryParam("limit")
@@ -89,7 +89,7 @@ public class KoutAPI extends TraverserAPI {
                   "direction '{}', edge label '{}', max depth '{}', nearest " +
                   "'{}', max degree '{}', capacity '{}' and limit '{}'",
                   graph, source, direction, edgeLabel, depth, nearest,
-                  degree, capacity, limit);
+                  maxDegree, capacity, limit);
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -99,7 +99,7 @@ public class KoutAPI extends TraverserAPI {
         Set<Id> ids;
         try (KoutTraverser traverser = new KoutTraverser(g)) {
             ids = traverser.kout(sourceId, dir, edgeLabel, depth,
-                                 nearest, degree, capacity, limit);
+                                 nearest, maxDegree, capacity, limit);
         }
         return manager.serializer(g).writeList("vertices", ids);
     }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KoutAPI.java
@@ -185,9 +185,9 @@ public class KoutAPI extends TraverserAPI {
         @JsonProperty("count_only")
         public boolean countOnly = false;
         @JsonProperty("capacity")
-        public long capacity = Long.valueOf(DEFAULT_CAPACITY);
+        public long capacity = Long.parseLong(DEFAULT_CAPACITY);
         @JsonProperty("limit")
-        public long limit = Long.valueOf(DEFAULT_PATHS_LIMIT);
+        public long limit = Long.parseLong(DEFAULT_PATHS_LIMIT);
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
         @JsonProperty("with_path")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KoutAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/KoutAPI.java
@@ -187,7 +187,7 @@ public class KoutAPI extends TraverserAPI {
         @JsonProperty("capacity")
         public long capacity = Long.parseLong(DEFAULT_CAPACITY);
         @JsonProperty("limit")
-        public long limit = Long.parseLong(DEFAULT_PATHS_LIMIT);
+        public long limit = Long.parseLong(DEFAULT_ELEMENTS_LIMIT);
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
         @JsonProperty("with_path")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/MultiNodeShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/MultiNodeShortestPathAPI.java
@@ -112,7 +112,7 @@ public class MultiNodeShortestPathAPI extends TraverserAPI {
         @JsonProperty("max_depth")
         public int maxDepth;
         @JsonProperty("capacity")
-        public long capacity = Long.valueOf(DEFAULT_CAPACITY);
+        public long capacity = Long.parseLong(DEFAULT_CAPACITY);
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
 

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/NeighborRankAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/NeighborRankAPI.java
@@ -48,6 +48,7 @@ import com.baidu.hugegraph.type.define.Directions;
 import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.Log;
 import com.codahale.metrics.annotation.Timed;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Path("graphs/{graph}/traversers/neighborrank")
@@ -123,6 +124,7 @@ public class NeighborRankAPI extends API {
         public Directions direction;
         @JsonProperty("labels")
         public List<String> labels;
+        @JsonAlias("degree")
         @JsonProperty("max_degree")
         public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/NeighborRankAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/NeighborRankAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEPTH;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
@@ -123,8 +123,8 @@ public class NeighborRankAPI extends API {
         public Directions direction;
         @JsonProperty("labels")
         public List<String> labels;
-        @JsonProperty("degree")
-        public long degree = Long.parseLong(DEFAULT_DEGREE);
+        @JsonProperty("max_degree")
+        public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")
         public long skipDegree = 0L;
         @JsonProperty("top")
@@ -134,15 +134,15 @@ public class NeighborRankAPI extends API {
 
         @Override
         public String toString() {
-            return String.format("Step{direction=%s,labels=%s,degree=%s," +
+            return String.format("Step{direction=%s,labels=%s,maxDegree=%s," +
                                  "top=%s}", this.direction, this.labels,
-                                 this.degree, this.top);
+                                 this.maxDegree, this.top);
         }
 
         private NeighborRankTraverser.Step jsonToStep(HugeGraph g) {
             return new NeighborRankTraverser.Step(g, this.direction,
                                                   this.labels,
-                                                  this.degree,
+                                                  this.maxDegree,
                                                   this.skipDegree,
                                                   this.top,
                                                   DEFAULT_CAPACITY_PER_LAYER);

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PathsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PathsAPI.java
@@ -164,9 +164,9 @@ public class PathsAPI extends TraverserAPI {
         @JsonProperty("nearest")
         public boolean nearest = false;
         @JsonProperty("capacity")
-        public long capacity = Long.valueOf(DEFAULT_CAPACITY);
+        public long capacity = Long.parseLong(DEFAULT_CAPACITY);
         @JsonProperty("limit")
-        public long limit = Long.valueOf(DEFAULT_PATHS_LIMIT);
+        public long limit = Long.parseLong(DEFAULT_PATHS_LIMIT);
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
 

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PathsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PathsAPI.java
@@ -25,7 +25,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
 import javax.inject.Singleton;
@@ -76,7 +76,7 @@ public class PathsAPI extends TraverserAPI {
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("max_depth") int depth,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity,
                       @QueryParam("limit")
@@ -85,7 +85,7 @@ public class PathsAPI extends TraverserAPI {
                   "direction {}, edge label {}, max depth '{}', " +
                   "max degree '{}', capacity '{}' and limit '{}'",
                   graph, source, target, direction, edgeLabel, depth,
-                  degree, capacity, limit);
+                  maxDegree, capacity, limit);
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
@@ -95,7 +95,7 @@ public class PathsAPI extends TraverserAPI {
         PathsTraverser traverser = new PathsTraverser(g);
         HugeTraverser.PathSet paths = traverser.paths(sourceId, dir, targetId,
                                                       dir.opposite(), edgeLabel,
-                                                      depth, degree, capacity,
+                                                      depth, maxDegree, capacity,
                                                       limit);
         return manager.serializer(g).writePaths("paths", paths, false);
     }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PersonalRankAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PersonalRankAPI.java
@@ -43,7 +43,7 @@ import com.baidu.hugegraph.util.Log;
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_LIMIT;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEPTH;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
@@ -68,9 +68,9 @@ public class PersonalRankAPI extends API {
         E.checkArgument(request.alpha > 0 && request.alpha <= 1.0,
                         "The alpha of rank request must be in range (0, 1], " +
                         "but got '%s'", request.alpha);
-        E.checkArgument(request.degree > 0 || request.degree == NO_LIMIT,
-                        "The degree of rank request must be > 0, but got: %s",
-                        request.degree);
+        E.checkArgument(request.maxDegree > 0 || request.maxDegree == NO_LIMIT,
+                        "The maxDegree of rank request must be > 0, but got: %s",
+                        request.maxDegree);
         E.checkArgument(request.limit > 0 || request.limit == NO_LIMIT,
                         "The limit of rank request must be > 0, but got: %s",
                         request.limit);
@@ -81,16 +81,16 @@ public class PersonalRankAPI extends API {
                         DEFAULT_MAX_DEPTH, request.maxDepth);
 
         LOG.debug("Graph [{}] get personal rank from '{}' with " +
-                  "edge label '{}', alpha '{}', degree '{}', " +
+                  "edge label '{}', alpha '{}', maxDegree '{}', " +
                   "max depth '{}' and sorted '{}'",
                   graph, request.source, request.label, request.alpha,
-                  request.degree, request.maxDepth, request.sorted);
+                  request.maxDegree, request.maxDepth, request.sorted);
 
         Id sourceId = HugeVertex.getIdValue(request.source);
         HugeGraph g = graph(manager, graph);
 
         PersonalRankTraverser traverser;
-        traverser = new PersonalRankTraverser(g, request.alpha, request.degree,
+        traverser = new PersonalRankTraverser(g, request.alpha, request.maxDegree,
                                               request.maxDepth);
         Map<Id, Double> ranks = traverser.personalRank(sourceId, request.label,
                                                        request.withLabel);
@@ -106,8 +106,8 @@ public class PersonalRankAPI extends API {
         private String label;
         @JsonProperty("alpha")
         private double alpha;
-        @JsonProperty("degree")
-        private long degree = Long.valueOf(DEFAULT_DEGREE);
+        @JsonProperty("max_degree")
+        private long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
         @JsonProperty("limit")
         private long limit = Long.valueOf(DEFAULT_LIMIT);
         @JsonProperty("max_depth")
@@ -121,10 +121,10 @@ public class PersonalRankAPI extends API {
         @Override
         public String toString() {
             return String.format("RankRequest{source=%s,label=%s,alpha=%s," +
-                                 "degree=%s,limit=%s,maxDepth=%s," +
+                                 "maxDegree=%s,limit=%s,maxDepth=%s," +
                                  "withLabel=%s,sorted=%s}",
                                  this.source, this.label, this.alpha,
-                                 this.degree, this.limit, this.maxDepth,
+                                 this.maxDegree, this.limit, this.maxDepth,
                                  this.withLabel, this.sorted);
         }
     }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PersonalRankAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PersonalRankAPI.java
@@ -107,9 +107,9 @@ public class PersonalRankAPI extends API {
         @JsonProperty("alpha")
         private double alpha;
         @JsonProperty("max_degree")
-        private long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
+        private long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("limit")
-        private long limit = Long.valueOf(DEFAULT_LIMIT);
+        private long limit = Long.parseLong(DEFAULT_LIMIT);
         @JsonProperty("max_depth")
         private int maxDepth;
         @JsonProperty("with_label")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PersonalRankAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PersonalRankAPI.java
@@ -69,8 +69,8 @@ public class PersonalRankAPI extends API {
                         "The alpha of rank request must be in range (0, 1], " +
                         "but got '%s'", request.alpha);
         E.checkArgument(request.maxDegree > 0L || request.maxDegree == NO_LIMIT,
-                        "The max_degree of rank request must be > 0," +
-                        " but got: %s", request.maxDegree);
+                        "The max_degree of rank request must be > 0, " +
+                        "but got: %s", request.maxDegree);
         E.checkArgument(request.limit > 0L || request.limit == NO_LIMIT,
                         "The limit of rank request must be > 0, but got: %s",
                         request.limit);

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PersonalRankAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/PersonalRankAPI.java
@@ -68,14 +68,14 @@ public class PersonalRankAPI extends API {
         E.checkArgument(request.alpha > 0 && request.alpha <= 1.0,
                         "The alpha of rank request must be in range (0, 1], " +
                         "but got '%s'", request.alpha);
-        E.checkArgument(request.maxDegree > 0 || request.maxDegree == NO_LIMIT,
-                        "The maxDegree of rank request must be > 0, but got: %s",
-                        request.maxDegree);
-        E.checkArgument(request.limit > 0 || request.limit == NO_LIMIT,
+        E.checkArgument(request.maxDegree > 0L || request.maxDegree == NO_LIMIT,
+                        "The max_degree of rank request must be > 0," +
+                        " but got: %s", request.maxDegree);
+        E.checkArgument(request.limit > 0L || request.limit == NO_LIMIT,
                         "The limit of rank request must be > 0, but got: %s",
                         request.limit);
-        E.checkArgument(request.maxDepth > 0 &&
-                        request.maxDepth <= Long.valueOf(DEFAULT_MAX_DEPTH),
+        E.checkArgument(request.maxDepth > 0L &&
+                        request.maxDepth <= Long.parseLong(DEFAULT_MAX_DEPTH),
                         "The max depth of rank request must be " +
                         "in range (0, %s], but got '%s'",
                         DEFAULT_MAX_DEPTH, request.maxDepth);

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/RaysAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/RaysAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
 import javax.inject.Singleton;
@@ -63,7 +63,7 @@ public class RaysAPI extends API {
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("max_depth") int depth,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity,
                       @QueryParam("limit")
@@ -71,7 +71,7 @@ public class RaysAPI extends API {
         LOG.debug("Graph [{}] get rays paths from '{}' with " +
                   "direction '{}', edge label '{}', max depth '{}', " +
                   "max degree '{}', capacity '{}' and limit '{}'",
-                  graph, sourceV, direction, edgeLabel, depth, degree,
+                  graph, sourceV, direction, edgeLabel, depth, maxDegree,
                   capacity, limit);
 
         Id source = VertexAPI.checkAndParseVertexId(sourceV);
@@ -81,7 +81,7 @@ public class RaysAPI extends API {
 
         SubGraphTraverser traverser = new SubGraphTraverser(g);
         HugeTraverser.PathSet paths = traverser.rays(source, dir, edgeLabel,
-                                                     depth, degree,
+                                                     depth, maxDegree,
                                                      capacity, limit);
         return manager.serializer(g).writePaths("rays", paths, false);
     }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/RingsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/RingsAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
 import javax.inject.Singleton;
@@ -65,7 +65,7 @@ public class RingsAPI extends API {
                       @QueryParam("source_in_ring")
                       @DefaultValue("true") boolean sourceInRing,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity,
                       @QueryParam("limit")
@@ -75,7 +75,7 @@ public class RingsAPI extends API {
                   "source in ring '{}', max degree '{}', capacity '{}' " +
                   "and limit '{}'",
                   graph, sourceV, direction, edgeLabel, depth, sourceInRing,
-                  degree, capacity, limit);
+                  maxDegree, capacity, limit);
 
         Id source = VertexAPI.checkAndParseVertexId(sourceV);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -85,7 +85,7 @@ public class RingsAPI extends API {
         SubGraphTraverser traverser = new SubGraphTraverser(g);
         HugeTraverser.PathSet paths = traverser.rings(source, dir, edgeLabel,
                                                       depth, sourceInRing,
-                                                      degree, capacity, limit);
+                                                      maxDegree, capacity, limit);
         return manager.serializer(g).writePaths("rings", paths, false);
     }
 }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/SameNeighborsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/SameNeighborsAPI.java
@@ -19,7 +19,7 @@
 
 package com.baidu.hugegraph.api.traversers;
 
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
 import java.util.Set;
@@ -63,12 +63,12 @@ public class SameNeighborsAPI extends API {
                       @QueryParam("direction") String direction,
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("limit")
                       @DefaultValue(DEFAULT_PATHS_LIMIT) long limit) {
         LOG.debug("Graph [{}] get same neighbors between '{}' and '{}' with " +
                   "direction {}, edge label {}, max degree '{}' and limit '{}'",
-                  graph, vertex, other, direction, edgeLabel, degree, limit);
+                  graph, vertex, other, direction, edgeLabel, maxDegree, limit);
 
         Id sourceId = VertexAPI.checkAndParseVertexId(vertex);
         Id targetId = VertexAPI.checkAndParseVertexId(other);
@@ -77,7 +77,7 @@ public class SameNeighborsAPI extends API {
         HugeGraph g = graph(manager, graph);
         SameNeighborTraverser traverser = new SameNeighborTraverser(g);
         Set<Id> neighbors = traverser.sameNeighbors(sourceId, targetId, dir,
-                                                    edgeLabel, degree, limit);
+                                                    edgeLabel, maxDegree, limit);
         return manager.serializer(g).writeList("same_neighbors", neighbors);
     }
 }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/ShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/ShortestPathAPI.java
@@ -22,7 +22,7 @@ package com.baidu.hugegraph.api.traversers;
 import java.util.List;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
 import javax.inject.Singleton;
 import javax.ws.rs.DefaultValue;
@@ -66,16 +66,16 @@ public class ShortestPathAPI extends API {
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("max_depth") int depth,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("skip_degree")
                       @DefaultValue("0") long skipDegree,
                       @QueryParam("capacity")
                       @DefaultValue(DEFAULT_CAPACITY) long capacity) {
         LOG.debug("Graph [{}] get shortest path from '{}', to '{}' with " +
                   "direction {}, edge label {}, max depth '{}', " +
-                  "max degree '{}', skipped degree '{}' and capacity '{}'",
+                  "max degree '{}', skipped maxDegree '{}' and capacity '{}'",
                   graph, source, target, direction, edgeLabel, depth,
-                  degree, skipDegree, capacity);
+                  maxDegree, skipDegree, capacity);
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
@@ -89,7 +89,7 @@ public class ShortestPathAPI extends API {
                                   ImmutableList.of(edgeLabel);
         HugeTraverser.Path path = traverser.shortestPath(sourceId, targetId,
                                                          dir, edgeLabels, depth,
-                                                         degree, skipDegree,
+                                                         maxDegree, skipDegree,
                                                          capacity);
         return manager.serializer(g).writeList("path", path.vertices());
     }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/SingleSourceShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/SingleSourceShortestPathAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_PATHS_LIMIT;
 
 import java.util.Iterator;
@@ -67,7 +67,7 @@ public class SingleSourceShortestPathAPI extends API {
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("weight") String weight,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("skip_degree")
                       @DefaultValue("0") long skipDegree,
                       @QueryParam("capacity")
@@ -79,7 +79,7 @@ public class SingleSourceShortestPathAPI extends API {
                   "with direction {}, edge label {}, weight property {}, " +
                   "max degree '{}', limit '{}' and with vertex '{}'",
                   graph, source, direction, edgeLabel,
-                  weight, degree, withVertex);
+                  weight, maxDegree, withVertex);
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Directions dir = Directions.convert(EdgeAPI.parseDirection(direction));
@@ -89,7 +89,7 @@ public class SingleSourceShortestPathAPI extends API {
                 new SingleSourceShortestPathTraverser(g);
         WeightedPaths paths = traverser.singleSourceShortestPaths(
                               sourceId, dir, edgeLabel, weight,
-                              degree, skipDegree, capacity, limit);
+                              maxDegree, skipDegree, capacity, limit);
         Iterator<Vertex> iterator = QueryResults.emptyIterator();
         assert paths != null;
         if (!paths.isEmpty() && withVertex) {

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/TemplatePathsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/TemplatePathsAPI.java
@@ -132,9 +132,9 @@ public class TemplatePathsAPI extends TraverserAPI {
         @JsonProperty("with_ring")
         public boolean withRing = false;
         @JsonProperty("capacity")
-        public long capacity = Long.valueOf(DEFAULT_CAPACITY);
+        public long capacity = Long.parseLong(DEFAULT_CAPACITY);
         @JsonProperty("limit")
-        public long limit = Long.valueOf(DEFAULT_PATHS_LIMIT);
+        public long limit = Long.parseLong(DEFAULT_PATHS_LIMIT);
         @JsonProperty("with_vertex")
         public boolean withVertex = false;
 

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/TemplatePathsAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/TemplatePathsAPI.java
@@ -117,7 +117,7 @@ public class TemplatePathsAPI extends TraverserAPI {
     private static RepeatEdgeStep repeatEdgeStep(HugeGraph graph,
                                                  TemplatePathStep step) {
         return new RepeatEdgeStep(graph, step.direction, step.labels,
-                                  step.properties, step.degree,
+                                  step.properties, step.maxDegree,
                                   step.skipDegree, step.maxTimes);
     }
 
@@ -157,10 +157,11 @@ public class TemplatePathsAPI extends TraverserAPI {
         @Override
         public String toString() {
             return String.format("TemplatePathStep{direction=%s,labels=%s," +
-                                 "properties=%s,degree=%s,skipDegree=%s," +
+                                 "properties=%s,maxDegree=%s,skipDegree=%s," +
                                  "maxTimes=%s}",
                                  this.direction, this.labels, this.properties,
-                                 this.degree, this.skipDegree, this.maxTimes);
+                                 this.maxDegree, this.skipDegree,
+                                 this.maxTimes);
         }
     }
 }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/TraverserAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/TraverserAPI.java
@@ -26,6 +26,7 @@ import com.baidu.hugegraph.HugeGraph;
 import com.baidu.hugegraph.api.API;
 import com.baidu.hugegraph.traversal.algorithm.steps.EdgeStep;
 import com.baidu.hugegraph.type.define.Directions;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
@@ -45,6 +46,7 @@ public class TraverserAPI extends API {
         public List<String> labels;
         @JsonProperty("properties")
         public Map<String, Object> properties;
+        @JsonAlias("degree")
         @JsonProperty("max_degree")
         public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/TraverserAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/TraverserAPI.java
@@ -28,13 +28,13 @@ import com.baidu.hugegraph.traversal.algorithm.steps.EdgeStep;
 import com.baidu.hugegraph.type.define.Directions;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
 public class TraverserAPI extends API {
 
     protected static EdgeStep step(HugeGraph graph, Step step) {
         return new EdgeStep(graph, step.direction, step.labels, step.properties,
-                            step.degree, step.skipDegree);
+                            step.maxDegree, step.skipDegree);
     }
 
     protected static class Step {
@@ -45,17 +45,17 @@ public class TraverserAPI extends API {
         public List<String> labels;
         @JsonProperty("properties")
         public Map<String, Object> properties;
-        @JsonProperty("degree")
-        public long degree = Long.valueOf(DEFAULT_DEGREE);
+        @JsonProperty("max_degree")
+        public long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")
         public long skipDegree = 0L;
 
         @Override
         public String toString() {
             return String.format("Step{direction=%s,labels=%s,properties=%s," +
-                                 "degree=%s,skipDegree=%s}",
+                                 "maxDegree=%s,skipDegree=%s}",
                                  this.direction, this.labels, this.properties,
-                                 this.degree, this.skipDegree);
+                                 this.maxDegree, this.skipDegree);
         }
     }
 }

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/TraverserAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/TraverserAPI.java
@@ -46,7 +46,7 @@ public class TraverserAPI extends API {
         @JsonProperty("properties")
         public Map<String, Object> properties;
         @JsonProperty("max_degree")
-        public long maxDegree = Long.valueOf(DEFAULT_MAX_DEGREE);
+        public long maxDegree = Long.parseLong(DEFAULT_MAX_DEGREE);
         @JsonProperty("skip_degree")
         public long skipDegree = 0L;
 

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/WeightedShortestPathAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/WeightedShortestPathAPI.java
@@ -20,7 +20,7 @@
 package com.baidu.hugegraph.api.traversers;
 
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_CAPACITY;
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
 import java.util.Iterator;
 
@@ -68,7 +68,7 @@ public class WeightedShortestPathAPI extends API {
                       @QueryParam("label") String edgeLabel,
                       @QueryParam("weight") String weight,
                       @QueryParam("max_degree")
-                      @DefaultValue(DEFAULT_DEGREE) long degree,
+                      @DefaultValue(DEFAULT_MAX_DEGREE) long maxDegree,
                       @QueryParam("skip_degree")
                       @DefaultValue("0") long skipDegree,
                       @QueryParam("capacity")
@@ -78,8 +78,8 @@ public class WeightedShortestPathAPI extends API {
                   "'{}' with direction {}, edge label {}, weight property {}, " +
                   "max degree '{}', skip degree '{}', capacity '{}', " +
                   "and with vertex '{}'",
-                  graph, source, target, direction, edgeLabel, weight, degree,
-                  skipDegree, capacity, withVertex);
+                  graph, source, target, direction, edgeLabel, weight,
+                  maxDegree, skipDegree, capacity, withVertex);
 
         Id sourceId = VertexAPI.checkAndParseVertexId(source);
         Id targetId = VertexAPI.checkAndParseVertexId(target);
@@ -92,7 +92,7 @@ public class WeightedShortestPathAPI extends API {
 
         NodeWithWeight path = traverser.weightedShortestPath(
                               sourceId, targetId, dir, edgeLabel, weight,
-                              degree, skipDegree, capacity);
+                              maxDegree, skipDegree, capacity);
         Iterator<Vertex> iterator = QueryResults.emptyIterator();
         if (path != null && withVertex) {
             assert !path.node().path().isEmpty();

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/version/ApiVersion.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/version/ApiVersion.java
@@ -61,7 +61,7 @@ public final class ApiVersion {
      * [0.20] HugeGraph-1210: Add paths api to find paths between two nodes
      * [0.21] HugeGraph-1197: Expose scan api for hugegraph-spark
      * [0.22] HugeGraph-1162: Support authentication and permission control
-     * [0.23] HugeGraph-1176: Support degree and capacity for traverse api
+     * [0.23] HugeGraph-1176: Support maxDegree and capacity for traverse api
      * [0.24] HugeGraph-1261: Add param offset for vertex/edge list API
      * [0.25] HugeGraph-1272: Support set/clear restore status of graph
      * [0.26] HugeGraph-1273: Add some monitoring counters to integrate with
@@ -75,7 +75,7 @@ public final class ApiVersion {
      * [0.31] Issue-182: Support restore graph in restoring and merging mode
      *
      * version 0.9:
-     * [0.32] Issue-250: Keep depth and degree consistent for traverser api
+     * [0.32] Issue-250: Keep depth and maxDegree consistent for traverser api
      * [0.33] Issue-305: Implement customized paths and crosspoints RESTful API
      * [0.34] Issue-307: Let VertexAPI use simplified property serializer
      * [0.35] Issue-287: Support pagination when do index query

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/version/ApiVersion.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/version/ApiVersion.java
@@ -61,7 +61,7 @@ public final class ApiVersion {
      * [0.20] HugeGraph-1210: Add paths api to find paths between two nodes
      * [0.21] HugeGraph-1197: Expose scan api for hugegraph-spark
      * [0.22] HugeGraph-1162: Support authentication and permission control
-     * [0.23] HugeGraph-1176: Support maxDegree and capacity for traverse api
+     * [0.23] HugeGraph-1176: Support degree and capacity for traverse api
      * [0.24] HugeGraph-1261: Add param offset for vertex/edge list API
      * [0.25] HugeGraph-1272: Support set/clear restore status of graph
      * [0.26] HugeGraph-1273: Add some monitoring counters to integrate with
@@ -75,7 +75,7 @@ public final class ApiVersion {
      * [0.31] Issue-182: Support restore graph in restoring and merging mode
      *
      * version 0.9:
-     * [0.32] Issue-250: Keep depth and maxDegree consistent for traverser api
+     * [0.32] Issue-250: Keep depth and degree consistent for traverser api
      * [0.33] Issue-305: Implement customized paths and crosspoints RESTful API
      * [0.34] Issue-307: Let VertexAPI use simplified property serializer
      * [0.35] Issue-287: Support pagination when do index query

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/version/ApiVersion.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/version/ApiVersion.java
@@ -110,7 +110,7 @@ public final class ApiVersion {
      *        multi-node-shortest-path, jaccard-similar and template-paths
      * [0.59] Issue-1333: Support graph read mode for olap property
      * [0.60] Issue-1392: Support create and resume snapshot
-     * [0.61] Issue-1433: Unify naming of degree for olap algorithms
+     * [0.61] Issue-1433: Unify naming of degree for oltp algorithms
      */
 
     // The second parameter of Version.of() is for IDE running without JAR

--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/version/ApiVersion.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/version/ApiVersion.java
@@ -110,10 +110,11 @@ public final class ApiVersion {
      *        multi-node-shortest-path, jaccard-similar and template-paths
      * [0.59] Issue-1333: Support graph read mode for olap property
      * [0.60] Issue-1392: Support create and resume snapshot
+     * [0.61] Issue-1433: Unify naming of degree for olap algorithms
      */
 
     // The second parameter of Version.of() is for IDE running without JAR
-    public static final Version VERSION = Version.of(ApiVersion.class, "0.60");
+    public static final Version VERSION = Version.of(ApiVersion.class, "0.61");
 
     public static final void check() {
         // Check version of hugegraph-core. Firstly do check from version 0.3

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -71,7 +71,7 @@ public class HugeTraverser {
     public static final String DEFAULT_ELEMENTS_LIMIT = "10000000";
     public static final String DEFAULT_PATHS_LIMIT = "10";
     public static final String DEFAULT_LIMIT = "100";
-    public static final String DEFAULT_DEGREE = "10000";
+    public static final String DEFAULT_MAX_DEGREE = "10000";
     public static final String DEFAULT_SKIP_DEGREE = "100000";
     public static final String DEFAULT_SAMPLE = "100";
     public static final String DEFAULT_MAX_DEPTH = "50";

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/EdgeStep.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/EdgeStep.java
@@ -66,7 +66,7 @@ public class EdgeStep {
     public EdgeStep(HugeGraph g, Directions direction, List<String> labels,
                     Map<String, Object> properties) {
         this(g, direction, labels, properties,
-             Long.valueOf(DEFAULT_MAX_DEGREE), 0L);
+             Long.parseLong(DEFAULT_MAX_DEGREE), 0L);
     }
 
     public EdgeStep(HugeGraph g, Directions direction, List<String> labels,

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/EdgeStep.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/EdgeStep.java
@@ -19,7 +19,7 @@
 
 package com.baidu.hugegraph.traversal.algorithm.steps;
 
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
 
 import java.util.HashMap;
@@ -66,7 +66,7 @@ public class EdgeStep {
     public EdgeStep(HugeGraph g, Directions direction, List<String> labels,
                     Map<String, Object> properties) {
         this(g, direction, labels, properties,
-             Long.valueOf(DEFAULT_DEGREE), 0L);
+             Long.valueOf(DEFAULT_MAX_DEGREE), 0L);
     }
 
     public EdgeStep(HugeGraph g, Directions direction, List<String> labels,

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/RepeatEdgeStep.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/RepeatEdgeStep.java
@@ -19,7 +19,7 @@
 
 package com.baidu.hugegraph.traversal.algorithm.steps;
 
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 
 import java.util.List;
 import java.util.Map;
@@ -76,7 +76,7 @@ public class RepeatEdgeStep extends EdgeStep {
                           List<String> labels,
                           Map<String, Object> properties) {
         this(g, direction, labels, properties,
-             Long.valueOf(DEFAULT_DEGREE), 0L, 1);
+             Long.valueOf(DEFAULT_MAX_DEGREE), 0L, 1);
     }
 
     public RepeatEdgeStep(HugeGraph g, Directions direction,

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/RepeatEdgeStep.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/RepeatEdgeStep.java
@@ -76,7 +76,7 @@ public class RepeatEdgeStep extends EdgeStep {
                           List<String> labels,
                           Map<String, Object> properties) {
         this(g, direction, labels, properties,
-             Long.valueOf(DEFAULT_MAX_DEGREE), 0L, 1);
+             Long.parseLong(DEFAULT_MAX_DEGREE), 0L, 1);
     }
 
     public RepeatEdgeStep(HugeGraph g, Directions direction,

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/WeightedEdgeStep.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/WeightedEdgeStep.java
@@ -71,8 +71,8 @@ public class WeightedEdgeStep {
                         "The sample must be > 0 or == -1, but got: %s",
                         sample);
         E.checkArgument(maxDegree == NO_LIMIT || maxDegree >= sample,
-                        "Max degree must be greater than or equal to sample," +
-                        " but got max degree %s and sample %s",
+                        "The max_degree must be greater than or equal to " +
+                        "sample, but got max_degree %s and sample %s",
                         maxDegree, sample);
 
         this.edgeStep = new EdgeStep(g, direction, labels, properties,

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/WeightedEdgeStep.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/WeightedEdgeStep.java
@@ -59,8 +59,8 @@ public class WeightedEdgeStep {
     public WeightedEdgeStep(HugeGraph g, Directions direction, List<String> labels,
                             Map<String, Object> properties) {
         this(g, direction, labels, properties,
-             Long.valueOf(DEFAULT_MAX_DEGREE), 0L, null, 0.0D,
-             Long.valueOf(DEFAULT_SAMPLE));
+             Long.parseLong(DEFAULT_MAX_DEGREE), 0L, null, 0.0D,
+             Long.parseLong(DEFAULT_SAMPLE));
     }
 
     public WeightedEdgeStep(HugeGraph g, Directions direction, List<String> labels,

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/WeightedEdgeStep.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/steps/WeightedEdgeStep.java
@@ -19,7 +19,7 @@
 
 package com.baidu.hugegraph.traversal.algorithm.steps;
 
-import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_DEGREE;
+import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_MAX_DEGREE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.DEFAULT_SAMPLE;
 import static com.baidu.hugegraph.traversal.algorithm.HugeTraverser.NO_LIMIT;
 
@@ -59,24 +59,24 @@ public class WeightedEdgeStep {
     public WeightedEdgeStep(HugeGraph g, Directions direction, List<String> labels,
                             Map<String, Object> properties) {
         this(g, direction, labels, properties,
-             Long.valueOf(DEFAULT_DEGREE), 0L, null, 0.0D,
+             Long.valueOf(DEFAULT_MAX_DEGREE), 0L, null, 0.0D,
              Long.valueOf(DEFAULT_SAMPLE));
     }
 
     public WeightedEdgeStep(HugeGraph g, Directions direction, List<String> labels,
                             Map<String, Object> properties,
-                            long degree, long skipDegree,
+                            long maxDegree, long skipDegree,
                             String weightBy, double defaultWeight, long sample) {
         E.checkArgument(sample > 0L || sample == NO_LIMIT,
                         "The sample must be > 0 or == -1, but got: %s",
                         sample);
-        E.checkArgument(degree == NO_LIMIT || degree >= sample,
-                        "Degree must be greater than or equal to sample," +
-                        " but got degree %s and sample %s",
-                        degree, sample);
+        E.checkArgument(maxDegree == NO_LIMIT || maxDegree >= sample,
+                        "Max degree must be greater than or equal to sample," +
+                        " but got max degree %s and sample %s",
+                        maxDegree, sample);
 
         this.edgeStep = new EdgeStep(g, direction, labels, properties,
-                                     degree, skipDegree);
+                                     maxDegree, skipDegree);
         if (weightBy != null) {
             this.weightBy = g.propertyKey(weightBy);
         } else {


### PR DESCRIPTION
Note: also keep `degree` for alias in `Step*` request