### PR TITLE
refact: early stop  & perf improve for paths traverser/api

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/HugeTraverser.java
@@ -618,7 +618,7 @@ public class HugeTraverser {
          */
         @Override
         public boolean equals(Object other) {
-            if (other == null || !(other instanceof Path)) {
+            if (!(other instanceof Path)) {
                 return false;
             }
             return this.vertices.equals(((Path) other).vertices);
@@ -724,6 +724,17 @@ public class HugeTraverser {
         @Override
         public String toString() {
             return this.paths.toString();
+        }
+
+        public void append(Id current) {
+            for (Iterator<Path> iter = paths.iterator(); iter.hasNext();) {
+                Path path = iter.next();
+                if (path.vertices().contains(current)) {
+                    iter.remove();
+                    continue;
+                }
+                path.addToLast(current);
+            }
         }
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/PathsTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/PathsTraverser.java
@@ -124,9 +124,11 @@ public class PathsTraverser extends HugeTraverser {
                     PathSet results = this.record.findPath(target, null,
                                                            true, false);
                     for (Path path : results) {
+                        if (Objects.equals(target, targetV)) {
+                            continue;
+                        }
                         this.paths.add(path);
-                        if ( this.reachLimit() ||
-                             Objects.equals(target, targetV)) {
+                        if (this.reachLimit()) {
                             return;
                         }
                     }
@@ -158,9 +160,11 @@ public class PathsTraverser extends HugeTraverser {
                     PathSet results = this.record.findPath(target, null,
                                                            true, false);
                     for (Path path : results) {
+                        if (Objects.equals(target, sourceV)) {
+                            continue;
+                        }
                         this.paths.add(path);
-                        if (this.reachLimit() ||
-                            Objects.equals(target, sourceV)) {
+                        if (this.reachLimit()) {
                             return;
                         }
                     }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/PathsTraverser.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/PathsTraverser.java
@@ -20,6 +20,7 @@
 package com.baidu.hugegraph.traversal.algorithm;
 
 import java.util.Iterator;
+import java.util.Objects;
 
 import org.apache.tinkerpop.gremlin.structure.Edge;
 
@@ -63,16 +64,17 @@ public class PathsTraverser extends HugeTraverser {
         Id labelId = this.getEdgeLabelId(label);
         Traverser traverser = new Traverser(sourceV, targetV, labelId,
                                             degree, capacity, limit);
+        // We should stop early if walk backtrace or reach limit
         while (true) {
             if (--depth < 0 || traverser.reachLimit()) {
                 break;
             }
-            traverser.forward(sourceDir);
+            traverser.forward(targetV, sourceDir);
 
             if (--depth < 0 || traverser.reachLimit()) {
                 break;
             }
-            traverser.backward(targetDir);
+            traverser.backward(sourceV, targetDir);
         }
         return traverser.paths();
     }
@@ -103,12 +105,15 @@ public class PathsTraverser extends HugeTraverser {
          * Search forward from source
          */
         @Watched
-        public void forward(Directions direction) {
+        public void forward(Id targetV, Directions direction) {
             Iterator<Edge> edges;
 
             this.record.startOneLayer(true);
             while (this.record.hasNextKey()) {
                 Id vid = this.record.nextKey();
+                if (vid.equals(targetV)) {
+                    continue;
+                }
 
                 edges = edgesOfVertex(vid, direction, this.label, this.degree);
 
@@ -120,7 +125,8 @@ public class PathsTraverser extends HugeTraverser {
                                                            true, false);
                     for (Path path : results) {
                         this.paths.add(path);
-                        if (this.reachLimit()) {
+                        if ( this.reachLimit() ||
+                             Objects.equals(target, targetV)) {
                             return;
                         }
                     }
@@ -133,12 +139,16 @@ public class PathsTraverser extends HugeTraverser {
          * Search backward from target
          */
         @Watched
-        public void backward(Directions direction) {
+        public void backward(Id sourceV, Directions direction) {
             Iterator<Edge> edges;
 
             this.record.startOneLayer(false);
             while (this.record.hasNextKey()) {
                 Id vid = this.record.nextKey();
+                if (vid.equals(sourceV)) {
+                    continue;
+                }
+
                 edges = edgesOfVertex(vid, direction, this.label, this.degree);
 
                 while (edges.hasNext()) {
@@ -149,7 +159,8 @@ public class PathsTraverser extends HugeTraverser {
                                                            true, false);
                     for (Path path : results) {
                         this.paths.add(path);
-                        if (this.reachLimit()) {
+                        if (this.reachLimit() ||
+                            Objects.equals(target, sourceV)) {
                             return;
                         }
                     }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/AbstractRecords.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/AbstractRecords.java
@@ -34,10 +34,12 @@ public abstract class AbstractRecords implements Records {
     private final RecordType type;
     private final boolean concurrent;
     private Record currentRecord;
+    private Record parentRecord;
 
     public AbstractRecords(RecordType type, boolean concurrent) {
         this.type = type;
         this.concurrent = concurrent;
+        this.parentRecord = null;
         this.idMapping = MappingFactory.newObjectIntMapping(this.concurrent);
     }
 
@@ -70,7 +72,12 @@ public abstract class AbstractRecords implements Records {
         return this.currentRecord;
     }
 
-    protected final void currentRecord(Record record) {
-        this.currentRecord = record;
+    protected void currentRecord(Record currentRecord, Record parentRecord) {
+        this.parentRecord = parentRecord;
+        this.currentRecord = currentRecord;
+    }
+
+    protected Record parentRecord() {
+        return this.parentRecord;
     }
 }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/DoubleWayMultiPathsRecords.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/DoubleWayMultiPathsRecords.java
@@ -40,7 +40,7 @@ public abstract class DoubleWayMultiPathsRecords extends AbstractRecords {
     private final Stack<Record> sourceRecords;
     private final Stack<Record> targetRecords;
 
-    private IntIterator lastRecordKeys;
+    private IntIterator parentRecordKeys;
     private int currentKey;
     private boolean movingForward;
     private long accessed;
@@ -65,10 +65,11 @@ public abstract class DoubleWayMultiPathsRecords extends AbstractRecords {
     @Override
     public void startOneLayer(boolean forward) {
         this.movingForward = forward;
-        this.currentRecord(this.newRecord());
-        this.lastRecordKeys = this.movingForward ?
-                              this.sourceRecords.peek().keys() :
-                              this.targetRecords.peek().keys();
+        Record parentRecord = this.movingForward ?
+                              this.sourceRecords.peek() :
+                              this.targetRecords.peek();
+        this.currentRecord(this.newRecord(), parentRecord);
+        this.parentRecordKeys = parentRecord.keys();
     }
 
     @Override
@@ -85,14 +86,31 @@ public abstract class DoubleWayMultiPathsRecords extends AbstractRecords {
     @Watched
     @Override
     public boolean hasNextKey() {
-        return this.lastRecordKeys.hasNext();
+        return this.parentRecordKeys.hasNext();
     }
 
     @Watched
     @Override
     public Id nextKey() {
-        this.currentKey = this.lastRecordKeys.next();
+        this.currentKey = this.parentRecordKeys.next();
         return this.id(this.currentKey);
+    }
+
+    public boolean parentsContain(int id) {
+        Record parentRecord = this.parentRecord();
+        if (parentRecord == null) {
+            return false;
+        }
+
+        IntIterator parents = parentRecord.get(this.currentKey);
+        while (parents.hasNext()) {
+            int parent = parents.next();
+            if (parent == id) {
+                // find backtrace path, stop
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -147,21 +165,13 @@ public abstract class DoubleWayMultiPathsRecords extends AbstractRecords {
             return results;
         }
 
-        Id sid = this.id(id);
+        Id current = this.id(id);
         Record layer = all.elementAt(layerIndex);
         IntIterator iterator = layer.get(id);
         while (iterator.hasNext()) {
             int parent = iterator.next();
             PathSet paths = this.linkPathLayer(all, parent, layerIndex - 1);
-            for (Iterator<Path> iter = paths.iterator(); iter.hasNext();) {
-                Path path = iter.next();
-                if (path.vertices().contains(sid)) {
-                    iter.remove();
-                    continue;
-                }
-                path.addToLast(sid);
-            }
-
+            paths.append(current);
             results.addAll(paths);
         }
         return results;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/DoubleWayMultiPathsRecords.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/DoubleWayMultiPathsRecords.java
@@ -106,7 +106,7 @@ public abstract class DoubleWayMultiPathsRecords extends AbstractRecords {
         while (parents.hasNext()) {
             int parent = parents.next();
             if (parent == id) {
-                // find backtrace path, stop
+                // Find backtrace path, stop
                 return true;
             }
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/PathsRecords.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/PathsRecords.java
@@ -39,10 +39,15 @@ public class PathsRecords extends DoubleWayMultiPathsRecords {
         assert all;
         int targetCode = this.code(target);
         int parentCode = this.current();
+        PathSet paths = PathSet.EMPTY;
+
+        if (this.parentsContain(targetCode)) {
+            return paths;
+        }
+
         // Add to current layer
         this.addPath(targetCode, parentCode);
         // If cross point exists, path found, concat them
-        PathSet paths = PathSet.EMPTY;
         if (this.movingForward() && this.targetContains(targetCode)) {
             paths = this.linkPath(parentCode, targetCode, ring);
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/PathsRecords.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/PathsRecords.java
@@ -41,6 +41,7 @@ public class PathsRecords extends DoubleWayMultiPathsRecords {
         int parentCode = this.current();
         PathSet paths = PathSet.EMPTY;
 
+        // Traverse backtrace is not allowed, stop now
         if (this.parentsContain(targetCode)) {
             return paths;
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/SingleWayMultiPathsRecords.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/traversal/algorithm/records/SingleWayMultiPathsRecords.java
@@ -50,7 +50,7 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
     private final boolean nearest;
     private final MutableIntSet accessedVertices;
 
-    private IntIterator lastRecordKeys;
+    private IntIterator parentRecordKeys;
 
     public SingleWayMultiPathsRecords(RecordType type, boolean concurrent,
                                       Id source, boolean nearest) {
@@ -70,8 +70,9 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
 
     @Override
     public void startOneLayer(boolean forward) {
-        this.currentRecord(this.newRecord());
-        this.lastRecordKeys = this.records.peek().keys();
+        Record parentRecord = this.records.peek();
+        this.currentRecord(this.newRecord(), parentRecord);
+        this.parentRecordKeys = parentRecord.keys();
     }
 
     @Override
@@ -81,12 +82,12 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
 
     @Override
     public boolean hasNextKey() {
-        return this.lastRecordKeys.hasNext();
+        return this.parentRecordKeys.hasNext();
     }
 
     @Override
     public Id nextKey() {
-        return this.id(this.lastRecordKeys.next());
+        return this.id(this.parentRecordKeys.next());
     }
 
     @Override
@@ -108,7 +109,7 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
     }
 
     public Iterator<Id> keys() {
-        return new MapperIterator<>(this.lastRecordKeys, this::id);
+        return new MapperIterator<>(this.parentRecordKeys, this::id);
     }
 
     @Watched
@@ -174,8 +175,7 @@ public abstract class SingleWayMultiPathsRecords extends AbstractRecords {
 
     protected final IntIntHashMap layer(int layerIndex) {
         Record record = this.records.elementAt(layerIndex);
-        IntIntHashMap layer = ((Int2IntRecord) record).layer();
-        return layer;
+        return ((Int2IntRecord) record).layer();
     }
 
     protected final Stack<Record> records() {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/util/collection/Int2IntsMap.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/util/collection/Int2IntsMap.java
@@ -25,6 +25,8 @@ import org.eclipse.collections.impl.map.mutable.primitive.IntIntHashMap;
 // TODO: move to common-module
 public class Int2IntsMap {
 
+    private static final int[] EMPTY = new int[0];
+
     private static final int INIT_KEY_CAPACITY = 16;
     private static final int CHUNK_SIZE = 10;
     private static final int EXPANSION_FACTOR = 2;
@@ -145,7 +147,11 @@ public class Int2IntsMap {
     }
 
     public int[] getValues(int key) {
-        int firstChunk = this.chunkMap.get(key);
+        int firstChunk = this.chunkMap.getIfAbsent(key, -1);
+        if (firstChunk == -1) {
+            return EMPTY;
+        }
+
         int size = this.chunkTable[firstChunk + OFFSET_SIZE];
         int[] values = new int[size];
         int position = firstChunk + OFFSET_FIRST_CHUNK_DATA;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/util/collection/Int2IntsMap.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/util/collection/Int2IntsMap.java
@@ -22,7 +22,9 @@ package com.baidu.hugegraph.util.collection;
 import org.eclipse.collections.api.iterator.IntIterator;
 import org.eclipse.collections.impl.map.mutable.primitive.IntIntHashMap;
 
-// TODO: move to common-module
+/**
+ * TODO: move to common-module
+ */
 public class Int2IntsMap {
 
     private static final int[] EMPTY = new int[0];

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/traversers/CrosspointsApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/traversers/CrosspointsApiTest.java
@@ -58,7 +58,6 @@ public class CrosspointsApiTest extends BaseApiTest {
         String content = assertResponseStatus(200, r);
         List<Map<String, Object>> crosspoints = assertJsonContains(
                                                 content, "crosspoints");
-        //Assert.assertEquals(2, crosspoints.size());
-        Assert.assertEquals(0, crosspoints.size());
+        Assert.assertEquals(2, crosspoints.size());
     }
 }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/api/traversers/CrosspointsApiTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/api/traversers/CrosspointsApiTest.java
@@ -58,6 +58,7 @@ public class CrosspointsApiTest extends BaseApiTest {
         String content = assertResponseStatus(200, r);
         List<Map<String, Object>> crosspoints = assertJsonContains(
                                                 content, "crosspoints");
-        Assert.assertEquals(2, crosspoints.size());
+        //Assert.assertEquals(2, crosspoints.size());
+        Assert.assertEquals(0, crosspoints.size());
     }
 }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/Int2IntsMapTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/Int2IntsMapTest.java
@@ -174,4 +174,19 @@ public class Int2IntsMapTest {
         Assert.assertEquals(VALUE_NUMBER, all.size());
         Assert.assertEquals(KEY_NUMBER, map.size());
     }
+
+    @Test
+    public void testEmptyInt2IntsMap() {
+        Int2IntsMap map = new Int2IntsMap();
+
+        int[] ints = map.getValues(-1);
+        Assert.assertEquals(0, map.size());
+        Assert.assertArrayEquals(new int[0], ints);
+
+        ints = map.getValues(1);
+        Assert.assertArrayEquals(new int[0], ints);
+
+        map.add(1, 1);
+        Assert.assertEquals(1, map.size());
+    }
 }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/Int2IntsMapTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/Int2IntsMapTest.java
@@ -190,6 +190,5 @@ public class Int2IntsMapTest {
 
         ints = map.getValues(2);
         Assert.assertArrayEquals(new int[0], ints);
-
     }
 }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/Int2IntsMapTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/core/Int2IntsMapTest.java
@@ -183,10 +183,13 @@ public class Int2IntsMapTest {
         Assert.assertEquals(0, map.size());
         Assert.assertArrayEquals(new int[0], ints);
 
+        map.add(1, 1);
         ints = map.getValues(1);
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals(1, ints[0]);
+
+        ints = map.getValues(2);
         Assert.assertArrayEquals(new int[0], ints);
 
-        map.add(1, 1);
-        Assert.assertEquals(1, map.size());
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17706099/145927512-a36f44b5-c36d-4fff-b2eb-12a83c481d4e.png)

As the graph above, we will drop `a->d->c->e` path now 
