### PR TITLE
unify special chars in index property

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TextSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TextSerializer.java
@@ -42,7 +42,6 @@ import com.baidu.hugegraph.backend.query.IdPrefixQuery;
 import com.baidu.hugegraph.backend.query.IdRangeQuery;
 import com.baidu.hugegraph.backend.query.Query;
 import com.baidu.hugegraph.backend.store.BackendEntry;
-import com.baidu.hugegraph.backend.tx.GraphIndexTransaction;
 import com.baidu.hugegraph.schema.EdgeLabel;
 import com.baidu.hugegraph.schema.IndexLabel;
 import com.baidu.hugegraph.schema.PropertyKey;
@@ -75,7 +74,7 @@ public class TextSerializer extends AbstractSerializer {
 
     private static final String VALUE_SPLITOR = TextBackendEntry.VALUE_SPLITOR;
     private static final String EDGE_NAME_ENDING =
-                                GraphIndexTransaction.INDEX_SYM_ENDING + "";
+                                ConditionQuery.INDEX_SYM_ENDING;
 
     private static final String EDGE_OUT_TYPE = writeType(HugeType.EDGE_OUT);
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphIndexTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/tx/GraphIndexTransaction.java
@@ -1338,7 +1338,7 @@ public class GraphIndexTransaction extends AbstractTransaction {
         String joinedValues;
         // 2.1 All fields have equal-conditions
         if (prefixes.size() == fields.size()) {
-            // Prefix numeric values should be converted to sort-able string
+            // Prefix numeric values should be converted to sortable string
             joinedValues = ConditionQuery.concatValues(prefixes);
             conditions.add(Condition.eq(key, joinedValues));
             return conditions;

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/EdgeCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/EdgeCoreTest.java
@@ -5686,7 +5686,11 @@ public class EdgeCoreTest extends BaseCoreTest {
                                "arrested", false);
                 graph.tx().commit();
             }, e -> {
-                Assert.assertContains("0x00", e.getMessage());
+                if (e instanceof BackendException) {
+                    Assert.assertContains("0x00", e.getCause().getMessage());
+                } else {
+                    Assert.assertContains("0x00", e.getMessage());
+                }
             });
         } else {
             louise.addEdge("strike", sean, "id", 0,

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/core/VertexCoreTest.java
@@ -6024,7 +6024,11 @@ public class VertexCoreTest extends BaseCoreTest {
                                 "city", "a\u0000", "age", 0);
                 graph.tx().commit();
             }, e -> {
-                Assert.assertContains("0x00", e.getMessage());
+                if (e instanceof BackendException) {
+                    Assert.assertContains("0x00", e.getCause().getMessage());
+                } else {
+                    Assert.assertContains("0x00", e.getMessage());
+                }
             });
         } else {
             graph.addVertex(T.label, "person", "name", "0",


### PR DESCRIPTION
just not allow leading special char in index property,
it's ok a special char is placed in non-leading position.

NOTE: not allowed 0x00 byte in any position for pgsql/rocksdb/hbase

fix #1638

Change-Id: Id3f0eb39c30da2ff4b11221df0e138cc77c885b2