### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,13 @@ jobs:
       fail-fast: false
       matrix:
         BACKEND: [memory, cassandra, scylladb, hbase, rocksdb]
+        java-version: ['8', '8.0.192']
     steps:
-      - name: Install JDK 8
+      - name: Install JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java-version }}
+          distribution: 'zulu'
 
       - name: Cache Maven packages
         uses: actions/cache@v2


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. Also, added a fixed (major) version.