### PR TITLE
Fix bug : unicode characters from \u0000 to \u0003 removed from property values indexed using search index

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphIndexTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphIndexTransaction.java
@@ -886,7 +886,11 @@ public class GraphIndexTransaction extends AbstractTransaction {
     }
 
     private Set<String> segmentWords(String text) {
-        return this.textAnalyzer.segment(text);
+        Set<String> words = this.textAnalyzer.segment(text);
+        for (char ch = INDEX_SYM_ENDING; ch <= INDEX_SYM_MAX; ch++) {
+            words.remove(ch);
+        }
+        return words;
     }
 
     private boolean needIndexForLabel() {


### PR DESCRIPTION
Fixed #1638