### PR TITLE
fix hbase scan startkey is null NPE

### DIFF
--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseSessions.java
@@ -712,7 +712,11 @@ public class HbaseSessions extends BackendSessionPool {
                                 byte[] stopRow, boolean inclusiveStop) {
             assert !this.hasChanges();
 
-            Scan scan = new Scan().withStartRow(startRow, inclusiveStart);
+            Scan scan = new Scan();
+            if (startRow != null) {
+                // Refer: https://issues.apache.org/jira/browse/HBASE-16498 (Bug Fix)
+                scan.withStartRow(startRow, inclusiveStart);
+            }
             if (stopRow != null) {
                 String version = VersionInfo.getVersion();
                 if (inclusiveStop && !VersionUtil.gte(version, "2.0")) {

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseTable.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseTable.java
@@ -367,7 +367,7 @@ public class HbaseTable extends BackendTable<Session, BackendEntry> {
 
         @Override
         public byte[] position(String position) {
-            if (END.equals(position)) {
+            if (START.equals(position) || END.equals(position)) {
                 return null;
             }
             return StringEncoding.decodeBase64(position);


### PR DESCRIPTION
Fix bug: HBase 表预分区 分区扫描数据发生NPE

fix #1690 