### PR TITLE
Fix Fusiform similarity api return all vertices when similars is empty

### DIFF
--- a/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/FusiformSimilarityAPI.java
+++ b/hugegraph-api/src/main/java/com/baidu/hugegraph/api/traversers/FusiformSimilarityAPI.java
@@ -113,7 +113,7 @@ public class FusiformSimilarityAPI extends API {
         CloseableIterator.closeIterator(sources);
 
         Iterator<Vertex> iterator = QueryResults.emptyIterator();
-        if (request.withVertex) {
+        if (request.withVertex && !result.isEmpty()) {
             iterator = g.vertices(result.vertices().toArray());
         }
         return manager.serializer(g).writeSimilars(result, iterator);


### PR DESCRIPTION
Fix Fusiform similarity api return all vertices when similars is empty