### PR TITLE
Refactor(HbaseOptions): use static inner class singleton pattern.

### DIFF
--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseOptions.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseOptions.java
@@ -32,14 +32,15 @@ public class HbaseOptions extends OptionHolder {
         super();
     }
 
-    private static volatile HbaseOptions instance;
-
-    public static synchronized HbaseOptions instance() {
-        if (instance == null) {
-            instance = new HbaseOptions();
+    private static class InstanceHolder {
+        private final static HbaseOptions instance = new HbaseOptions();
+        static {
             instance.registerOptions();
         }
-        return instance;
+    }
+
+    public static HbaseOptions instance() {
+        return InstanceHolder.instance;
     }
 
     public static final ConfigOption<String> HBASE_HOSTS =


### PR DESCRIPTION
1.instance is initialized only when the instance() method is called for the first time.
2. before optimization, every time instance() method is called, will be request lock. this optimization avoid request lock and improved performance.