### PR TITLE
refact: use batch flush & async way to output log

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/auth/ResourceObject.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/auth/ResourceObject.java
@@ -58,8 +58,10 @@ public class ResourceObject<V> {
         if (this.type.isAuth()) {
             operated = ((AuthElement) this.operated).idString();
         }
-        return String.format("Resource{graph=%s,type=%s,operated=%s}",
-                             this.graph, this.type, operated);
+
+        StringBuilder sb = new StringBuilder("Resource{graph=");
+        return sb.append(this.graph).append(",type=").append(this.type)
+                 .append(",operated=").append(operated).append("}").toString();
     }
 
     public static ResourceObject<SchemaElement> of(String graph,

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/auth/ResourceObject.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/auth/ResourceObject.java
@@ -59,9 +59,15 @@ public class ResourceObject<V> {
             operated = ((AuthElement) this.operated).idString();
         }
 
-        StringBuilder sb = new StringBuilder(64);
-        return sb.append("Resource{graph=").append(this.graph).append(",type=")
-                 .append(this.type).append(",operated=").append(operated)
+        String typeStr = this.type.toString();
+        String operatedStr = operated.toString();
+        int capacity = this.graph.length() + typeStr.length() +
+                       operatedStr.length() + 36;
+
+        StringBuilder sb = new StringBuilder(capacity);
+        return sb.append("Resource{graph=").append(this.graph)
+                 .append(",type=").append(typeStr)
+                 .append(",operated=").append(operatedStr)
                  .append("}").toString();
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/auth/ResourceObject.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/auth/ResourceObject.java
@@ -59,9 +59,10 @@ public class ResourceObject<V> {
             operated = ((AuthElement) this.operated).idString();
         }
 
-        StringBuilder sb = new StringBuilder("Resource{graph=");
-        return sb.append(this.graph).append(",type=").append(this.type)
-                 .append(",operated=").append(operated).append("}").toString();
+        StringBuilder sb = new StringBuilder(64);
+        return sb.append("Resource{graph=").append(this.graph).append(",type=")
+                 .append(this.type).append(",operated=").append(operated)
+                 .append("}").toString();
     }
 
     public static ResourceObject<SchemaElement> of(String graph,

--- a/hugegraph-dist/src/assembly/static/conf/log4j2.xml
+++ b/hugegraph-dist/src/assembly/static/conf/log4j2.xml
@@ -7,13 +7,26 @@
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
         </Console>
 
-        <RollingFile name="file" fileName="logs/hugegraph-server.log"
-                     filePattern="logs/$${date:yyyy-MM}/hugegraph-server-%d{yyyy-MM-dd}-%i.log">
+        <!-- Normal server log config -->
+        <RollingRandomAccessFile name="file" fileName="logs/hugegraph-server.log"
+            filePattern="logs/$${date:yyyy-MM}/hugegraph-server-%d{yyyy-MM-dd}-%i.log"
+            immediateFlush="false">
             <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
             <SizeBasedTriggeringPolicy size="50MB"/>
-        </RollingFile>
+        </RollingRandomAccessFile>
+
+        <!-- Separate audit log, buffer size is 512KB -->
+        <RollingRandomAccessFile name="audit" fileName="logs/audit-hugegraph-server.log"
+            filePattern="logs/$${date:yyyy-MM}/audit-hugegraph-server-%d{yyyy-MM-dd}-%i.log"
+            bufferSize="524288" immediateFlush="false">
+            <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            <!-- Use simple format for audit log to speed up -->
+            <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} - %m%n"/>
+            <SizeBasedTriggeringPolicy size="50MB"/>
+        </RollingRandomAccessFile>
     </appenders>
+
     <loggers>
         <root level="INFO">
             <appender-ref ref="file"/>
@@ -39,8 +52,12 @@
         <logger name="org.apache.commons" level="INFO" additivity="false">
             <appender-ref ref="file"/>
         </logger>
-        <logger name="com.baidu.hugegraph" level="INFO" additivity="false">
+        <!-- Use mixed async way to output logs -->
+        <AsyncLogger name="com.baidu.hugegraph" level="INFO" additivity="false">
             <appender-ref ref="file"/>
-        </logger>
+        </AsyncLogger>
+        <AsyncLogger name="com.baidu.hugegraph.auth" level="INFO" additivity="false">
+            <appender-ref ref="audit"/>
+        </AsyncLogger>
     </loggers>
 </configuration>

--- a/hugegraph-dist/src/main/resources/log4j2.xml
+++ b/hugegraph-dist/src/main/resources/log4j2.xml
@@ -7,13 +7,26 @@
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
         </Console>
 
-        <RollingFile name="file" fileName="logs/hugegraph-server.log"
-                     filePattern="logs/$${date:yyyy-MM}/hugegraph-server-%d{yyyy-MM-dd}-%i.log">
+        <!-- Normal server log config -->
+        <RollingRandomAccessFile name="file" fileName="logs/hugegraph-server.log"
+            filePattern="logs/$${date:yyyy-MM}/hugegraph-server-%d{yyyy-MM-dd}-%i.log"
+            immediateFlush="false">
             <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
             <SizeBasedTriggeringPolicy size="50MB"/>
-        </RollingFile>
+        </RollingRandomAccessFile>
+
+        <!-- Separate audit log, buffer size is 512KB -->
+        <RollingRandomAccessFile name="audit" fileName="logs/audit-hugegraph-server.log"
+            filePattern="logs/$${date:yyyy-MM}/audit-hugegraph-server-%d{yyyy-MM-dd}-%i.log"
+            bufferSize="524288" immediateFlush="false">
+            <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            <!-- Use simple format for audit log to speed up -->
+            <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} - %m%n"/>
+            <SizeBasedTriggeringPolicy size="50MB"/>
+        </RollingRandomAccessFile>
     </appenders>
+
     <loggers>
         <root level="INFO">
             <appender-ref ref="console"/>
@@ -47,9 +60,14 @@
             <appender-ref ref="console"/>
             <appender-ref ref="file"/>
         </logger>
-        <logger name="com.baidu.hugegraph" level="INFO" additivity="false">
+        <!-- Use mixed async way to output logs -->
+        <AsyncLogger name="com.baidu.hugegraph" level="INFO" additivity="false">
             <appender-ref ref="console"/>
             <appender-ref ref="file"/>
-        </logger>
+        </AsyncLogger>
+        <AsyncLogger name="com.baidu.hugegraph.auth" level="INFO" additivity="false">
+            <appender-ref ref="console"/>
+            <appender-ref ref="audit"/>
+        </AsyncLogger>
     </loggers>
 </configuration>

--- a/hugegraph-example/src/main/resources/log4j2.xml
+++ b/hugegraph-example/src/main/resources/log4j2.xml
@@ -7,13 +7,26 @@
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
         </Console>
 
-        <RollingFile name="file" fileName="logs/hugegraph-example.log"
-                     filePattern="logs/$${date:yyyy-MM}/hugegraph-example-%d{yyyy-MM-dd}-%i.log">
+        <!-- Normal server log config -->
+        <RollingRandomAccessFile name="file" fileName="logs/hugegraph-example.log"
+            filePattern="logs/$${date:yyyy-MM}/hugegraph-example-%d{yyyy-MM-dd}-%i.log"
+            immediateFlush="false">
             <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
             <SizeBasedTriggeringPolicy size="50MB"/>
-        </RollingFile>
+        </RollingRandomAccessFile>
+
+        <!-- Separate audit log, buffer size is 512KB -->
+        <RollingRandomAccessFile name="audit" fileName="logs/audit-hugegraph-example.log"
+            filePattern="logs/$${date:yyyy-MM}/audit-hugegraph-example-%d{yyyy-MM-dd}-%i.log"
+            bufferSize="524288" immediateFlush="false">
+            <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            <!-- Use simple format for audit log to speed up -->
+            <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} - %m%n"/>
+            <SizeBasedTriggeringPolicy size="50MB"/>
+        </RollingRandomAccessFile>
     </appenders>
+
     <loggers>
         <root level="INFO">
             <appender-ref ref="console"/>
@@ -47,9 +60,14 @@
             <appender-ref ref="console"/>
             <appender-ref ref="file"/>
         </logger>
-        <logger name="com.baidu.hugegraph" level="INFO" additivity="false">
+        <!-- Use mixed async way to output logs -->
+        <AsyncLogger name="com.baidu.hugegraph" level="INFO" additivity="false">
             <appender-ref ref="console"/>
             <appender-ref ref="file"/>
-        </logger>
+        </AsyncLogger>
+        <AsyncLogger name="com.baidu.hugegraph.auth" level="INFO" additivity="false">
+            <appender-ref ref="console"/>
+            <appender-ref ref="audit"/>
+        </AsyncLogger>
     </loggers>
 </configuration>

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
@@ -233,11 +233,7 @@ public class MysqlSessions extends BackendSessionPool {
         if (timeout != null) {
             builder.setParameter("socketTimeout", String.valueOf(timeout));
         }
-
-        String finalUrl = builder.toString();
-        LOG.info("The jdbc prefix url = '%s', and the final jdbc url = '%s'",
-                 url, finalUrl);
-        return finalUrl;
+        return builder.toString();
     }
 
     protected String buildUrlPrefix(boolean withDB) {

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSessions.java
@@ -233,7 +233,11 @@ public class MysqlSessions extends BackendSessionPool {
         if (timeout != null) {
             builder.setParameter("socketTimeout", String.valueOf(timeout));
         }
-        return builder.toString();
+
+        String finalUrl = builder.toString();
+        LOG.info("The jdbc prefix url = '%s', and the final jdbc url = '%s'",
+                 url, finalUrl);
+        return finalUrl;
     }
 
     protected String buildUrlPrefix(boolean withDB) {

--- a/hugegraph-test/src/main/resources/log4j2.xml
+++ b/hugegraph-test/src/main/resources/log4j2.xml
@@ -7,13 +7,27 @@
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
         </Console>
 
-        <RollingFile name="file" fileName="logs/hugegraph-test.log"
-                     filePattern="logs/$${date:yyyy-MM}/hugegraph-test-%d{yyyy-MM-dd}-%i.log">
+        <!-- Normal server log config -->
+        <RollingRandomAccessFile name="file" fileName="logs/hugegraph-server.log"
+                                 filePattern="logs/$${date:yyyy-MM}/hugegraph-server-%d{yyyy-MM-dd}-%i.log"
+                                 immediateFlush="false">
             <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
             <SizeBasedTriggeringPolicy size="50MB"/>
-        </RollingFile>
+        </RollingRandomAccessFile>
+
+        <!-- Separate audit log, buffer size is 512KB -->
+        <RollingRandomAccessFile name="audit" fileName="logs/audit.log"
+                                 bufferSize="524288"
+                                 filePattern="logs/$${date:yyyy-MM}/audit-%d{yyyy-MM-dd}-%i.log"
+                                 immediateFlush="false">
+            <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
+            <!-- Use simple format for audit log to speed up -->
+            <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} - %m%n"/>
+            <SizeBasedTriggeringPolicy size="50MB"/>
+        </RollingRandomAccessFile>
     </appenders>
+
     <loggers>
         <root level="INFO">
             <appender-ref ref="console"/>
@@ -47,9 +61,14 @@
             <appender-ref ref="console"/>
             <appender-ref ref="file"/>
         </logger>
-        <logger name="com.baidu.hugegraph" level="INFO" additivity="false">
+        <!-- Use mixed async way to output logs -->
+        <AsyncLogger name="com.baidu.hugegraph" level="INFO" additivity="false">
             <appender-ref ref="console"/>
             <appender-ref ref="file"/>
-        </logger>
+        </AsyncLogger>
+        <AsyncLogger name="com.baidu.hugegraph.auth.HugeGraphAuthProxy" level="INFO" additivity="false">
+            <appender-ref ref="console"/>
+            <appender-ref ref="auth"/>
+        </AsyncLogger>
     </loggers>
 </configuration>

--- a/hugegraph-test/src/main/resources/log4j2.xml
+++ b/hugegraph-test/src/main/resources/log4j2.xml
@@ -8,19 +8,18 @@
         </Console>
 
         <!-- Normal server log config -->
-        <RollingRandomAccessFile name="file" fileName="logs/hugegraph-server.log"
-                                 filePattern="logs/$${date:yyyy-MM}/hugegraph-server-%d{yyyy-MM-dd}-%i.log"
-                                 immediateFlush="false">
+        <RollingRandomAccessFile name="file" fileName="logs/hugegraph-test.log"
+            filePattern="logs/$${date:yyyy-MM}/hugegraph-test-%d{yyyy-MM-dd}-%i.log"
+            immediateFlush="false">
             <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
             <SizeBasedTriggeringPolicy size="50MB"/>
         </RollingRandomAccessFile>
 
         <!-- Separate audit log, buffer size is 512KB -->
-        <RollingRandomAccessFile name="audit" fileName="logs/audit.log"
-                                 bufferSize="524288"
-                                 filePattern="logs/$${date:yyyy-MM}/audit-%d{yyyy-MM-dd}-%i.log"
-                                 immediateFlush="false">
+        <RollingRandomAccessFile name="audit" fileName="logs/audit-hugegraph-test.log"
+            filePattern="logs/$${date:yyyy-MM}/audit-hugegraph-test-%d{yyyy-MM-dd}-%i.log"
+            bufferSize="524288" immediateFlush="false">
             <ThresholdFilter level="TRACE" onMatch="ACCEPT" onMismatch="DENY"/>
             <!-- Use simple format for audit log to speed up -->
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} - %m%n"/>
@@ -66,9 +65,9 @@
             <appender-ref ref="console"/>
             <appender-ref ref="file"/>
         </AsyncLogger>
-        <AsyncLogger name="com.baidu.hugegraph.auth.HugeGraphAuthProxy" level="INFO" additivity="false">
+        <AsyncLogger name="com.baidu.hugegraph.auth" level="INFO" additivity="false">
             <appender-ref ref="console"/>
-            <appender-ref ref="auth"/>
+            <appender-ref ref="audit"/>
         </AsyncLogger>
     </loggers>
 </configuration>


### PR DESCRIPTION
More perf details refer to [doc](https://github.com/hugegraph-ee/hugegraph-designdoc/blob/0d503494efb7c066cc90abb80348c481f756a8d9/hugegraph-process/HugeGraph%E6%9D%83%E9%99%90%E6%80%A7%E8%83%BD%E9%97%AE%E9%A2%98%E5%88%86%E6%9E%90.md), here are some points, for `log4j2`:
1. change appender  to `RandomAccessFile` to improve perf (default is BufferedOutputStream)
2. change to not flush immediately  (default is true)
3. use bigger (512K) buffer size (default is 4k)
4. use (LMAX Disruptor) async way to improve log perf (default is sync)
5. separate audit log & server log to keep sever log clean & readable
6. use simple layout format for audit log
7. enable non-gc mode (_TODO_) 

Others:
1. use `StringBuilder` to reduce about `9%` cost for audit log