### PR TITLE
feat: add auto stale/close workflow for issue & pr

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,18 +7,23 @@ assignees: ''
 
 ---
 
+<details>
+<summary> Note ( 特别注意, 点击展开 ) </summary>
+
 ### Note ( 特别注意 ) : 
 
 > 1. 请先**搜索**, 并**确认**现有的 [Issues](https://github.com/hugegraph/hugegraph/issues) 与 [FAQ](https://hugegraph.github.io/hugegraph-doc/guides/faq.html) 中没有与您相同 / 相关的问题, 请勿重复提交
 > 2. 我们需要尽可能**详细**的信息来**复现**问题, 越详细的信息 (包括**日志 / 截图 / 配置**等) 会**越快**被响应和处理
-> 3. 请关注提交的 issue, 缺乏信息 / 长时间 ( > 14 天) 没有回复, issue 可能会被 **关闭** (需要时可再开启)
+> 3. Issue 标题请保持原有模板`[分类]`, 长段描述之间可以增加空行或使用`序号`标记, 保持排版清晰
+> 4. 请关注提交的 issue, 缺乏信息 / 长时间 ( > 14 天) 没有回复, issue 可能会被 **关闭** (更新时会再开启)
 
+</details>
 
 ## Environment ( 环境信息 - 必填 )
 - **Server Version**: v0.11.x (refer [here](https://hugegraph.github.io/hugegraph-doc/clients/restful-api/other.html))
 - **Backend**: Cassandra 3.x, x nodes, HDD or SSD
 - **OS**: xx CPUs, xx G RAM, Centos 7.x
-- **Data Size**:  xx vertices, xx edges (like 1000W 点, 9000W 边)
+- **Data Size**:  xx vertices, xx edges <!-- (like 1000W 点, 9000W 边) -->
 
 ## Expected behavior ( 期望表现 )
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 
 # 设置提 issue 前的参考文档
 contact_links:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,6 @@ labels: 'feature'
 assignees: ''
 ---
 
-## Feature Description: 
+## Feature Description:
 
-xxx
+请简要描述新功能 / 需求的使用场景或上下文, 最好能给个具体的例子说明

--- a/.github/ISSUE_TEMPLATE/question_ask.md
+++ b/.github/ISSUE_TEMPLATE/question_ask.md
@@ -7,18 +7,23 @@ assignees: ''
 
 ---
 
+<details>
+<summary> Note ( 特别注意, 点击展开 ) </summary>
+
 ### Note ( 特别注意 ) : 
 
 > 1. 请先**搜索**, 并**确认**现有的 [Issues](https://github.com/hugegraph/hugegraph/issues) 与 [FAQ](https://hugegraph.github.io/hugegraph-doc/guides/faq.html) 中没有与您相同 / 相关的问题, 请勿重复提交
 > 2. 我们需要尽可能**详细**的信息来**分析**问题, 越详细的信息 (包括**日志 / 截图 / 配置**等) 会**越快**被响应和处理
-> 3. 请关注提交的 issue, 缺乏信息 / 长时间 ( > 14 天) 没有回复, issue 可能会被 **关闭** (需要时可再开启)
+> 3. Issue 标题请保持原有模板`[分类]`, 长段描述之间可以增加空行或使用`序号`标记, 保持排版清晰
+> 4. 请关注提交的 issue, 缺乏信息 / 长时间 ( > 14 天) 没有回复, issue 可能会被 **关闭** (更新时会再开启)
 
+</details>
 
 ## Environment ( 环境信息 - 必填 )
 - **Server Version**: v0.11.x (refer [here](https://hugegraph.github.io/hugegraph-doc/clients/restful-api/other.html))
 - **Backend**: Cassandra 3.x, x nodes, HDD or SSD
 - **OS**: xx CPUs, xx G RAM, Centos 7.x
-- **Data Size**:  xx vertices, xx edges (like 1000W 点, 9000W 边)
+- **Data Size**:  xx vertices, xx edges <!-- (like 1000W 点, 9000W 边) -->
 
 ## Your Question ( 问题描述 )
 
@@ -28,7 +33,7 @@ xxx
 
 ### Related information ( 补充相关信息 ) :
 <details>
-<summary> Provide related "Data & Schema" info (Click to expand) </summary>
+<summary> Related "Data & Schema" info ( Click to expand ) </summary>
 
 ### Vertex/Edge example ( 问题点 / 边数据举例 )
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "30 9 * * *"
+  - cron: "0 21 * * *"
 
 jobs:
   stale:
@@ -20,16 +20,16 @@ jobs:
         stale-pr-message: 'Due to the lack of activity, the current pr is marked as stale and will be closed after 180 days, any update will remove the stale label'
         stale-issue-label: 'inactive'
         stale-pr-label: 'inactive'
-        exempt-issue-labels: 'feature,bug,wontfix,beta,enhancement,improvement,todo'
+        exempt-issue-labels: 'feature,bug,enhancement,improvement,wontfix,todo'
 
         days-before-issue-stale: 15
         days-before-issue-close: 20
         days-before-pr-stale: 30
         days-before-pr-close: 180
         operations-per-run: 25
-        start-date: '2021-01-01T00:00:00Z'
-        exempt-assignees: 'javame,Linary,zhoney'
+        start-date: '2020-12-01T00:00:00Z'
 
+        exempt-all-assignees: true
         remove-stale-when-updated: true
         exempt-all-pr-milestones: true
         delete-branch: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "30 9 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Due to the lack of activity, the current issue is marked as stale and will be closed after 20 days, any update will remove the stale label'
+        stale-pr-message: 'Due to the lack of activity, the current pr is marked as stale and will be closed after 180 days, any update will remove the stale label'
+        stale-issue-label: 'inactive'
+        stale-pr-label: 'inactive'
+        exempt-issue-labels: 'feature,bug,wontfix,beta,enhancement,improvement,todo'
+
+        days-before-issue-stale: 15
+        days-before-issue-close: 20
+        days-before-pr-stale: 30
+        days-before-pr-close: 180
+        operations-per-run: 25
+        start-date: '2021-01-01T00:00:00Z'
+        exempt-assignees: 'javame,Linary,zhoney'
+
+        remove-stale-when-updated: true
+        exempt-all-pr-milestones: true
+        delete-branch: false
+        enable-statistics: true


### PR DESCRIPTION
After merge the pr, the `stale.yml` will link to a github action, and auto run with schedule (need install it first, refer [doc](https://github.com/marketplace/actions/close-stale-issues):
1. after 15 / 30 days inactive, robot will auto mark `inactive` for issue / pr
2. then after 20 / 180 days inactive, robot will auto **close** stale issue / pr
3. specific "**authors & labels**" are excluded (white list)
4. now, only check issues after `2021-01-01` (need ensure)

auto mark & close like this: 
![image](https://user-images.githubusercontent.com/17706099/120161262-b02b2f80-c229-11eb-8a55-bd71ea682a88.png)

any update will auto remove stale status
![image](https://user-images.githubusercontent.com/17706099/120263078-9511fb80-c2cd-11eb-8424-6cc23e1e1031.png)

 

And also hide `note` message for issue template..  here is [preview](https://github.com/hugegraph/hugegraph/blob/b4cefe010dd9e67b1f7c722f770b1b86fb530c43/.github/ISSUE_TEMPLATE/question_ask.md)