### PR TITLE
fix(core): edge cache not clear when update or delete associated vertex

### DIFF
--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
@@ -398,7 +398,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
             // for vertex change, the edge associated with that vertex should also be updated
             // here we just clear all the edge cache , before we use a more precise strategy
             boolean invalidEdgesCache = (this.edgesInTxSize() + updates.size() + deletions.size()) > 0;
-            if (invalidEdgesCache) {
+            if (invalidEdgesCache && this.enableCacheEdge()) {
                 // TODO: Use a more precise strategy to update the edge cache
                 this.edgesCache.clear();
                 this.notifyChanges(Cache.ACTION_CLEARED, HugeType.EDGE, null);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
@@ -394,8 +394,11 @@ public final class CachedGraphTransaction extends GraphTransaction {
                 }
             }
 
-            // Update edge cache if any edges change
-            if (edgesInTxSize > 0 && this.enableCacheEdge()) {
+            // Update edge cache if any vertex or edge change
+            // for vertex change, the edge associated with that vertex should also be updated
+            // here we just clear all the edge cache , before we use a more precise strategy
+            boolean invalidEdgesCache = (this.edgesInTxSize() + updates.size() + deletions.size()) > 0;
+            if (invalidEdgesCache) {
                 // TODO: Use a more precise strategy to update the edge cache
                 this.edgesCache.clear();
                 this.notifyChanges(Cache.ACTION_CLEARED, HugeType.EDGE, null);

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
@@ -397,7 +397,7 @@ public final class CachedGraphTransaction extends GraphTransaction {
             /*
              * Update edge cache if any vertex or edge changed
              * For vertex change, the edges linked with should also be updated
-             * Before we use a more precise strategy,now we just clear all the edge cache
+             * Before we find a more precise strategy, just clear all the edge cache now
              */
             boolean invalidEdgesCache = (edgesInTxSize + updates.size() + deletions.size()) > 0;
             if (invalidEdgesCache && this.enableCacheEdge()) {

--- a/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
+++ b/hugegraph-core/src/main/java/com/baidu/hugegraph/backend/cache/CachedGraphTransaction.java
@@ -394,10 +394,12 @@ public final class CachedGraphTransaction extends GraphTransaction {
                 }
             }
 
-            // Update edge cache if any vertex or edge change
-            // for vertex change, the edge associated with that vertex should also be updated
-            // here we just clear all the edge cache , before we use a more precise strategy
-            boolean invalidEdgesCache = (this.edgesInTxSize() + updates.size() + deletions.size()) > 0;
+            /*
+             * Update edge cache if any vertex or edge changed
+             * For vertex change, the edges linked with should also be updated
+             * Before we use a more precise strategy,now we just clear all the edge cache
+             */
+            boolean invalidEdgesCache = (edgesInTxSize + updates.size() + deletions.size()) > 0;
             if (invalidEdgesCache && this.enableCacheEdge()) {
                 // TODO: Use a more precise strategy to update the edge cache
                 this.edgesCache.clear();

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedGraphTransactionTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedGraphTransactionTest.java
@@ -19,8 +19,6 @@
 
 package com.baidu.hugegraph.unit.cache;
 
-import com.baidu.hugegraph.structure.HugeEdge;
-import com.baidu.hugegraph.structure.HugeVertexProperty;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +30,9 @@ import com.baidu.hugegraph.backend.cache.CachedGraphTransaction;
 import com.baidu.hugegraph.backend.id.Id;
 import com.baidu.hugegraph.backend.id.IdGenerator;
 import com.baidu.hugegraph.schema.VertexLabel;
+import com.baidu.hugegraph.structure.HugeEdge;
 import com.baidu.hugegraph.structure.HugeVertex;
+import com.baidu.hugegraph.structure.HugeVertexProperty;
 import com.baidu.hugegraph.testutil.Assert;
 import com.baidu.hugegraph.testutil.Whitebox;
 import com.baidu.hugegraph.type.HugeType;
@@ -68,24 +68,24 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
     private HugeVertex newVertex(Id id) {
         HugeGraph graph = this.cache().graph();
         graph.schema().propertyKey("name").asText()
-                .checkExist(false).create();
+             .checkExist(false).create();
         graph.schema().vertexLabel("person")
-                .idStrategy(IdStrategy.CUSTOMIZE_NUMBER)
-                .properties("name").nullableKeys("name")
-                .checkExist(false)
-                .create();
+             .idStrategy(IdStrategy.CUSTOMIZE_NUMBER)
+             .properties("name").nullableKeys("name")
+             .checkExist(false)
+             .create();
         VertexLabel vl = graph.vertexLabel("person");
         return new HugeVertex(graph, id, vl);
     }
 
-    private HugeEdge newEdge(HugeVertex out, HugeVertex in){
+    private HugeEdge newEdge(HugeVertex out, HugeVertex in) {
         HugeGraph graph = this.cache().graph();
         graph.schema().edgeLabel("person_know_person")
-                .sourceLabel("person")
-                .targetLabel("person")
-                .checkExist(false)
-                .create();
-        return out.addEdge("person_know_person",in);
+             .sourceLabel("person")
+             .targetLabel("person")
+             .checkExist(false)
+             .create();
+        return out.addEdge("person_know_person", in);
     }
 
     @Test
@@ -143,7 +143,7 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
 
 
     @Test
-    public void testClearEdgeCacheWhenDeleteVertex(){
+    public void testEdgeCacheClearWhenDeleteVertex() {
         CachedGraphTransaction cache = this.cache();
         HugeVertex v1 = this.newVertex(IdGenerator.of(1));
         HugeVertex v2 = this.newVertex(IdGenerator.of(2));
@@ -152,35 +152,34 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
         cache.addVertex(v1);
         cache.addVertex(v2);
         cache.commit();
-        HugeEdge edge = this.newEdge(v1,v2);
+        HugeEdge edge = this.newEdge(v1, v2);
         cache.addEdge(edge);
         cache.commit();
         Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(1)).hasNext());
         Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(2)).hasNext());
 
         Assert.assertEquals(2L,
-                Whitebox.invoke(cache, "edgesCache", "size"));
+                            Whitebox.invoke(cache, "edgesCache", "size"));
         cache.removeVertex(v3);
         cache.commit();
         Assert.assertEquals(0L,
-                Whitebox.invoke(cache, "edgesCache", "size"));
+                            Whitebox.invoke(cache, "edgesCache", "size"));
 
         Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(1)).hasNext());
         Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(2)).hasNext());
         Assert.assertEquals(2L,
-                Whitebox.invoke(cache, "edgesCache", "size"));
+                            Whitebox.invoke(cache, "edgesCache", "size"));
 
         cache.removeVertex(v1);
         cache.commit();
 
         Assert.assertEquals(0L,
-                Whitebox.invoke(cache, "edgesCache", "size"));
+                            Whitebox.invoke(cache, "edgesCache", "size"));
         Assert.assertFalse(cache.queryEdgesByVertex(IdGenerator.of(2)).hasNext());
-
     }
 
     @Test
-    public void testClearEdgeCacheWhenUpdateVertex(){
+    public void testEdgeCacheClearWhenUpdateVertex() {
         CachedGraphTransaction cache = this.cache();
         HugeVertex v1 = this.newVertex(IdGenerator.of(1));
         HugeVertex v2 = this.newVertex(IdGenerator.of(2));
@@ -189,38 +188,36 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
         cache.addVertex(v1);
         cache.addVertex(v2);
         cache.commit();
-        HugeEdge edge = this.newEdge(v1,v2);
+        HugeEdge edge = this.newEdge(v1, v2);
         cache.addEdge(edge);
         cache.commit();
         Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(1)).hasNext());
         Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(2)).hasNext());
 
         Assert.assertEquals(2L,
-                Whitebox.invoke(cache, "edgesCache", "size"));
+                            Whitebox.invoke(cache, "edgesCache", "size"));
 
-        ///update property of v3
         cache.addVertexProperty(new HugeVertexProperty<>(v3,
-                cache.graph().schema().getPropertyKey("name"),"test-name"));
+                                                         cache.graph().schema().getPropertyKey("name"),
+                                                         "test-name"));
         cache.commit();
         Assert.assertEquals(0L,
-                Whitebox.invoke(cache, "edgesCache", "size"));
+                            Whitebox.invoke(cache, "edgesCache", "size"));
 
         Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(1)).hasNext());
         Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(2)).hasNext());
         Assert.assertEquals(2L,
-                Whitebox.invoke(cache, "edgesCache", "size"));
+                            Whitebox.invoke(cache, "edgesCache", "size"));
 
         cache.addVertexProperty(new HugeVertexProperty<>(v1,
-                cache.graph().schema().getPropertyKey("name"),"test-name"));
+                                                         cache.graph().schema().getPropertyKey("name"),
+                                                         "test-name"));
         cache.commit();
 
         Assert.assertEquals(0L,
-                Whitebox.invoke(cache, "edgesCache", "size"));
+                            Whitebox.invoke(cache, "edgesCache", "size"));
         String name = cache.queryEdgesByVertex(IdGenerator.of(1)).next().outVertex()
-                .value("name");
-        Assert.assertEquals("test-name",name);
-
-
+                     .value("name");
+        Assert.assertEquals("test-name", name);
     }
 }
-

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedGraphTransactionTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedGraphTransactionTest.java
@@ -19,6 +19,8 @@
 
 package com.baidu.hugegraph.unit.cache;
 
+import com.baidu.hugegraph.structure.HugeEdge;
+import com.baidu.hugegraph.structure.HugeVertexProperty;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,12 +67,25 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
 
     private HugeVertex newVertex(Id id) {
         HugeGraph graph = this.cache().graph();
+        graph.schema().propertyKey("name").asText()
+                .checkExist(false).create();
         graph.schema().vertexLabel("person")
-                      .idStrategy(IdStrategy.CUSTOMIZE_NUMBER)
-                      .checkExist(false)
-                      .create();
+                .idStrategy(IdStrategy.CUSTOMIZE_NUMBER)
+                .properties("name").nullableKeys("name")
+                .checkExist(false)
+                .create();
         VertexLabel vl = graph.vertexLabel("person");
         return new HugeVertex(graph, id, vl);
+    }
+
+    private HugeEdge newEdge(HugeVertex out, HugeVertex in){
+        HugeGraph graph = this.cache().graph();
+        graph.schema().edgeLabel("person_know_person")
+                .sourceLabel("person")
+                .targetLabel("person")
+                .checkExist(false)
+                .create();
+        return out.addEdge("person_know_person",in);
     }
 
     @Test
@@ -125,4 +140,87 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
         Assert.assertEquals(2L,
                             Whitebox.invoke(cache, "verticesCache", "size"));
     }
+
+
+    @Test
+    public void testClearEdgeCacheWhenDeleteVertex(){
+        CachedGraphTransaction cache = this.cache();
+        HugeVertex v1 = this.newVertex(IdGenerator.of(1));
+        HugeVertex v2 = this.newVertex(IdGenerator.of(2));
+        HugeVertex v3 = this.newVertex(IdGenerator.of(3));
+
+        cache.addVertex(v1);
+        cache.addVertex(v2);
+        cache.commit();
+        HugeEdge edge = this.newEdge(v1,v2);
+        cache.addEdge(edge);
+        cache.commit();
+        Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(1)).hasNext());
+        Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(2)).hasNext());
+
+        Assert.assertEquals(2L,
+                Whitebox.invoke(cache, "edgesCache", "size"));
+        cache.removeVertex(v3);
+        cache.commit();
+        Assert.assertEquals(0L,
+                Whitebox.invoke(cache, "edgesCache", "size"));
+
+        Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(1)).hasNext());
+        Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(2)).hasNext());
+        Assert.assertEquals(2L,
+                Whitebox.invoke(cache, "edgesCache", "size"));
+
+        cache.removeVertex(v1);
+        cache.commit();
+
+        Assert.assertEquals(0L,
+                Whitebox.invoke(cache, "edgesCache", "size"));
+        Assert.assertFalse(cache.queryEdgesByVertex(IdGenerator.of(2)).hasNext());
+
+    }
+
+    @Test
+    public void testClearEdgeCacheWhenUpdateVertex(){
+        CachedGraphTransaction cache = this.cache();
+        HugeVertex v1 = this.newVertex(IdGenerator.of(1));
+        HugeVertex v2 = this.newVertex(IdGenerator.of(2));
+        HugeVertex v3 = this.newVertex(IdGenerator.of(3));
+
+        cache.addVertex(v1);
+        cache.addVertex(v2);
+        cache.commit();
+        HugeEdge edge = this.newEdge(v1,v2);
+        cache.addEdge(edge);
+        cache.commit();
+        Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(1)).hasNext());
+        Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(2)).hasNext());
+
+        Assert.assertEquals(2L,
+                Whitebox.invoke(cache, "edgesCache", "size"));
+
+        ///update property of v3
+        cache.addVertexProperty(new HugeVertexProperty<>(v3,
+                cache.graph().schema().getPropertyKey("name"),"test-name"));
+        cache.commit();
+        Assert.assertEquals(0L,
+                Whitebox.invoke(cache, "edgesCache", "size"));
+
+        Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(1)).hasNext());
+        Assert.assertTrue(cache.queryEdgesByVertex(IdGenerator.of(2)).hasNext());
+        Assert.assertEquals(2L,
+                Whitebox.invoke(cache, "edgesCache", "size"));
+
+        cache.addVertexProperty(new HugeVertexProperty<>(v1,
+                cache.graph().schema().getPropertyKey("name"),"test-name"));
+        cache.commit();
+
+        Assert.assertEquals(0L,
+                Whitebox.invoke(cache, "edgesCache", "size"));
+        String name = cache.queryEdgesByVertex(IdGenerator.of(1)).next().outVertex()
+                .value("name");
+        Assert.assertEquals("test-name",name);
+
+
+    }
 }
+

--- a/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedGraphTransactionTest.java
+++ b/hugegraph-test/src/main/java/com/baidu/hugegraph/unit/cache/CachedGraphTransactionTest.java
@@ -141,7 +141,6 @@ public class CachedGraphTransactionTest extends BaseUnitTest {
                             Whitebox.invoke(cache, "verticesCache", "size"));
     }
 
-
     @Test
     public void testEdgeCacheClearWhenDeleteVertex() {
         CachedGraphTransaction cache = this.cache();


### PR DESCRIPTION
1. fix the bug when vertex updated, but the edge cache associated with that vertex was not updated. Here we simply clear all edge cache when  any vertex changes.
2. add two test case for the fixing

fix #1779