### PR TITLE
Fix tx leak

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1002,9 +1003,15 @@ public class StandardHugeGraph implements HugeGraph {
             LockUtil.destroy(this.name);
         }
         // Make sure that all transactions are closed in all threads
+        if(!this.tx.closed()){
+            for (String key : this.tx.openedThreads) {
+                LOG.warn("thread [{}] did not close transaction", key);
+            }
+        }
         E.checkState(this.tx.closed(),
                      "Ensure tx closed in all threads when closing graph '%s'",
                      this.name);
+
     }
 
     @Override
@@ -1356,6 +1363,8 @@ public class StandardHugeGraph implements HugeGraph {
 
         // Times opened from the upper layer
         private final AtomicInteger refs;
+        private final ConcurrentHashMap.KeySetView<String, Boolean> openedThreads =
+                ConcurrentHashMap.newKeySet();
         // Flag opened of each thread
         private final ThreadLocal<Boolean> opened;
         // Backend transactions
@@ -1470,6 +1479,7 @@ public class StandardHugeGraph implements HugeGraph {
             assert !this.opened.get();
             this.opened.set(true);
             this.transactions.get().openedTime(DateUtil.now().getTime());
+            this.openedThreads.add(Thread.currentThread().getName());
             this.refs.incrementAndGet();
         }
 
@@ -1477,6 +1487,7 @@ public class StandardHugeGraph implements HugeGraph {
             // Just set flag opened=false to reuse the backend tx
             if (this.opened.get()) {
                 this.opened.set(false);
+                this.openedThreads.remove(Thread.currentThread().getName());
                 this.refs.decrementAndGet();
             }
         }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/task/StandardTaskScheduler.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/task/StandardTaskScheduler.java
@@ -154,6 +154,9 @@ public class StandardTaskScheduler implements TaskScheduler {
             LOG.info("restore task {}", task);
             this.restore(task);
         }
+
+        this.graph.graphTransaction().commit();
+        this.graph.closeTx();
     }
 
     private <V> Future<?> restore(HugeTask<V> task) {


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

- fix #2310 <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #1024 -->

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better and faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->
- I added two lines of code under the `restoreTasks`
```java
        this.graph.graphTransaction().commit();
        this.graph.closeTx();
```

- added a concurrent set in the `TinkerPopTransaction` class to show which threads have not closed the transaction
```java
  private final ConcurrentHashMap.KeySetView<String, Boolean> openedThreads =
                ConcurrentHashMap.newKeySet();
```
- insert key when open tx and remove key when close tx

```java
       private void setOpened() {
            // The backend tx may be reused, here just set a flag
            assert !this.opened.get();
            this.opened.set(true);
            this.transactions.get().openedTime(DateUtil.now().getTime());
            this.openedThreads.add(Thread.currentThread().getName());
            this.refs.incrementAndGet();
        }

        private void setClosed() {
            // Just set flag opened=false to reuse the backend tx
            if (this.opened.get()) {
                this.opened.set(false);
                this.openedThreads.remove(Thread.currentThread().getName());
                this.refs.decrementAndGet();
            }
        }

```

- show threads have not close tx before `E.checkState`
```java
        if(!this.tx.closed()){
            for (String key : this.tx.openedThreads) {
                LOG.warn("thread [{}] did not close transaction", key);
            }
        }
        E.checkState(this.tx.closed(),
                     "Ensure tx closed in all threads when closing graph '%s'",
                     this.name);

    }
```

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
 - add closetx under the `restoreTasks` , the shutdown log , did not warn `Ensure tx closed in all threads when closing graph 'hugegraph'`
```
2025-06-09 20:32:49 [gremlin-server-shutdown] [INFO] o.a.t.g.s.GremlinServer - Shutting down OpProcessor[]
2025-06-09 20:32:49 [gremlin-server-shutdown] [INFO] o.a.t.g.s.GremlinServer - Shutting down OpProcessor[cypher]
2025-06-09 20:32:49 [hugegraph-server-shutdown] [INFO] o.a.h.d.HugeGraphServer - HugeGraphServer stopping
2025-06-09 20:32:49 [gremlin-server-shutdown] [INFO] o.a.t.g.s.GremlinServer - Shutting down OpProcessor[session]
2025-06-09 20:32:49 [hugegraph-server-shutdown] [INFO] o.a.h.d.MemoryMonitor - Memory monitoring stopped.
2025-06-09 20:32:49 [gremlin-server-shutdown] [INFO] o.a.t.g.s.GremlinServer - Shutting down OpProcessor[traversal]
2025-06-09 20:32:49 [gremlin-server-shutdown] [INFO] o.a.t.g.s.GremlinServer - Shutting down thread pools.
2025-06-09 20:32:49 [gremlin-server-stop] [INFO] o.a.t.g.s.GremlinServer - Executing shutdown LifeCycleHook
2025-06-09 20:32:49 [gremlin-server-stop] [INFO] o.a.t.g.s.GremlinServer - Executed once at shutdown of Gremlin Server.
2025-06-09 20:32:51 [gremlin-server-stop] [INFO] o.a.h.StandardHugeGraph - Close graph standardhugegraph[hugegraph]
2025-06-09 20:32:51 [gremlin-server-stop] [INFO] o.a.h.t.ServerInfoManager - Remove server info: server-1
2025-06-09 20:32:51 [gremlin-server-stop] [INFO] o.a.t.g.s.GremlinServer - Closed Graph instance [hugegraph]
2025-06-09 20:32:51 [gremlin-server-stop] [INFO] o.a.t.g.s.GremlinServer - Gremlin Server - shutdown complete
2025-06-09 20:32:51 [hugegraph-server-shutdown] [INFO] o.a.h.d.HugeGraphServer - HugeGremlinServer stopped
2025-06-09 20:32:51 [hugegraph-server-shutdown] [INFO] o.a.h.d.HugeGraphServer - HugeRestServer stopped
2025-06-09 20:32:51 [hugegraph-server-shutdown] [INFO] o.a.h.HugeFactory - HugeFactory shutdown
2025-06-09 20:32:51 [hugegraph-server-shutdown] [INFO] o.a.h.d.HugeGraphServer - HugeGraph stopped
2025-06-09 20:32:51 [hugegraph-server-shutdown] [INFO] o.a.h.d.HugeGraphServer - HugeGraphServer stopped
```

- log show which thread have not closed tx
```
025-06-09 20:30:43 [gremlin-server-stop] [INFO] o.a.h.t.ServerInfoManager - Remove server info: server-1
2025-06-09 20:30:43 [gremlin-server-stop] [WARN] o.a.h.StandardHugeGraph - thread [main] did not close transaction
2025-06-09 20:30:43 [gremlin-server-stop] [WARN] o.a.t.g.s.GremlinServer - Exception while closing Graph instance [hugegraph]
java.lang.IllegalStateException: Ensure tx closed in all threads when closing graph 'hugegraph'
	at com.google.common.base.Preconditions.checkState(Preconditions.java:534) ~[guava-31.0.1-android.jar:?]
	at org.apache.hugegraph.util.E.checkState(E.java:64) ~[classes/:?]
	at org.apache.hugegraph.StandardHugeGraph.close(StandardHugeGraph.java:1011) ~[classes/:?]
	at org.apache.tinkerpop.gremlin.server.GremlinServer.lambda$null$7(GremlinServer.java:307) ~[gremlin-server-3.5.1.jar:3.5.1]
	at java.util.concurrent.ConcurrentHashMap$KeySetView.forEach(ConcurrentHashMap.java:4696) ~[?:?]
	at org.apache.tinkerpop.gremlin.server.GremlinServer.lambda$stop$8(GremlinServer.java:304) ~[gremlin-server-3.5.1.jar:3.5.1]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [x]  Other affects (standardHugeGraph)
- [ ]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在图关闭时，新增了对未关闭事务线程的警告日志，提升了事务管理的可见性。

- **修复**
  - 优化了任务恢复后的事务提交与关闭，确保任务恢复流程更加稳定可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->