### PR TITLE
feat(hbase): support hash rowkey struct & pre-init tables

### DIFF
--- a/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraSerializer.java
+++ b/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraSerializer.java
@@ -34,6 +34,7 @@ import com.baidu.hugegraph.backend.serializer.BytesBuffer;
 import com.baidu.hugegraph.backend.serializer.TableBackendEntry;
 import com.baidu.hugegraph.backend.serializer.TableSerializer;
 import com.baidu.hugegraph.backend.store.BackendEntry;
+import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.schema.PropertyKey;
 import com.baidu.hugegraph.schema.SchemaElement;
 import com.baidu.hugegraph.structure.HugeElement;
@@ -50,6 +51,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 public class CassandraSerializer extends TableSerializer {
+
+    public CassandraSerializer(HugeConfig config) {
+        super(config);
+    }
 
     @Override
     public CassandraBackendEntry newBackendEntry(HugeType type, Id id) {

--- a/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraStoreProvider.java
+++ b/hugegraph-cassandra/src/main/java/com/baidu/hugegraph/backend/store/cassandra/CassandraStoreProvider.java
@@ -23,6 +23,7 @@ import com.baidu.hugegraph.backend.store.AbstractBackendStoreProvider;
 import com.baidu.hugegraph.backend.store.BackendStore;
 import com.baidu.hugegraph.backend.store.cassandra.CassandraStore.CassandraGraphStore;
 import com.baidu.hugegraph.backend.store.cassandra.CassandraStore.CassandraSchemaStore;
+import com.baidu.hugegraph.config.HugeConfig;
 
 public class CassandraStoreProvider extends AbstractBackendStoreProvider {
 
@@ -31,12 +32,12 @@ public class CassandraStoreProvider extends AbstractBackendStoreProvider {
     }
 
     @Override
-    protected BackendStore newSchemaStore(String store) {
+    protected BackendStore newSchemaStore(HugeConfig config, String store) {
         return new CassandraSchemaStore(this, this.keyspace(), store);
     }
 
     @Override
-    protected BackendStore newGraphStore(String store) {
+    protected BackendStore newGraphStore(HugeConfig config, String store) {
         return new CassandraGraphStore(this, this.keyspace(), store);
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/StandardHugeGraph.java
@@ -447,17 +447,17 @@ public class StandardHugeGraph implements HugeGraph {
 
     private BackendStore loadSchemaStore() {
         String name = this.configuration.get(CoreOptions.STORE_SCHEMA);
-        return this.storeProvider.loadSchemaStore(name);
+        return this.storeProvider.loadSchemaStore(this.configuration, name);
     }
 
     private BackendStore loadGraphStore() {
         String name = this.configuration.get(CoreOptions.STORE_GRAPH);
-        return this.storeProvider.loadGraphStore(name);
+        return this.storeProvider.loadGraphStore(this.configuration, name);
     }
 
     private BackendStore loadSystemStore() {
         String name = this.configuration.get(CoreOptions.STORE_SYSTEM);
-        return this.storeProvider.loadSystemStore(name);
+        return this.storeProvider.loadSystemStore(this.configuration, name);
     }
 
     @Watched
@@ -498,7 +498,7 @@ public class StandardHugeGraph implements HugeGraph {
     private AbstractSerializer serializer() {
         String name = this.configuration.get(CoreOptions.SERIALIZER);
         LOG.debug("Loading serializer '{}' for graph '{}'", name, this.name);
-        AbstractSerializer serializer = SerializerFactory.serializer(name);
+        AbstractSerializer serializer = SerializerFactory.serializer(this.configuration, name);
         if (serializer == null) {
             throw new HugeException("Can't load serializer with name " + name);
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/AbstractSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/AbstractSerializer.java
@@ -25,10 +25,19 @@ import com.baidu.hugegraph.backend.query.ConditionQuery;
 import com.baidu.hugegraph.backend.query.IdQuery;
 import com.baidu.hugegraph.backend.query.Query;
 import com.baidu.hugegraph.backend.store.BackendEntry;
+import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.type.HugeType;
 
 public abstract class AbstractSerializer
                 implements GraphSerializer, SchemaSerializer {
+
+    public AbstractSerializer() {
+        // TODO: default constructor
+    }
+
+    public AbstractSerializer(HugeConfig config) {
+        // TODO: use the config
+    }
 
     protected BackendEntry convertEntry(BackendEntry entry) {
         return entry;

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinaryBackendEntry.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinaryBackendEntry.java
@@ -45,7 +45,11 @@ public class BinaryBackendEntry implements BackendEntry {
     private boolean olap;
 
     public BinaryBackendEntry(HugeType type, byte[] bytes) {
-        this(type, BytesBuffer.wrap(bytes).parseId(type));
+        this(type, BytesBuffer.wrap(bytes).parseId(type, false));
+    }
+
+    public BinaryBackendEntry(HugeType type, byte[] bytes, boolean enablePartition) {
+        this(type, BytesBuffer.wrap(bytes).parseId(type, enablePartition));
     }
 
     public BinaryBackendEntry(HugeType type, BinaryId id) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinaryScatterSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BinaryScatterSerializer.java
@@ -24,6 +24,7 @@ import com.baidu.hugegraph.backend.id.Id;
 import com.baidu.hugegraph.backend.id.IdGenerator;
 import com.baidu.hugegraph.backend.store.BackendEntry;
 import com.baidu.hugegraph.backend.store.BackendEntry.BackendColumn;
+import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.schema.VertexLabel;
 import com.baidu.hugegraph.structure.HugeProperty;
 import com.baidu.hugegraph.structure.HugeVertex;
@@ -32,8 +33,8 @@ import com.baidu.hugegraph.type.define.HugeKeys;
 
 public class BinaryScatterSerializer extends BinarySerializer {
 
-    public BinaryScatterSerializer() {
-        super(true, true);
+    public BinaryScatterSerializer(HugeConfig config) {
+        super(true, true, false);
     }
 
     @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/BytesBuffer.java
@@ -707,6 +707,7 @@ public final class BytesBuffer extends OutputStream {
     }
 
     public BytesBuffer writeEdgeId(Id id) {
+        // owner-vertex + dir + edge-label + sort-values + other-vertex
         EdgeId edge = (EdgeId) id;
         this.writeId(edge.ownerVertexId());
         this.write(edge.directionCode());
@@ -767,11 +768,14 @@ public final class BytesBuffer extends OutputStream {
         return new BinaryId(this.bytes(), null);
     }
 
-    public BinaryId parseId(HugeType type) {
+    public BinaryId parseId(HugeType type, boolean enablePartition) {
         if (type.isIndex()) {
             return this.readIndexId(type);
         }
         // Parse id from bytes
+        if ((type.isVertex() || type.isEdge()) && enablePartition) {
+            this.readShort();
+        }
         int start = this.buffer.position();
         /*
          * Since edge id in edges table doesn't prefix with leading 0x7e,

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/SerializerFactory.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/SerializerFactory.java
@@ -19,10 +19,13 @@
 
 package com.baidu.hugegraph.backend.serializer;
 
+import java.lang.reflect.Constructor;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.baidu.hugegraph.backend.BackendException;
+import com.baidu.hugegraph.config.HugeConfig;
+import com.baidu.hugegraph.type.HugeType;
 
 public class SerializerFactory {
 
@@ -32,15 +35,15 @@ public class SerializerFactory {
         serializers = new ConcurrentHashMap<>();
     }
 
-    public static AbstractSerializer serializer(String name) {
+    public static AbstractSerializer serializer(HugeConfig config, String name) {
         name = name.toLowerCase();
         switch (name) {
             case "binary":
-                return new BinarySerializer();
+                return new BinarySerializer(config);
             case "binaryscatter":
-                return new BinaryScatterSerializer();
+                return new BinaryScatterSerializer(config);
             case "text":
-                return new TextSerializer();
+                return new TextSerializer(config);
             default:
         }
 
@@ -51,7 +54,7 @@ public class SerializerFactory {
 
         assert AbstractSerializer.class.isAssignableFrom(clazz);
         try {
-            return clazz.getConstructor().newInstance();
+            return clazz.getConstructor(HugeConfig.class).newInstance(config);
         } catch (Exception e) {
             throw new BackendException(e);
         }

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TableSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TableSerializer.java
@@ -34,6 +34,7 @@ import com.baidu.hugegraph.backend.query.Condition;
 import com.baidu.hugegraph.backend.query.ConditionQuery;
 import com.baidu.hugegraph.backend.query.Query;
 import com.baidu.hugegraph.backend.store.BackendEntry;
+import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.schema.EdgeLabel;
 import com.baidu.hugegraph.schema.IndexLabel;
 import com.baidu.hugegraph.schema.PropertyKey;
@@ -63,6 +64,10 @@ import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.JsonUtil;
 
 public abstract class TableSerializer extends AbstractSerializer {
+
+    public TableSerializer(HugeConfig config) {
+        super(config);
+    }
 
     @Override
     public TableBackendEntry newBackendEntry(HugeType type, Id id) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TextSerializer.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/serializer/TextSerializer.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import com.baidu.hugegraph.config.HugeConfig;
 import org.apache.commons.lang.NotImplementedException;
 
 import com.baidu.hugegraph.HugeException;
@@ -77,6 +78,10 @@ public class TextSerializer extends AbstractSerializer {
                                 ConditionQuery.INDEX_SYM_ENDING;
 
     private static final String EDGE_OUT_TYPE = writeType(HugeType.EDGE_OUT);
+
+    public TextSerializer(HugeConfig config) {
+        super(config);
+    }
 
     @Override
     public TextBackendEntry newBackendEntry(HugeType type, Id id) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/AbstractBackendStoreProvider.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/AbstractBackendStoreProvider.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 
+import com.baidu.hugegraph.config.HugeConfig;
 import org.slf4j.Logger;
 
 import com.baidu.hugegraph.HugeGraph;
@@ -61,9 +62,9 @@ public abstract class AbstractBackendStoreProvider
                      "The BackendStoreProvider has not been opened");
     }
 
-    protected abstract BackendStore newSchemaStore(String store);
+    protected abstract BackendStore newSchemaStore(HugeConfig config, String store);
 
-    protected abstract BackendStore newGraphStore(String store);
+    protected abstract BackendStore newGraphStore(HugeConfig config, String store);
 
     @Override
     public void listen(EventListener listener) {
@@ -170,13 +171,13 @@ public abstract class AbstractBackendStoreProvider
     }
 
     @Override
-    public BackendStore loadSchemaStore(final String name) {
+    public BackendStore loadSchemaStore(HugeConfig config, String name) {
         LOG.debug("The '{}' StoreProvider load SchemaStore '{}'",
                   this.type(), name);
 
         this.checkOpened();
         if (!this.stores.containsKey(name)) {
-            BackendStore s = this.newSchemaStore(name);
+            BackendStore s = this.newSchemaStore(config, name);
             this.stores.putIfAbsent(name, s);
         }
 
@@ -186,13 +187,13 @@ public abstract class AbstractBackendStoreProvider
     }
 
     @Override
-    public BackendStore loadGraphStore(String name) {
+    public BackendStore loadGraphStore(HugeConfig config, String name) {
         LOG.debug("The '{}' StoreProvider load GraphStore '{}'",
-                  this.type(),  name);
+                  this.type(), name);
 
         this.checkOpened();
         if (!this.stores.containsKey(name)) {
-            BackendStore s = this.newGraphStore(name);
+            BackendStore s = this.newGraphStore(config, name);
             this.stores.putIfAbsent(name, s);
         }
 
@@ -202,8 +203,8 @@ public abstract class AbstractBackendStoreProvider
     }
 
     @Override
-    public BackendStore loadSystemStore(String name) {
-        return this.loadGraphStore(name);
+    public BackendStore loadSystemStore(HugeConfig config, String name) {
+        return this.loadGraphStore(config, name);
     }
 
     @Override

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStoreProvider.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/BackendStoreProvider.java
@@ -35,11 +35,12 @@ public interface BackendStoreProvider {
     // Graph name (that's database name)
     public String graph();
 
-    public BackendStore loadSystemStore(String name);
+    public BackendStore loadSystemStore(HugeConfig config, String name);
 
-    public BackendStore loadSchemaStore(String name);
+    public BackendStore loadSchemaStore(HugeConfig config, String name);
 
-    public BackendStore loadGraphStore(String name);
+    public BackendStore loadGraphStore(HugeConfig config, String name);
+
 
     public void open(String name);
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/memory/InMemoryDBStoreProvider.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/memory/InMemoryDBStoreProvider.java
@@ -26,6 +26,7 @@ import com.baidu.hugegraph.backend.store.AbstractBackendStoreProvider;
 import com.baidu.hugegraph.backend.store.BackendStore;
 import com.baidu.hugegraph.backend.store.memory.InMemoryDBStore.InMemoryGraphStore;
 import com.baidu.hugegraph.backend.store.memory.InMemoryDBStore.InMemorySchemaStore;
+import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.util.Events;
 
 public class InMemoryDBStoreProvider extends AbstractBackendStoreProvider {
@@ -66,12 +67,12 @@ public class InMemoryDBStoreProvider extends AbstractBackendStoreProvider {
     }
 
     @Override
-    protected BackendStore newSchemaStore(String store) {
+    protected BackendStore newSchemaStore(HugeConfig config, String store) {
         return new InMemorySchemaStore(this, this.graph(), store);
     }
 
     @Override
-    protected BackendStore newGraphStore(String store) {
+    protected BackendStore newGraphStore(HugeConfig config, String store) {
         return new InMemoryGraphStore(this, this.graph(), store);
     }
 

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/raft/RaftBackendStoreProvider.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/raft/RaftBackendStoreProvider.java
@@ -22,6 +22,7 @@ package com.baidu.hugegraph.backend.store.raft;
 import java.util.Set;
 import java.util.concurrent.Future;
 
+import com.baidu.hugegraph.config.HugeConfig;
 import org.slf4j.Logger;
 
 import com.baidu.hugegraph.HugeGraph;
@@ -97,10 +98,10 @@ public class RaftBackendStoreProvider implements BackendStoreProvider {
     }
 
     @Override
-    public synchronized BackendStore loadSchemaStore(final String name) {
+    public synchronized BackendStore loadSchemaStore(HugeConfig config, String name) {
         if (this.schemaStore == null) {
             LOG.info("Init raft backend schema store");
-            BackendStore store = this.provider.loadSchemaStore(name);
+            BackendStore store = this.provider.loadSchemaStore(config, name);
             this.checkNonSharedStore(store);
             this.schemaStore = new RaftBackendStore(store, this.context);
             this.context.addStore(StoreType.SCHEMA, this.schemaStore);
@@ -109,10 +110,10 @@ public class RaftBackendStoreProvider implements BackendStoreProvider {
     }
 
     @Override
-    public synchronized BackendStore loadGraphStore(String name) {
+    public synchronized BackendStore loadGraphStore(HugeConfig config, String name) {
         if (this.graphStore == null) {
             LOG.info("Init raft backend graph store");
-            BackendStore store = this.provider.loadGraphStore(name);
+            BackendStore store = this.provider.loadGraphStore(config, name);
             this.checkNonSharedStore(store);
             this.graphStore = new RaftBackendStore(store, this.context);
             this.context.addStore(StoreType.GRAPH, this.graphStore);
@@ -121,10 +122,10 @@ public class RaftBackendStoreProvider implements BackendStoreProvider {
     }
 
     @Override
-    public synchronized BackendStore loadSystemStore(String name) {
+    public synchronized BackendStore loadSystemStore(HugeConfig config, String name) {
         if (this.systemStore == null) {
             LOG.info("Init raft backend system store");
-            BackendStore store = this.provider.loadSystemStore(name);
+            BackendStore store = this.provider.loadSystemStore(config, name);
             this.checkNonSharedStore(store);
             this.systemStore = new RaftBackendStore(store, this.context);
             this.context.addStore(StoreType.SYSTEM, this.systemStore);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamTable.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/store/ram/RamTable.java
@@ -200,6 +200,7 @@ public final class RamTable {
         Id lastId = IdGenerator.ZERO;
         while (vertices.hasNext()) {
             Id vertex = (Id) vertices.next().id();
+            LOG.info("scan from hbase {} loadfromDB", vertex);
             if (vertex.compareTo(lastId) < 0) {
                 throw new HugeException("The ramtable feature is not " +
                                         "supported by %s backend",
@@ -541,6 +542,7 @@ public final class RamTable {
             if (this.vertices.size() > 0) {
                 lastId = this.vertices.get(this.vertices.size() - 1);
             }
+            LOG.info("scan from hbase source {} lastId value: {} compare {} size {}", vertex, lastId, vertex.compareTo(lastId), this.vertices.size());
             if (vertex.compareTo(lastId) < 0) {
                 throw new HugeException("The ramtable feature is not " +
                                         "supported by %s backend",

--- a/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
+++ b/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
@@ -66,6 +66,12 @@ cassandra.password=
 #hbase.port=2181
 #hbase.znode_parent=/hbase
 #hbase.threads_max=64
+# IMPORTANT: recommend to modify the HBase partition number
+#            by the actual/env data amount & RS amount before init store
+#            It will influence the load speed a lot
+#hbase.enable_partition=true
+#hbase.vertex_partitions=10
+#hbase.edge_partitions=30
 
 # mysql backend config
 #jdbc.driver=com.mysql.jdbc.Driver

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseFeatures.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseFeatures.java
@@ -36,12 +36,12 @@ public class HbaseFeatures implements BackendFeatures {
 
     @Override
     public boolean supportsScanKeyPrefix() {
-        return !enablePartition;
+        return !this.enablePartition;
     }
 
     @Override
     public boolean supportsScanKeyRange() {
-        return !enablePartition;
+        return !this.enablePartition;
     }
 
     @Override

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseFeatures.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseFeatures.java
@@ -23,6 +23,12 @@ import com.baidu.hugegraph.backend.store.BackendFeatures;
 
 public class HbaseFeatures implements BackendFeatures {
 
+    private boolean enablePartition;
+
+    public HbaseFeatures(boolean enablePartition) {
+        this.enablePartition = enablePartition;
+    }
+
     @Override
     public boolean supportsScanToken() {
         return false;
@@ -30,12 +36,12 @@ public class HbaseFeatures implements BackendFeatures {
 
     @Override
     public boolean supportsScanKeyPrefix() {
-        return true;
+        return !enablePartition;
     }
 
     @Override
     public boolean supportsScanKeyRange() {
-        return true;
+        return !enablePartition;
     }
 
     @Override

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseOptions.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseOptions.java
@@ -22,6 +22,7 @@ package com.baidu.hugegraph.backend.store.hbase;
 import static com.baidu.hugegraph.config.OptionChecker.disallowEmpty;
 import static com.baidu.hugegraph.config.OptionChecker.positiveInt;
 import static com.baidu.hugegraph.config.OptionChecker.rangeInt;
+import static com.baidu.hugegraph.config.OptionChecker.nonNegativeInt;
 
 import com.baidu.hugegraph.config.ConfigOption;
 import com.baidu.hugegraph.config.OptionHolder;
@@ -136,5 +137,29 @@ public class HbaseOptions extends OptionHolder {
                     "The HBase's key tab file for kerberos authentication.",
                     null,
                     ""
+            );
+
+    public static final ConfigOption<Boolean> HBASE_ENABLE_PARTITION =
+            new ConfigOption<>(
+                    "hbase.enable_partition",
+                    "Is pre-split partitions enabled for HBase.",
+                    disallowEmpty(),
+                    true
+            );
+
+    public static final ConfigOption<Integer> HBASE_VERTEX_PARTITION =
+            new ConfigOption<>(
+                    "hbase.vertex_partitions",
+                    "The number of partitions of the HBase vertex table",
+                    nonNegativeInt(),
+                    10
+            );
+
+    public static final ConfigOption<Integer> HBASE_EDGE_PARTITION =
+            new ConfigOption<>(
+                    "hbase.edge_partitions",
+                    "The number of partitions of the HBase edge table",
+                    nonNegativeInt(),
+                    30
             );
 }

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStore.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStore.java
@@ -54,7 +54,7 @@ public abstract class HbaseStore extends AbstractBackendStore<Session> {
 
     private static final Logger LOG = Log.logger(HbaseStore.class);
 
-    private static BackendFeatures FEATURES;
+    private final BackendFeatures FEATURES;
 
     private final String store;
     private final String namespace;
@@ -66,8 +66,8 @@ public abstract class HbaseStore extends AbstractBackendStore<Session> {
 
     private HbaseSessions sessions;
 
-    public HbaseStore(final BackendStoreProvider provider,
-                      final String namespace, final String store, boolean enablePartition) {
+    public HbaseStore(BackendStoreProvider provider,
+                      String namespace, String store, boolean enablePartition) {
         this.tables = new HashMap<>();
 
         this.provider = provider;

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStore.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStore.java
@@ -54,7 +54,7 @@ public abstract class HbaseStore extends AbstractBackendStore<Session> {
 
     private static final Logger LOG = Log.logger(HbaseStore.class);
 
-    private static final BackendFeatures FEATURES = new HbaseFeatures();
+    private static BackendFeatures FEATURES;
 
     private final String store;
     private final String namespace;
@@ -67,13 +67,14 @@ public abstract class HbaseStore extends AbstractBackendStore<Session> {
     private HbaseSessions sessions;
 
     public HbaseStore(final BackendStoreProvider provider,
-                      final String namespace, final String store) {
+                      final String namespace, final String store, boolean enablePartition) {
         this.tables = new HashMap<>();
 
         this.provider = provider;
         this.namespace = namespace;
         this.store = store;
         this.sessions = null;
+        this.FEATURES = new HbaseFeatures(enablePartition);
 
         this.registerMetaHandlers();
         LOG.debug("Store loaded: {}", store);
@@ -442,9 +443,9 @@ public abstract class HbaseStore extends AbstractBackendStore<Session> {
 
         private final HbaseTables.Counters counters;
 
-        public HbaseSchemaStore(BackendStoreProvider provider,
+        public HbaseSchemaStore(HugeConfig config, BackendStoreProvider provider,
                                 String namespace, String store) {
-            super(provider, namespace, store);
+            super(provider, namespace, store, config.get(HbaseOptions.HBASE_ENABLE_PARTITION).booleanValue());
 
             this.counters = new HbaseTables.Counters();
 
@@ -491,7 +492,7 @@ public abstract class HbaseStore extends AbstractBackendStore<Session> {
         private boolean enablePartition;
         public HbaseGraphStore(HugeConfig config, BackendStoreProvider provider,
                                String namespace, String store) {
-            super(provider, namespace, store);
+            super(provider, namespace, store, config.get(HbaseOptions.HBASE_ENABLE_PARTITION).booleanValue());
             this.enablePartition = config.get(HbaseOptions.HBASE_ENABLE_PARTITION).booleanValue();
             registerTableManager(HugeType.VERTEX,
                                  new HbaseTables.Vertex(store, enablePartition));

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStoreProvider.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStoreProvider.java
@@ -33,7 +33,7 @@ public class HbaseStoreProvider extends AbstractBackendStoreProvider {
 
     @Override
     protected BackendStore newSchemaStore(HugeConfig config, String store) {
-        return new HbaseSchemaStore(this, this.namespace(), store);
+        return new HbaseSchemaStore(config, this, this.namespace(), store);
     }
 
     @Override

--- a/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStoreProvider.java
+++ b/hugegraph-hbase/src/main/java/com/baidu/hugegraph/backend/store/hbase/HbaseStoreProvider.java
@@ -23,6 +23,7 @@ import com.baidu.hugegraph.backend.store.AbstractBackendStoreProvider;
 import com.baidu.hugegraph.backend.store.BackendStore;
 import com.baidu.hugegraph.backend.store.hbase.HbaseStore.HbaseGraphStore;
 import com.baidu.hugegraph.backend.store.hbase.HbaseStore.HbaseSchemaStore;
+import com.baidu.hugegraph.config.HugeConfig;
 
 public class HbaseStoreProvider extends AbstractBackendStoreProvider {
 
@@ -31,13 +32,13 @@ public class HbaseStoreProvider extends AbstractBackendStoreProvider {
     }
 
     @Override
-    protected BackendStore newSchemaStore(String store) {
+    protected BackendStore newSchemaStore(HugeConfig config, String store) {
         return new HbaseSchemaStore(this, this.namespace(), store);
     }
 
     @Override
-    protected BackendStore newGraphStore(String store) {
-        return new HbaseGraphStore(this, this.namespace(), store);
+    protected BackendStore newGraphStore(HugeConfig config, String store) {
+        return new HbaseGraphStore(config, this, this.namespace(), store);
     }
 
     @Override

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSerializer.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlSerializer.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.baidu.hugegraph.config.HugeConfig;
 import org.apache.commons.lang.NotImplementedException;
 
 import com.baidu.hugegraph.backend.BackendException;
@@ -42,6 +43,10 @@ import com.baidu.hugegraph.util.InsertionOrderUtil;
 import com.baidu.hugegraph.util.JsonUtil;
 
 public class MysqlSerializer extends TableSerializer {
+
+    public MysqlSerializer(HugeConfig config) {
+        super(config);
+    }
 
     @Override
     public MysqlBackendEntry newBackendEntry(HugeType type, Id id) {

--- a/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlStoreProvider.java
+++ b/hugegraph-mysql/src/main/java/com/baidu/hugegraph/backend/store/mysql/MysqlStoreProvider.java
@@ -23,6 +23,7 @@ import com.baidu.hugegraph.backend.store.AbstractBackendStoreProvider;
 import com.baidu.hugegraph.backend.store.BackendStore;
 import com.baidu.hugegraph.backend.store.mysql.MysqlStore.MysqlGraphStore;
 import com.baidu.hugegraph.backend.store.mysql.MysqlStore.MysqlSchemaStore;
+import com.baidu.hugegraph.config.HugeConfig;
 
 public class MysqlStoreProvider extends AbstractBackendStoreProvider {
 
@@ -31,12 +32,12 @@ public class MysqlStoreProvider extends AbstractBackendStoreProvider {
     }
 
     @Override
-    protected BackendStore newSchemaStore(String store) {
+    protected BackendStore newSchemaStore(HugeConfig config, String store) {
         return new MysqlSchemaStore(this, this.database(), store);
     }
 
     @Override
-    protected BackendStore newGraphStore(String store) {
+    protected BackendStore newGraphStore(HugeConfig config, String store) {
         return new MysqlGraphStore(this, this.database(), store);
     }
 

--- a/hugegraph-palo/src/main/java/com/baidu/hugegraph/backend/store/palo/PaloSerializer.java
+++ b/hugegraph-palo/src/main/java/com/baidu/hugegraph/backend/store/palo/PaloSerializer.java
@@ -21,10 +21,15 @@ package com.baidu.hugegraph.backend.store.palo;
 
 import com.baidu.hugegraph.backend.serializer.TableBackendEntry;
 import com.baidu.hugegraph.backend.store.mysql.MysqlSerializer;
+import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.schema.SchemaLabel;
 import com.baidu.hugegraph.type.define.HugeKeys;
 
 public class PaloSerializer extends MysqlSerializer {
+
+    public PaloSerializer(HugeConfig config) {
+        super(config);
+    }
 
     @Override
     protected void writeEnableLabelIndex(SchemaLabel schema,

--- a/hugegraph-palo/src/main/java/com/baidu/hugegraph/backend/store/palo/PaloStoreProvider.java
+++ b/hugegraph-palo/src/main/java/com/baidu/hugegraph/backend/store/palo/PaloStoreProvider.java
@@ -25,6 +25,7 @@ import com.baidu.hugegraph.backend.store.BackendFeatures;
 import com.baidu.hugegraph.backend.store.BackendStore;
 import com.baidu.hugegraph.backend.store.BackendStoreProvider;
 import com.baidu.hugegraph.backend.store.mysql.MysqlStoreProvider;
+import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.type.define.Directions;
 
@@ -33,12 +34,12 @@ public class PaloStoreProvider extends MysqlStoreProvider {
     private static final BackendFeatures FEATURES = new PaloFeatures();
 
     @Override
-    protected BackendStore newSchemaStore(String store) {
+    protected BackendStore newSchemaStore(HugeConfig config, String store) {
         return new PaloSchemaStore(this, this.database(), store);
     }
 
     @Override
-    protected BackendStore newGraphStore(String store) {
+    protected BackendStore newGraphStore(HugeConfig config, String store) {
         return new PaloGraphStore(this, this.database(), store);
     }
 

--- a/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlSerializer.java
+++ b/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlSerializer.java
@@ -19,6 +19,7 @@
 
 package com.baidu.hugegraph.backend.store.postgresql;
 
+import com.baidu.hugegraph.config.HugeConfig;
 import org.apache.logging.log4j.util.Strings;
 
 import com.baidu.hugegraph.backend.id.IdUtil;
@@ -29,6 +30,10 @@ import com.baidu.hugegraph.structure.HugeIndex;
 import com.baidu.hugegraph.type.define.HugeKeys;
 
 public class PostgresqlSerializer extends MysqlSerializer {
+
+    public PostgresqlSerializer(HugeConfig config) {
+        super(config);
+    }
 
     @Override
     public BackendEntry writeIndex(HugeIndex index) {

--- a/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlStoreProvider.java
+++ b/hugegraph-postgresql/src/main/java/com/baidu/hugegraph/backend/store/postgresql/PostgresqlStoreProvider.java
@@ -29,18 +29,19 @@ import com.baidu.hugegraph.backend.store.BackendStoreProvider;
 import com.baidu.hugegraph.backend.store.mysql.MysqlSessions;
 import com.baidu.hugegraph.backend.store.mysql.MysqlStoreProvider;
 import com.baidu.hugegraph.backend.store.mysql.MysqlTable;
+import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.type.HugeType;
 import com.baidu.hugegraph.type.define.Directions;
 
 public class PostgresqlStoreProvider extends MysqlStoreProvider {
 
     @Override
-    protected BackendStore newSchemaStore(String store) {
+    protected BackendStore newSchemaStore(HugeConfig config, String store) {
         return new PostgresqlSchemaStore(this, this.database(), store);
     }
 
     @Override
-    protected BackendStore newGraphStore(String store) {
+    protected BackendStore newGraphStore(HugeConfig config, String store) {
         return new PostgresqlGraphStore(this, this.database(), store);
     }
 

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStoreProvider.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdb/RocksDBStoreProvider.java
@@ -35,12 +35,12 @@ public class RocksDBStoreProvider extends AbstractBackendStoreProvider {
     }
 
     @Override
-    protected BackendStore newSchemaStore(String store) {
+    protected BackendStore newSchemaStore(HugeConfig config, String store) {
         return new RocksDBSchemaStore(this, this.database(), store);
     }
 
     @Override
-    protected BackendStore newGraphStore(String store) {
+    protected BackendStore newGraphStore(HugeConfig config, String store) {
         return new RocksDBGraphStore(this, this.database(), store);
     }
 

--- a/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdbsst/RocksDBSstStoreProvider.java
+++ b/hugegraph-rocksdb/src/main/java/com/baidu/hugegraph/backend/store/rocksdbsst/RocksDBSstStoreProvider.java
@@ -22,11 +22,12 @@ package com.baidu.hugegraph.backend.store.rocksdbsst;
 import com.baidu.hugegraph.backend.store.BackendStore;
 import com.baidu.hugegraph.backend.store.rocksdb.RocksDBStoreProvider;
 import com.baidu.hugegraph.backend.store.rocksdbsst.RocksDBSstStore.RocksDBSstGraphStore;
+import com.baidu.hugegraph.config.HugeConfig;
 
 public class RocksDBSstStoreProvider extends RocksDBStoreProvider {
 
     @Override
-    protected BackendStore newGraphStore(String store) {
+    protected BackendStore newGraphStore(HugeConfig config, String store) {
         return new RocksDBSstGraphStore(this, this.database(), store);
     }
 

--- a/hugegraph-scylladb/src/main/java/com/baidu/hugegraph/backend/store/scylladb/ScyllaDBStoreProvider.java
+++ b/hugegraph-scylladb/src/main/java/com/baidu/hugegraph/backend/store/scylladb/ScyllaDBStoreProvider.java
@@ -45,7 +45,7 @@ public class ScyllaDBStoreProvider extends CassandraStoreProvider {
     }
 
     @Override
-    public BackendStore loadSchemaStore(String name) {
+    public BackendStore loadSchemaStore(HugeConfig config, String name) {
         LOG.debug("ScyllaDBStoreProvider load SchemaStore '{}'", name);
 
         if (!this.stores.containsKey(name)) {
@@ -61,7 +61,7 @@ public class ScyllaDBStoreProvider extends CassandraStoreProvider {
     }
 
     @Override
-    public BackendStore loadGraphStore(String name) {
+    public BackendStore loadGraphStore(HugeConfig config, String name) {
         LOG.debug("ScyllaDBStoreProvider load GraphStore '{}'", name);
 
         if (!this.stores.containsKey(name)) {

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/FakeObjects.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/FakeObjects.java
@@ -172,4 +172,47 @@ public final class FakeObjects {
 
         return edge;
     }
+
+    public HugeEdge newEdge(String sourceVertexId, String targetVertexId) {
+        PropertyKey name = this.newPropertyKey(IdGenerator.of(1), "name");
+        PropertyKey age = this.newPropertyKey(IdGenerator.of(2), "age",
+                                              DataType.INT,
+                                              Cardinality.SINGLE);
+        PropertyKey city = this.newPropertyKey(IdGenerator.of(3), "city");
+        PropertyKey date = this.newPropertyKey(IdGenerator.of(4), "date",
+                                               DataType.DATE);
+        PropertyKey weight = this.newPropertyKey(IdGenerator.of(5),
+                                                "weight", DataType.DOUBLE);
+
+        VertexLabel vl = this.newVertexLabel(IdGenerator.of(1), "person",
+                                             IdStrategy.CUSTOMIZE_NUMBER,
+                                             name.id(), age.id(), city.id());
+
+        EdgeLabel el = this.newEdgeLabel(IdGenerator.of(1), "knows",
+                                         Frequency.SINGLE,  vl.id(), vl.id(),
+                                         date.id(), weight.id());
+
+        HugeVertex source = new HugeVertex(this.graph(),
+                                           IdGenerator.of(sourceVertexId), vl);
+        source.addProperty(name, "tom");
+        source.addProperty(age, 18);
+        source.addProperty(city, "Beijing");
+
+        HugeVertex target = new HugeVertex(this.graph(),
+                                           IdGenerator.of(targetVertexId), vl);
+        target.addProperty(name, "cat");
+        target.addProperty(age, 20);
+        target.addProperty(city, "Shanghai");
+
+        Id id = EdgeId.parse("L123456>1>>L987654");
+        HugeEdge edge = new HugeEdge(this.graph(), id, el);
+
+        Whitebox.setInternalState(edge, "sourceVertex", source);
+        Whitebox.setInternalState(edge, "targetVertex", target);
+        edge.assignId();
+        edge.addProperty(date, new Date());
+        edge.addProperty(weight, 0.75);
+
+        return edge;
+    }
 }

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/serializer/BinaryScatterSerializerTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/serializer/BinaryScatterSerializerTest.java
@@ -19,6 +19,7 @@
 
 package com.baidu.hugegraph.unit.serializer;
 
+import com.baidu.hugegraph.config.HugeConfig;
 import org.junit.Test;
 
 import com.baidu.hugegraph.backend.serializer.BinaryBackendEntry;
@@ -35,7 +36,8 @@ public class BinaryScatterSerializerTest extends BaseUnitTest {
 
     @Test
     public void testVertex() {
-        BinaryScatterSerializer ser = new BinaryScatterSerializer();
+        HugeConfig config = FakeObjects.newConfig();
+        BinaryScatterSerializer ser = new BinaryScatterSerializer(config);
         HugeEdge edge = new FakeObjects().newEdge(123, 456);
 
         BackendEntry entry1 = ser.writeVertex(edge.sourceVertex());
@@ -60,7 +62,8 @@ public class BinaryScatterSerializerTest extends BaseUnitTest {
 
     @Test
     public void testEdge() {
-        BinaryScatterSerializer ser = new BinaryScatterSerializer();
+        HugeConfig config = FakeObjects.newConfig();
+        BinaryScatterSerializer ser = new BinaryScatterSerializer(config);
 
         FakeObjects objects = new FakeObjects();
         HugeEdge edge1 = objects.newEdge(123, 456);

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/serializer/BinarySerializerTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/serializer/BinarySerializerTest.java
@@ -19,6 +19,7 @@
 
 package com.baidu.hugegraph.unit.serializer;
 
+import com.baidu.hugegraph.config.HugeConfig;
 import org.junit.Test;
 
 import com.baidu.hugegraph.backend.serializer.BinarySerializer;
@@ -34,7 +35,8 @@ public class BinarySerializerTest extends BaseUnitTest {
 
     @Test
     public void testVertex() {
-        BinarySerializer ser = new BinarySerializer();
+        HugeConfig config = FakeObjects.newConfig();
+        BinarySerializer ser = new BinarySerializer(config);
         HugeEdge edge = new FakeObjects().newEdge(123, 456);
 
         BackendEntry entry1 = ser.writeVertex(edge.sourceVertex());
@@ -59,7 +61,8 @@ public class BinarySerializerTest extends BaseUnitTest {
 
     @Test
     public void testEdge() {
-        BinarySerializer ser = new BinarySerializer();
+        HugeConfig config = FakeObjects.newConfig();
+        BinarySerializer ser = new BinarySerializer(config);
 
         FakeObjects objects = new FakeObjects();
         HugeEdge edge1 = objects.newEdge(123, 456);
@@ -74,6 +77,54 @@ public class BinarySerializerTest extends BaseUnitTest {
 
         BackendEntry entry2 = ser.writeEdge(edge2);
         HugeVertex vertex2 = ser.readVertex(edge1.graph(), entry2);
+        Assert.assertEquals(1, vertex2.getEdges().size());
+        edge = vertex2.getEdges().iterator().next();
+        Assert.assertEquals(edge2, edge);
+        assertCollectionEquals(edge2.getProperties(), edge.getProperties());
+    }
+
+    @Test
+    public void testVertexForPartition() {
+        BinarySerializer ser = new BinarySerializer(true, true, true);
+        HugeEdge edge = new FakeObjects().newEdge("123", "456");
+
+        BackendEntry entry1 = ser.writeVertex(edge.sourceVertex());
+        HugeVertex vertex1 = ser.readVertex(edge.graph(), entry1);
+        Assert.assertEquals(edge.sourceVertex(), vertex1);
+        assertCollectionEquals(edge.sourceVertex().getProperties(),
+                               vertex1.getProperties());
+
+        BackendEntry entry2 = ser.writeVertex(edge.targetVertex());
+        HugeVertex vertex2 = ser.readVertex(edge.graph(), entry2);
+        Assert.assertEquals(edge.targetVertex(), vertex2);
+        assertCollectionEquals(edge.targetVertex().getProperties(),
+                               vertex2.getProperties());
+
+        Whitebox.setInternalState(vertex2, "removed", true);
+        Assert.assertTrue(vertex2.removed());
+        BackendEntry entry3 = ser.writeVertex(vertex2);
+        Assert.assertEquals(0, entry3.columnsSize());
+
+        Assert.assertNull(ser.readVertex(edge.graph(), null));
+    }
+
+    @Test
+    public void testEdgeForPartition() {
+        BinarySerializer ser = new BinarySerializer(true, true, true);
+
+        FakeObjects objects = new FakeObjects();
+        HugeEdge edge1 = objects.newEdge("123", "456");
+        HugeEdge edge2 = objects.newEdge("147", "789");
+
+        BackendEntry entry1 = ser.writeEdge(edge1);
+        HugeVertex vertex1 = ser.readVertex(edge1.graph(), ser.parse(entry1));
+        Assert.assertEquals(1, vertex1.getEdges().size());
+        HugeEdge edge = vertex1.getEdges().iterator().next();
+        Assert.assertEquals(edge1, edge);
+        assertCollectionEquals(edge1.getProperties(), edge.getProperties());
+
+        BackendEntry entry2 = ser.writeEdge(edge2);
+        HugeVertex vertex2 = ser.readVertex(edge1.graph(), ser.parse(entry2));
         Assert.assertEquals(1, vertex2.getEdges().size());
         edge = vertex2.getEdges().iterator().next();
         Assert.assertEquals(edge2, edge);

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/serializer/SerializerFactoryTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/serializer/SerializerFactoryTest.java
@@ -19,6 +19,9 @@
 
 package com.baidu.hugegraph.unit.serializer;
 
+import com.baidu.hugegraph.config.HugeConfig;
+import com.baidu.hugegraph.type.HugeType;
+import com.baidu.hugegraph.unit.FakeObjects;
 import org.junit.Test;
 
 import com.baidu.hugegraph.backend.BackendException;
@@ -34,18 +37,19 @@ public class SerializerFactoryTest extends BaseUnitTest {
 
     @Test
     public void testSerializer() {
-        AbstractSerializer serializer = SerializerFactory.serializer("text");
+        HugeConfig config = FakeObjects.newConfig();
+        AbstractSerializer serializer = SerializerFactory.serializer(config,"text");
         Assert.assertEquals(TextSerializer.class, serializer.getClass());
 
-        serializer = SerializerFactory.serializer("binary");
+        serializer = SerializerFactory.serializer(config, "binary");
         Assert.assertEquals(BinarySerializer.class, serializer.getClass());
 
-        serializer = SerializerFactory.serializer("binaryscatter");
+        serializer = SerializerFactory.serializer(config, "binaryscatter");
         Assert.assertEquals(BinaryScatterSerializer.class,
                             serializer.getClass());
 
         Assert.assertThrows(BackendException.class, () -> {
-            SerializerFactory.serializer("invalid");
+            SerializerFactory.serializer(config, "invalid");
         }, e -> {
             Assert.assertContains("Not exists serializer:", e.getMessage());
         });
@@ -53,9 +57,10 @@ public class SerializerFactoryTest extends BaseUnitTest {
 
     @Test
     public void testRegister() {
+        HugeConfig config = FakeObjects.newConfig();
         SerializerFactory.register("fake", FakeSerializer.class.getName());
         Assert.assertEquals(FakeSerializer.class,
-                            SerializerFactory.serializer("fake").getClass());
+                            SerializerFactory.serializer(config, "fake").getClass());
 
         Assert.assertThrows(BackendException.class, () -> {
             // exist
@@ -82,8 +87,12 @@ public class SerializerFactoryTest extends BaseUnitTest {
 
     public static class FakeSerializer extends BinarySerializer {
 
+        public FakeSerializer(HugeConfig config){
+            super(config);
+        }
+
         public FakeSerializer() {
-            super(true, true);
+            super(true, true, false);
         }
     }
 }


### PR DESCRIPTION
implement feature #822 

目前实现了HBase 点 边表的预分区 及可配置化
核心设计逻辑：
取2字节作为rowkey前缀：(short) (startNode.hashCode() % totalPartitions)
具体使用：
hugegraph.properties 配置文件 增加如下配置

是否打开预分区
hbase.enable_partition=true「默认值」

点表预分区
hbase.vertex_partition=10「默认值」

边表预分区
hbase.edge_partition=30「默认值」

注: 下面的结构简图是简单推测, 实际情况如有不同请更新一下

```mermaid
graph LR

full((Hbase Rowkey)) --字符串 vid--> a0(2 Byte hash) --append--> a(1 Byte vid长度)--append-->a1(1-128 Byte 不定长字符串 vid)--final-->a2(完整rowkey: 4-131 字节)

full --数值 vid--> b0(2 Byte hash) --append--> b(1 Byte 标识长度)--append-->b1(1-8 Byte-变长)--final-->b2(完整rowkey: 4-8 字节)

full --UUID 类 vid--> c0(2 Byte hash) --append--> c(1 Byte 标识UUID)--append-->c1(写入固定16 Byte)--final-->c2(完整rowkey: 19 字节)

```