### PR TITLE
chore: update ubuntu version for ci actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       TRAVIS_DIR: hugegraph-dist/src/assembly/travis
     strategy:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,6 +21,8 @@ jobs:
         stale-issue-label: 'inactive'
         stale-pr-label: 'inactive'
         exempt-issue-labels: 'feature,bug,enhancement,improvement,wontfix,todo'
+        exempt-pr-labels: 'feature,bug,enhancement,improvement,wontfix,todo'
+        exempt-all-milestones: true
 
         days-before-issue-stale: 15
         days-before-issue-close: 20


### PR DESCRIPTION
test in versions below: (✓ mark as ci passed)
- [x] 18.04
- [x] 20.04 (choose it)
- [ ] latest (even pass now, maybe not suitable to use, because cannot control the stable version)