### PR TITLE
chore: use tokenless way for coverage & update configs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,6 +30,7 @@ assignees: ''
 xxx
 
 ## Actual behavior ( 实际表现 / 报错)
+<!-- 请提供清晰的截图, 动图录屏更佳  -->
 
 xxx
 

--- a/.github/ISSUE_TEMPLATE/question_ask.md
+++ b/.github/ISSUE_TEMPLATE/question_ask.md
@@ -26,6 +26,7 @@ assignees: ''
 - **Data Size**:  xx vertices, xx edges <!-- (like 1000W 点, 9000W 边) -->
 
 ## Your Question ( 问题描述 )
+<!-- 请提供清晰的截图, 动图录屏更佳  -->
 
 xxx
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
           $TRAVIS_DIR/run-unit-test.sh ${{ matrix.BACKEND }}
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: target/site/jacoco/jacoco.xml

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
         days-before-pr-stale: 30
         days-before-pr-close: 180
         operations-per-run: 25
-        start-date: '2020-12-01T00:00:00Z'
+        start-date: '2018-10-01T00:00:00Z'
 
         exempt-all-assignees: true
         remove-stale-when-updated: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HugeGraph
 
 [![License](https://img.shields.io/badge/license-Apache%202-0E78BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![Build Status](https://travis-ci.org/hugegraph/hugegraph.svg?branch=master)](https://travis-ci.org/hugegraph/hugegraph)
+[![Build Status](https://github.com/hugegraph/hugegraph/actions/workflows/ci.yml/badge.svg)](https://github.com/hugegraph/hugegraph/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/hugegraph/hugegraph/branch/master/graph/badge.svg)](https://codecov.io/gh/hugegraph/hugegraph)
 
 HugeGraph is a fast-speed and highly-scalable [graph database](https://en.wikipedia.org/wiki/Graph_database). Billions of vertices and edges can be easily stored into and queried from HugeGraph due to its excellent OLTP ability. As compliance to [Apache TinkerPop 3](https://tinkerpop.apache.org/) framework, various complicated graph queries can be accomplished through [Gremlin](https://tinkerpop.apache.org/gremlin.html)(a powerful graph traversal language).


### PR DESCRIPTION
TODO: refact the whole issue template (much more user friendly)

The core reason of this problem is github-API didn't allow FORK/Outside PR use current project's secret token, so that code coverage can't load correctly.

Refer the issue from code coverage & official github blog, we have 3 way to solve this problem:

## 1. use the code coverage version `v1.0` instead of `1.0.x`, and it works
  ![image](https://user-images.githubusercontent.com/17706099/123819997-cf060a00-d92c-11eb-835d-ddcd4bff5f2e.png)

and it occurs:
![image](https://user-images.githubusercontent.com/17706099/123820551-3e7bf980-d92d-11eb-9e64-7a60f5c47c4c.png)



## 2.remove useless secret token for public repository (private repo needs)
refer code coverage issue: `https://github.com/codecov/codecov-action/issues/29`

## 3. share secrets with fork projects or prs (BETA)

refer github official blog / doc:
- blog: [GitHub Actions improvements for fork and pull request workflows](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/)
- use `pull_request_target` [label](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target). 
