### PR TITLE
refact: let kout degree applied to all labels & remove source vertex from kneighbor default results 

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphTransaction.java
@@ -72,6 +72,7 @@ import com.baidu.hugegraph.iterator.BatchMapperIterator;
 import com.baidu.hugegraph.iterator.ExtendableIterator;
 import com.baidu.hugegraph.iterator.FilterIterator;
 import com.baidu.hugegraph.iterator.FlatMapperIterator;
+import com.baidu.hugegraph.iterator.LimitIterator;
 import com.baidu.hugegraph.iterator.ListIterator;
 import com.baidu.hugegraph.iterator.MapperIterator;
 import com.baidu.hugegraph.iterator.WrappedIterator;
@@ -1993,49 +1994,6 @@ public class GraphTransaction extends IndexableTransaction {
                     CloseableIterator.closeIterator(iter);
                 }
             } while (page != null);
-        }
-    }
-
-    // TODO: move to common module
-    public static class LimitIterator<T> extends WrappedIterator<T> {
-
-        private final Iterator<T> originIterator;
-        private final Function<T, Boolean> filterCallback;
-
-        public LimitIterator(Iterator<T> origin, Function<T, Boolean> filter) {
-            this.originIterator = origin;
-            this.filterCallback = filter;
-        }
-
-        @Override
-        protected Iterator<T> originIterator() {
-            return this.originIterator;
-        }
-
-        @Override
-        protected final boolean fetch() {
-            while (this.originIterator.hasNext()) {
-                T next = this.originIterator.next();
-                // Do filter
-                boolean reachLimit = this.filterCallback.apply(next);
-                if (reachLimit) {
-                    this.closeOriginIterator();
-                    return false;
-                }
-                if (next != null) {
-                    assert this.current == none();
-                    this.current = next;
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        protected final void closeOriginIterator() {
-            if (this.originIterator == null) {
-                return;
-            }
-            close(this.originIterator);
         }
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -48,6 +48,7 @@ import com.baidu.hugegraph.config.CoreOptions;
 import com.baidu.hugegraph.exception.NotFoundException;
 import com.baidu.hugegraph.iterator.ExtendableIterator;
 import com.baidu.hugegraph.iterator.FilterIterator;
+import com.baidu.hugegraph.iterator.LimitIterator;
 import com.baidu.hugegraph.iterator.MapperIterator;
 import com.baidu.hugegraph.schema.SchemaLabel;
 import com.baidu.hugegraph.structure.HugeEdge;
@@ -182,10 +183,19 @@ public class HugeTraverser {
         ExtendableIterator<Edge> results = new ExtendableIterator<>();
         for (Id label : labels.keySet()) {
             E.checkNotNull(label, "edge label");
-            // TODO: limit should be applied to all labels
             results.extend(this.edgesOfVertex(source, dir, label, limit));
         }
-        return results;
+
+        if (limit == NO_LIMIT) {
+            return results;
+        }
+
+        Query query = new Query(HugeType.EDGE);
+        query.limit(limit);
+        return new LimitIterator<>(results, e -> {
+            long count = query.goOffset(1L);
+            return query.reachLimit(count - 1L);
+        });
     }
 
     protected Iterator<Edge> edgesOfVertex(Id source, EdgeStep edgeStep) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -190,11 +190,9 @@ public class HugeTraverser {
             return results;
         }
 
-        Query query = new Query(HugeType.EDGE);
-        query.limit(limit);
+        long[] count = new long[1];
         return new LimitIterator<>(results, e -> {
-            long count = query.goOffset(1L);
-            return query.reachLimit(count - 1L);
+            return count[0]++ >= limit;
         });
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -149,7 +149,8 @@ public class HugeTraverser {
             while (edges.hasNext()) {
                 Id target = ((HugeEdge) edges.next()).id().otherVertexId();
                 KNode kNode = new KNode(target, (KNode) source);
-                if (excluded != null && excluded.contains(kNode)) {
+                if ((excluded != null && excluded.contains(kNode)) ||
+                    neighbors.contains(kNode)) {
                     continue;
                 }
                 neighbors.add(kNode);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/KneighborTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/KneighborTraverser.java
@@ -86,7 +86,6 @@ public class KneighborTraverser extends OltpTraverser {
         Node sourceV = new KNode(source, null);
 
         latest.add(sourceV);
-        all.add(sourceV);
 
         while (maxDepth-- > 0) {
             long remaining = limit == NO_LIMIT ? NO_LIMIT : limit - all.size();


### PR DESCRIPTION
Contains 3 point:
1. kout degree applied to all labels
2. remove source vertex from default kneighbor result
3. fix kneighbor result with limit may loss data because the duplicate elements of current layer are not excluded

PS: Also remove LimitIterator (moved to common) & add/adapt test for them on [client#122](https://github.com/hugegraph/hugegraph-client/pull/122) 