### PR TITLE
fix: replace '+' to '%2B' to handle page strs encode

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/page/PageState.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/page/PageState.java
@@ -77,7 +77,7 @@ public class PageState {
         E.checkNotNull(page, "page");
         /*
          * URLDecoder will auto decode '+' to space in url due to the request
-         * of HTML4, so we choose to replace the space to '+' after get it
+         * of HTML4, so we choose to replace the space to '+' after getting it
          * More details refer to #1437
          */
         page = page.replace(SPACE, PLUS);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/page/PageState.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/page/PageState.java
@@ -73,7 +73,8 @@ public class PageState {
 
     public static PageState fromString(String page) {
         E.checkNotNull(page, "page");
-        return fromBytes(toBytes(page));
+        String originalPage = page.replace(' ', '+');
+        return fromBytes(toBytes(originalPage));
     }
 
     public static PageState fromBytes(byte[] bytes) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/page/PageState.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/page/PageState.java
@@ -29,6 +29,8 @@ public class PageState {
 
     public static final byte[] EMPTY_BYTES = new byte[0];
     public static final PageState EMPTY = new PageState(EMPTY_BYTES, 0, 0);
+    public static final char SPACE = ' ';
+    public static final char PLUS = '+';
 
     private final byte[] position;
     private final int offset;
@@ -73,8 +75,13 @@ public class PageState {
 
     public static PageState fromString(String page) {
         E.checkNotNull(page, "page");
-        String originalPage = page.replace(' ', '+');
-        return fromBytes(toBytes(originalPage));
+        /*
+         * URLDecoder will auto decode '+' to space in url due to the request
+         * of HTML4, so we choose to replace the space to '+' after get it
+         * More details refer to #1437
+         */
+        page = page.replace(SPACE, PLUS);
+        return fromBytes(toBytes(page));
     }
 
     public static PageState fromBytes(byte[] bytes) {

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
@@ -6670,8 +6670,7 @@ public class VertexCoreTest extends BaseCoreTest {
     }
 
     @Test
-    public void testQueryByPageWithSpecialBase64CharacterPage() {
-        // Assert decode '+' and '/' and '=' and space successfully
+    public void testQueryByPageWithSpecialBase64Chars() {
         final String pageWith3Base64Chars = "AAAAADsyABwAEAqI546LS6WW57unBgA" +
                                             "EAAAAAPB////+8H////4alhxAZS8va6" +
                                             "opcAKpklipAAQAAAAAAAAAAQ==";
@@ -6679,25 +6678,25 @@ public class VertexCoreTest extends BaseCoreTest {
         final String pageWithSpace = "AAAAADsyABwAEAqI546LS6WW57unBgAEAAAAAP" +
                                      "B//// 8H////4alhxAZS8va6opcAKpklipAAQA" +
                                      "AAAAAAAAAQ==";
-        Assert.assertNotNull(PageState.fromString(pageWith3Base64Chars));
 
-        byte[] decodePlus = PageState.fromString(pageWith3Base64Chars)
-                                     .position();
-        byte[] decodeSpace = PageState.fromString(pageWithSpace).position();
-
-        Assert.assertTrue(Arrays.equals(decodePlus, decodeSpace));
         Assume.assumeTrue("Not support paging",
                           storeFeatures().supportsQueryByPage());
 
         HugeGraph graph = graph();
         init100Books();
 
-        // Assert not throw exception when contains '+' or '/' or '=' or space
         // Contains valid character '+' and '/' and '='
-        graph.traversal().V().has("~page", pageWith3Base64Chars)
-             .limit(10);
+        GraphTraversal<Vertex, Vertex> traversal;
+        traversal = graph.traversal().V()
+                         .has("~page", pageWith3Base64Chars).limit(10);
+        Assert.assertNotNull(traversal);
+        CloseableIterator.closeIterator(traversal);
+
         // Contains invalid base64 character ' ', will be replaced to '+'
-        graph.traversal().V().has("~page", pageWithSpace).limit(10);
+        traversal = graph.traversal().V()
+                         .has("~page", pageWithSpace).limit(10);
+        Assert.assertNotNull(traversal);
+        CloseableIterator.closeIterator(traversal);
     }
 
     @Test

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
@@ -21,6 +21,7 @@ package com.baidu.hugegraph.core;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -6668,33 +6669,33 @@ public class VertexCoreTest extends BaseCoreTest {
         });
     }
 
-
     @Test
     public void testQueryByPageWithSpecialBase64CharacterPage() {
-        // TODO: Not ready for commit, lack valid page contains '+' or '/'
-        // Assert decode space succees first
-        final String pageWithPlus = "5p2+"; // 松
-        final String pageWithSlash = "c3ViamVjdHM/X2Q9MQ==";
-        final String pageWithSpace = "5p2 ";
+        // Assert decode '+' and '/' and '=' and space successfully
+        final String pageWith3Base64Chars = "AAAAADsyABwAEAqI546LS6WW57unBgA" +
+                                            "EAAAAAPB////+8H////4alhxAZS8va6" +
+                                            "opcAKpklipAAQAAAAAAAAAAQ==";
 
-        // Throws 'java.nio.BufferUnderflowException' now (bad test case)
-        PageState.fromString(pageWithSlash);
-        Assert.assertEquals(PageState.fromString(pageWithPlus),
-                            PageState.fromString(pageWithSpace));
+        final String pageWithSpace = "AAAAADsyABwAEAqI546LS6WW57unBgAEAAAAAP" +
+                                     "B//// 8H////4alhxAZS8va6opcAKpklipAAQA" +
+                                     "AAAAAAAAAQ==";
+        Assert.assertNotNull(PageState.fromString(pageWith3Base64Chars));
 
+        byte[] decodePlus = PageState.fromString(pageWith3Base64Chars)
+                                     .position();
+        byte[] decodeSpace = PageState.fromString(pageWithSpace).position();
+
+        Assert.assertTrue(Arrays.equals(decodePlus, decodeSpace));
         Assume.assumeTrue("Not support paging",
                           storeFeatures().supportsQueryByPage());
 
         HugeGraph graph = graph();
         init100Books();
 
-        // Assert not throws exception when contains '+' or '/'
-        // Contains valid character '+'
-        graph.traversal().V().has("~page", pageWithPlus).limit(10);
-
-        // Contains valid character '/'
-        graph.traversal().V().has("~page", pageWithSlash).limit(10);
-
+        // Assert not throw exception when contains '+' or '/' or '=' or space
+        // Contains valid character '+' and '/' and '='
+        graph.traversal().V().has("~page", pageWith3Base64Chars)
+             .limit(10);
         // Contains invalid base64 character ' ', will be replaced to '+'
         graph.traversal().V().has("~page", pageWithSpace).limit(10);
     }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
@@ -6671,6 +6671,8 @@ public class VertexCoreTest extends BaseCoreTest {
 
     @Test
     public void testQueryByPageWithSpecialBase64Chars() {
+        Assume.assumeTrue("Not support paging",
+                          storeFeatures().supportsQueryByPage());
         final String pageWith3Base64Chars = "AAAAADsyABwAEAqI546LS6WW57unBgA" +
                                             "EAAAAAPB////+8H////4alhxAZS8va6" +
                                             "opcAKpklipAAQAAAAAAAAAAQ==";
@@ -6678,9 +6680,6 @@ public class VertexCoreTest extends BaseCoreTest {
         final String pageWithSpace = "AAAAADsyABwAEAqI546LS6WW57unBgAEAAAAAP" +
                                      "B//// 8H////4alhxAZS8va6opcAKpklipAAQA" +
                                      "AAAAAAAAAQ==";
-
-        Assume.assumeTrue("Not support paging",
-                          storeFeatures().supportsQueryByPage());
 
         HugeGraph graph = graph();
         init100Books();

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/UnitTestSuite.java
@@ -37,6 +37,7 @@ import com.baidu.hugegraph.unit.core.DataTypeTest;
 import com.baidu.hugegraph.unit.core.DirectionsTest;
 import com.baidu.hugegraph.unit.core.ExceptionTest;
 import com.baidu.hugegraph.unit.core.LocksTableTest;
+import com.baidu.hugegraph.unit.core.PageStateTest;
 import com.baidu.hugegraph.unit.core.QueryTest;
 import com.baidu.hugegraph.unit.core.RangeTest;
 import com.baidu.hugegraph.unit.core.RolePermissionTest;
@@ -99,6 +100,7 @@ import com.baidu.hugegraph.unit.util.VersionTest;
     ExceptionTest.class,
     BackendStoreSystemInfoTest.class,
     TraversalUtilTest.class,
+    PageStateTest.class,
 
     /* serializer */
     BytesBufferTest.class,

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/PageStateTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/PageStateTest.java
@@ -23,21 +23,35 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import com.baidu.hugegraph.backend.BackendException;
 import com.baidu.hugegraph.backend.page.PageState;
 import com.baidu.hugegraph.testutil.Assert;
 
 public class PageStateTest {
 
+    private String pageWith3Base64Chars = "AAAAADsyABwAEAqI546LS6WW57unBgA" +
+                                          "EAAAAAPB////+8H////4alhxAZS8va6" +
+                                          "opcAKpklipAAQAAAAAAAAAAQ==";
+
+    private String pageWithSpace = "AAAAADsyABwAEAqI546LS6WW57unBgAEAAAAAP" +
+                                   "B//// 8H////4alhxAZS8va6opcAKpklipAAQA" +
+                                   "AAAAAAAAAQ==";
+
+    @Test
+    public void testOriginalStringPageToBytes() {
+        byte[] validPage = PageState.toBytes(pageWith3Base64Chars);
+        Assert.assertNotNull(validPage);
+
+        Assert.assertThrows(BackendException.class, () -> {
+            PageState.toBytes(pageWithSpace);
+        }, e -> {
+            Assert.assertContains("Invalid page:", e.toString());
+        });
+    }
+
     @Test
     public void testDecodePageWithSpecialBase64Chars() {
         // Assert decode '+' and '/' and '=' and space successfully
-        final String pageWith3Base64Chars = "AAAAADsyABwAEAqI546LS6WW57unBgA" +
-                                            "EAAAAAPB////+8H////4alhxAZS8va6" +
-                                            "opcAKpklipAAQAAAAAAAAAAQ==";
-
-        final String pageWithSpace = "AAAAADsyABwAEAqI546LS6WW57unBgAEAAAAAP" +
-                                     "B//// 8H////4alhxAZS8va6opcAKpklipAAQA" +
-                                     "AAAAAAAAAQ==";
         Assert.assertNotNull(PageState.fromString(pageWith3Base64Chars));
 
         byte[] decodePlus = PageState.fromString(pageWith3Base64Chars)
@@ -45,5 +59,32 @@ public class PageStateTest {
         byte[] decodeSpace = PageState.fromString(pageWithSpace).position();
 
         Assert.assertTrue(Arrays.equals(decodePlus, decodeSpace));
+    }
+
+    @Test
+    public void testDecodePageWithInvalidStringPage() {
+        final String invalidPageWithBase64Chars = "dGVzdCBiYXNlNjQ=";
+
+        Assert.assertThrows(BackendException.class, () -> {
+            PageState.fromString(invalidPageWithBase64Chars);
+        }, e -> {
+            Assert.assertContains("Invalid page: '0x", e.toString());
+        });
+
+        final String invalidBase64Chars = "!abc~";
+        Assert.assertThrows(BackendException.class, () -> {
+            PageState.fromString(invalidBase64Chars);
+        }, e -> {
+            Assert.assertContains("Invalid page:", e.toString());
+        });
+    }
+
+    @Test
+    public void testEmptyPageState() {
+        Assert.assertEquals(0, PageState.EMPTY.offset());
+        Assert.assertNull(PageState.EMPTY.toString());
+
+        Assert.assertEquals(PageState.EMPTY,
+                            PageState.fromBytes(PageState.EMPTY_BYTES));
     }
 }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/PageStateTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/PageStateTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.unit.core;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.baidu.hugegraph.backend.page.PageState;
+import com.baidu.hugegraph.testutil.Assert;
+
+public class PageStateTest {
+
+    @Test
+    public void testDecodePageWithSpecialBase64Chars() {
+        // Assert decode '+' and '/' and '=' and space successfully
+        final String pageWith3Base64Chars = "AAAAADsyABwAEAqI546LS6WW57unBgA" +
+                                            "EAAAAAPB////+8H////4alhxAZS8va6" +
+                                            "opcAKpklipAAQAAAAAAAAAAQ==";
+
+        final String pageWithSpace = "AAAAADsyABwAEAqI546LS6WW57unBgAEAAAAAP" +
+                                     "B//// 8H////4alhxAZS8va6opcAKpklipAAQA" +
+                                     "AAAAAAAAAQ==";
+        Assert.assertNotNull(PageState.fromString(pageWith3Base64Chars));
+
+        byte[] decodePlus = PageState.fromString(pageWith3Base64Chars)
+                                     .position();
+        byte[] decodeSpace = PageState.fromString(pageWithSpace).position();
+
+        Assert.assertTrue(Arrays.equals(decodePlus, decodeSpace));
+    }
+}


### PR DESCRIPTION
When we get a `page` value from vertex/edge API like this
```javascript
GET xxx/graphs/hugegraph/graph/vertices?page&limit=3
```

We will get `page = xxxxx` to scan next page's values. however, when we get page value containis `+`, like this:
`ab4c+def123`

The url decoder(`@QueryParam`) will auto encode it to a space(refer to [W3C-HTML4.01](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1)'s request), which leads to some error. So we condiser to 3 ways to solve it:
1. replace all `+` to `%2B` **before return** page to users (refer to[ W3C hex code](https://www.w3school.com.cn/tags/html_ref_urlencode.asp))
2. when param contains `+`, server will get a space, **then** we replace all space to `+`
3. use `getQueryString()` from HTTPRequest's URI, then split it and handle params.


