### PR TITLE
fix: gremlin exec timeout cause statement unclose

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/query/QueryResults.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/query/QueryResults.java
@@ -170,7 +170,11 @@ public class QueryResults<R> {
     }
 
     public static <T> ListIterator<T> toList(Iterator<T> iterator) {
-        return new ListIterator<>(Query.DEFAULT_CAPACITY, iterator);
+        try {
+            return new ListIterator<>(Query.DEFAULT_CAPACITY, iterator);
+        } finally {
+            CloseableIterator.closeIterator(iterator);
+        }
     }
 
     public static <T> void fillList(Iterator<T> iterator, List<T> list) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendEntryIterator.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendEntryIterator.java
@@ -123,7 +123,7 @@ public abstract class BackendEntryIterator implements CIter<BackendEntry> {
         } catch (Throwable e) {
             try {
                 this.close();
-            } catch (Exception ex) {
+            } catch (Throwable ex) {
                 LOG.warn("Failed to close backend entry iterator for interrupted query", ex);
             }
             throw e;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendEntryIterator.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendEntryIterator.java
@@ -120,8 +120,7 @@ public abstract class BackendEntryIterator implements CIter<BackendEntry> {
     protected final boolean reachLimit(long count) {
         try {
             checkInterrupted();
-            return this.query.reachLimit(count);
-        } catch (BackendException e) {
+        } catch (Throwable e) {
             try {
                 this.close();
             } catch (Exception ex) {
@@ -129,6 +128,7 @@ public abstract class BackendEntryIterator implements CIter<BackendEntry> {
             }
             throw e;
         }
+        return this.query.reachLimit(count);
     }
 
     protected final long count() {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendEntryIterator.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendEntryIterator.java
@@ -125,7 +125,7 @@ public abstract class BackendEntryIterator implements CIter<BackendEntry> {
             try {
                 this.close();
             } catch (Exception ex) {
-                LOG.warn("failed to close backend entry iterator for interrupted query", ex);
+                LOG.warn("Failed to close backend entry iterator for interrupted query", ex);
             }
             throw e;
         }


### PR DESCRIPTION
Fix bug: gremlin语句执行超时 将导致内存泄漏statement未释放

fix #1639