### PR TITLE
refact(core): support Infinity & NaN number in float/double property

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeVertex.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/structure/HugeVertex.java
@@ -445,7 +445,7 @@ public class HugeVertex extends HugeElement implements Vertex, Cloneable {
         if (cardinality != VertexProperty.Cardinality.single) {
             E.checkArgument(propertyKey.cardinality() ==
                             Cardinality.convert(cardinality),
-                            "Invalid cardinalty '%s' for property key '%s', " +
+                            "Invalid cardinality '%s' for property key '%s', " +
                             "expect '%s'", cardinality, key,
                             propertyKey.cardinality().string());
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/type/define/DataType.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/type/define/DataType.java
@@ -49,6 +49,9 @@ public enum DataType implements SerialEnum {
     private final byte code;
     private final String name;
     private final Class<?> clazz;
+    private final static String POSITIVE_INFINITY = "Infinity";
+    private final static String NEGATIVE_INFINITY = "-Infinity";
+    private final static String NaN = "NaN";
 
     static {
         SerialEnum.register(DataType.class);
@@ -104,15 +107,22 @@ public enum DataType implements SerialEnum {
         return this == DataType.UUID;
     }
 
+    private <V> boolean isInfinityOrNaN(V value) {
+        return value instanceof String &&
+               (POSITIVE_INFINITY.equals(value) ||
+                NEGATIVE_INFINITY.equals(value) || NaN.equals(value));
+    }
+
     public <V> Number valueToNumber(V value) {
-        if (!(this.isNumber() && value instanceof Number)) {
+        if (!(this.isNumber() && value instanceof Number) &&
+            !isInfinityOrNaN(value)) {
             return null;
         }
         if (this.clazz.isInstance(value)) {
             return (Number) value;
         }
 
-        Number number = null;
+        Number number;
         try {
             switch (this) {
                 case BYTE:
@@ -126,15 +136,11 @@ public enum DataType implements SerialEnum {
                     break;
                 case FLOAT:
                     Float fvalue = Float.valueOf(value.toString());
-                    if (!fvalue.isInfinite() && !fvalue.isNaN()) {
-                        number = fvalue;
-                    }
+                    number = fvalue;
                     break;
                 case DOUBLE:
                     Double dvalue = Double.valueOf(value.toString());
-                    if (!dvalue.isInfinite() && !dvalue.isNaN()) {
-                        number = dvalue;
-                    }
+                    number = dvalue;
                     break;
                 default:
                     throw new AssertionError(String.format(
@@ -219,6 +225,6 @@ public enum DataType implements SerialEnum {
                 return type;
             }
         }
-        throw new HugeException("Unknow clazz '%s' for DataType", clazz);
+        throw new HugeException("Unknown clazz '%s' for DataType", clazz);
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/type/define/DataType.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/type/define/DataType.java
@@ -107,7 +107,7 @@ public enum DataType implements SerialEnum {
         return this == DataType.UUID;
     }
 
-    private <V> boolean isInfinityOrNaN(V value) {
+    private static <V> boolean isInfinityOrNaN(V value) {
         return value instanceof String &&
                (POSITIVE_INFINITY.equals(value) ||
                 NEGATIVE_INFINITY.equals(value) || NaN.equals(value));

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/type/define/DataType.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/type/define/DataType.java
@@ -29,8 +29,8 @@ import com.baidu.hugegraph.backend.serializer.BytesBuffer;
 import com.baidu.hugegraph.util.Blob;
 import com.baidu.hugegraph.util.Bytes;
 import com.baidu.hugegraph.util.DateUtil;
+import com.baidu.hugegraph.util.JsonUtil;
 import com.baidu.hugegraph.util.StringEncoding;
-import com.google.common.collect.ImmutableSet;
 
 public enum DataType implements SerialEnum {
 
@@ -50,11 +50,9 @@ public enum DataType implements SerialEnum {
     private final byte code;
     private final String name;
     private final Class<?> clazz;
-    private final static ImmutableSet<String> specialNums;
 
     static {
         SerialEnum.register(DataType.class);
-        specialNums = ImmutableSet.of("-Infinity", "Infinity", "NaN");
     }
 
     DataType(int code, String name, Class<?> clazz) {
@@ -107,13 +105,9 @@ public enum DataType implements SerialEnum {
         return this == DataType.UUID;
     }
 
-    private static <V> boolean isInfinityOrNaN(V value) {
-        return value instanceof String && specialNums.contains(value);
-    }
-
     public <V> Number valueToNumber(V value) {
         if (!(this.isNumber() && value instanceof Number) &&
-            !isInfinityOrNaN(value)) {
+            !JsonUtil.isInfinityOrNaN(value)) {
             return null;
         }
         if (this.clazz.isInstance(value)) {
@@ -133,12 +127,10 @@ public enum DataType implements SerialEnum {
                     number = Long.valueOf(value.toString());
                     break;
                 case FLOAT:
-                    Float fvalue = Float.valueOf(value.toString());
-                    number = fvalue;
+                    number = Float.valueOf(value.toString());
                     break;
                 case DOUBLE:
-                    Double dvalue = Double.valueOf(value.toString());
-                    number = dvalue;
+                    number = Double.valueOf(value.toString());
                     break;
                 default:
                     throw new AssertionError(String.format(

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/type/define/DataType.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/type/define/DataType.java
@@ -30,6 +30,7 @@ import com.baidu.hugegraph.util.Blob;
 import com.baidu.hugegraph.util.Bytes;
 import com.baidu.hugegraph.util.DateUtil;
 import com.baidu.hugegraph.util.StringEncoding;
+import com.google.common.collect.ImmutableSet;
 
 public enum DataType implements SerialEnum {
 
@@ -49,12 +50,11 @@ public enum DataType implements SerialEnum {
     private final byte code;
     private final String name;
     private final Class<?> clazz;
-    private final static String POSITIVE_INFINITY = "Infinity";
-    private final static String NEGATIVE_INFINITY = "-Infinity";
-    private final static String NaN = "NaN";
+    private final static ImmutableSet<String> specialNums;
 
     static {
         SerialEnum.register(DataType.class);
+        specialNums = ImmutableSet.of("-Infinity", "Infinity", "NaN");
     }
 
     DataType(int code, String name, Class<?> clazz) {
@@ -108,9 +108,7 @@ public enum DataType implements SerialEnum {
     }
 
     private static <V> boolean isInfinityOrNaN(V value) {
-        return value instanceof String &&
-               (POSITIVE_INFINITY.equals(value) ||
-                NEGATIVE_INFINITY.equals(value) || NaN.equals(value));
+        return value instanceof String && specialNums.contains(value);
     }
 
     public <V> Number valueToNumber(V value) {

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/PropertyCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/PropertyCoreTest.java
@@ -19,6 +19,7 @@
 
 package com.baidu.hugegraph.core;
 
+import java.math.BigDecimal;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Date;
@@ -451,8 +452,18 @@ public abstract class PropertyCoreTest extends BaseCoreTest {
                             property("float", Float.MAX_VALUE));
         Assert.assertEquals(Float.POSITIVE_INFINITY,
                             property("float", Float.POSITIVE_INFINITY));
+        Assert.assertEquals(Float.POSITIVE_INFINITY,
+                            property("float", Double.MAX_VALUE));
+        Assert.assertEquals(Float.POSITIVE_INFINITY,
+                            property("float", Double.POSITIVE_INFINITY));
         Assert.assertEquals(Float.NEGATIVE_INFINITY,
                             property("float", Float.NEGATIVE_INFINITY));
+        Assert.assertEquals(Float.NEGATIVE_INFINITY,
+                            property("float", -Double.MAX_VALUE));
+        Assert.assertEquals(Float.POSITIVE_INFINITY,
+                            property("float", -Double.NEGATIVE_INFINITY));
+        Assert.assertEquals(Float.POSITIVE_INFINITY,
+                            property("float", -2 * Double.NEGATIVE_INFINITY));
         Assert.assertEquals(Float.NaN, property("float", Float.NaN));
 
         List<Float> list = ImmutableList.of(1f, 3f, 3f, 127f, 128f);
@@ -508,6 +519,23 @@ public abstract class PropertyCoreTest extends BaseCoreTest {
                             property("double", Double.MAX_VALUE));
         Assert.assertEquals(Double.POSITIVE_INFINITY,
                             property("double", Double.POSITIVE_INFINITY));
+        Assert.assertEquals(Double.POSITIVE_INFINITY,
+                            property("double", 2 * Double.POSITIVE_INFINITY));
+
+        BigDecimal two = new BigDecimal(2);
+        BigDecimal value = BigDecimal.valueOf(Double.MAX_VALUE).multiply(two);
+        Assert.assertEquals(Double.POSITIVE_INFINITY,
+                            property("double", value));
+        Assert.assertEquals(Double.POSITIVE_INFINITY,
+                            property("double", -Double.NEGATIVE_INFINITY));
+        Assert.assertEquals(Double.POSITIVE_INFINITY,
+                            property("double", -2 * Double.NEGATIVE_INFINITY));
+
+        value = BigDecimal.valueOf(-Double.MAX_VALUE).multiply(two);
+        Assert.assertEquals(Double.NEGATIVE_INFINITY,
+                            property("double", value));
+        value = BigDecimal.valueOf(Double.MIN_VALUE).divide(two);
+        Assert.assertEquals(0.0, property("double", value));
         Assert.assertEquals(Double.NEGATIVE_INFINITY,
                             property("double", Double.NEGATIVE_INFINITY));
         Assert.assertEquals(Double.NaN, property("double", Double.NaN));

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/PropertyCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/PropertyCoreTest.java
@@ -449,6 +449,11 @@ public abstract class PropertyCoreTest extends BaseCoreTest {
                             property("float", Float.MIN_VALUE));
         Assert.assertEquals(Float.MAX_VALUE,
                             property("float", Float.MAX_VALUE));
+        Assert.assertEquals(Float.POSITIVE_INFINITY,
+                            property("float", Float.POSITIVE_INFINITY));
+        Assert.assertEquals(Float.NEGATIVE_INFINITY,
+                            property("float", Float.NEGATIVE_INFINITY));
+        Assert.assertEquals(Float.NaN, property("float", Float.NaN));
 
         List<Float> list = ImmutableList.of(1f, 3f, 3f, 127f, 128f);
         Assert.assertEquals(list, propertyList("float",
@@ -462,13 +467,13 @@ public abstract class PropertyCoreTest extends BaseCoreTest {
                                              1f, 3f, 3f, 127f, 128f));
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            property("float", Double.MAX_VALUE);
+            property("float", 'a');
         }, e -> {
             Assert.assertContains("Invalid property value " +
-                                  "'1.7976931348623157E308' for key 'float'",
+                                  "'a' for key 'float'",
                                   e.getMessage());
             Assert.assertContains("expect a value of type Float, " +
-                                  "actual type Double",
+                                  "actual type Character",
                                   e.getMessage());
         });
 
@@ -501,6 +506,11 @@ public abstract class PropertyCoreTest extends BaseCoreTest {
                             property("double", Double.MIN_VALUE));
         Assert.assertEquals(Double.MAX_VALUE,
                             property("double", Double.MAX_VALUE));
+        Assert.assertEquals(Double.POSITIVE_INFINITY,
+                            property("double", Double.POSITIVE_INFINITY));
+        Assert.assertEquals(Double.NEGATIVE_INFINITY,
+                            property("double", Double.NEGATIVE_INFINITY));
+        Assert.assertEquals(Double.NaN, property("double", Double.NaN));
 
         List<Double> list = ImmutableList.of(1d, 3d, 3d, 127d, 128d);
         Assert.assertEquals(list, propertyList("double",

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
@@ -283,19 +283,6 @@ public class VertexCoreTest extends BaseCoreTest {
         schema.propertyKey("float").asFloat().create();
         schema.vertexLabel("number").properties("float").create();
 
-        //Assert.assertThrows(IllegalArgumentException.class, () -> {
-        //    double value = Float.MAX_VALUE * 2.0d;
-        //    graph.addVertex(T.label, "number", "float", value);
-        //});
-        //Assert.assertThrows(IllegalArgumentException.class, () -> {
-        //    double value = -(Float.MAX_VALUE * 2.0d);
-        //    graph.addVertex(T.label, "number", "float", value);
-        //});
-        //
-        //Assert.assertThrows(IllegalArgumentException.class, () -> {
-        //    graph.addVertex(T.label, "number", "float", Double.MAX_VALUE);
-        //});
-
         double value = Float.MIN_VALUE / 2.0d;
         float fvalue = graph.addVertex(T.label, "number", "float", value)
                             .value("float");
@@ -317,17 +304,6 @@ public class VertexCoreTest extends BaseCoreTest {
         SchemaManager schema = graph.schema();
         schema.propertyKey("double").asDouble().create();
         schema.vertexLabel("number").properties("double").create();
-
-        //Assert.assertThrows(IllegalArgumentException.class, () -> {
-        //    BigDecimal two = new BigDecimal(2);
-        //    BigDecimal value = new BigDecimal(Double.MAX_VALUE).multiply(two);
-        //    graph.addVertex(T.label, "number", "double", value);
-        //});
-        //Assert.assertThrows(IllegalArgumentException.class, () -> {
-        //    BigDecimal two = new BigDecimal(2);
-        //    BigDecimal value = new BigDecimal(-Double.MAX_VALUE).multiply(two);
-        //    graph.addVertex(T.label, "number", "double", value);
-        //});
 
         BigDecimal two = new BigDecimal(2);
         BigDecimal value = new BigDecimal(Double.MIN_VALUE).divide(two);

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
@@ -283,18 +283,18 @@ public class VertexCoreTest extends BaseCoreTest {
         schema.propertyKey("float").asFloat().create();
         schema.vertexLabel("number").properties("float").create();
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            double value = Float.MAX_VALUE * 2.0d;
-            graph.addVertex(T.label, "number", "float", value);
-        });
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            double value = -(Float.MAX_VALUE * 2.0d);
-            graph.addVertex(T.label, "number", "float", value);
-        });
-
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            graph.addVertex(T.label, "number", "float", Double.MAX_VALUE);
-        });
+        //Assert.assertThrows(IllegalArgumentException.class, () -> {
+        //    double value = Float.MAX_VALUE * 2.0d;
+        //    graph.addVertex(T.label, "number", "float", value);
+        //});
+        //Assert.assertThrows(IllegalArgumentException.class, () -> {
+        //    double value = -(Float.MAX_VALUE * 2.0d);
+        //    graph.addVertex(T.label, "number", "float", value);
+        //});
+        //
+        //Assert.assertThrows(IllegalArgumentException.class, () -> {
+        //    graph.addVertex(T.label, "number", "float", Double.MAX_VALUE);
+        //});
 
         double value = Float.MIN_VALUE / 2.0d;
         float fvalue = graph.addVertex(T.label, "number", "float", value)
@@ -318,16 +318,16 @@ public class VertexCoreTest extends BaseCoreTest {
         schema.propertyKey("double").asDouble().create();
         schema.vertexLabel("number").properties("double").create();
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            BigDecimal two = new BigDecimal(2);
-            BigDecimal value = new BigDecimal(Double.MAX_VALUE).multiply(two);
-            graph.addVertex(T.label, "number", "double", value);
-        });
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            BigDecimal two = new BigDecimal(2);
-            BigDecimal value = new BigDecimal(-Double.MAX_VALUE).multiply(two);
-            graph.addVertex(T.label, "number", "double", value);
-        });
+        //Assert.assertThrows(IllegalArgumentException.class, () -> {
+        //    BigDecimal two = new BigDecimal(2);
+        //    BigDecimal value = new BigDecimal(Double.MAX_VALUE).multiply(two);
+        //    graph.addVertex(T.label, "number", "double", value);
+        //});
+        //Assert.assertThrows(IllegalArgumentException.class, () -> {
+        //    BigDecimal two = new BigDecimal(2);
+        //    BigDecimal value = new BigDecimal(-Double.MAX_VALUE).multiply(two);
+        //    graph.addVertex(T.label, "number", "double", value);
+        //});
 
         BigDecimal two = new BigDecimal(2);
         BigDecimal value = new BigDecimal(Double.MIN_VALUE).divide(two);


### PR DESCRIPTION
Fix #1575 :
1. due to this, float can support the value > Float.MAX (treat as Infinity), so as the double
2. add test case in client (later)

PS: Shall we delete old test cases directly