### PR TITLE
feat(rocksdb): support ToplingDB provider

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      packages: read
       security-events: write
 
     strategy:

--- a/.specs/hugegraph-server/ToplingDB/design.md
+++ b/.specs/hugegraph-server/ToplingDB/design.md
@@ -40,34 +40,39 @@ sequenceDiagram
 
 ### RocksDB Startup Logic
 
-Use reflection to detect whether ToplingDB APIs are available. If present, attempt to start the storage engine using ToplingDB; otherwise, fall back to standard RocksDB APIs.
+HugeGraph routes the main RocksDB open/close paths through `RocksDBProviderLoader`.
+Providers are discovered via Java SPI, but the active provider is selected explicitly by
+`rocksdb.provider`. `standard` uses vanilla RocksDB; `topling` requires
+`org.rocksdb.SidePluginRepo` to be available at runtime.
 
 ```mermaid
 sequenceDiagram
   autonumber
-  participant Store as HugeGraph Store
+  participant Store as HugeGraph Server/PD/Store
   participant Config as HugeConfig
-  participant Sessions as RocksDBStdSessions
-  participant SPR as SidePluginRepo (Reflection)
+  participant Loader as RocksDBProviderLoader
+  participant Provider as Configured Provider
   participant Repo as Repo Instance
   participant Rocks as RocksDB
 
-  Store->>Config: Read OPTION_PATH / OPEN_HTTP
-  Store->>Sessions: Create Sessions(..., optionPath, openHttp)
-  alt optionPath provided and SPR available
-    Sessions->>SPR: Reflectively load/create Repo
-    Sessions->>Repo: importAutoFile(optionPath)
-    Sessions->>Repo: open (with JSON descriptor)
-    opt openHttp is true and instance is GRAPH_STORE
-      Sessions->>Repo: startHttpServer()
+  Store->>Config: Read PROVIDER / OPTION_PATH / OPEN_HTTP
+  Store->>Loader: selectProviderIfNeeded(provider)
+  Store->>Loader: openRocksDB(..., optionPath, openHttp)
+  Loader->>Provider: openRocksDB(...)
+  alt provider is standard
+    Provider->>Rocks: RocksDB.open(...)
+  else provider is topling and optionPath valid
+    Provider->>Repo: Reflectively create SidePluginRepo
+    Provider->>Repo: importAutoFile(optionPath)
+    Provider->>Repo: openDB(JSON descriptor)
+    opt Server openHttp is true and instance is GRAPH_STORE
+      Provider->>Repo: startHttpServer()
     end
-    Sessions->>Rocks: Get RocksDB instance (with CF handles)
-    Sessions-->>Store: Return OpenedRocksDB(repo, handles)
-  else optionPath not provided or SPR unavailable
-    Sessions->>Rocks: Standard open()
-    Sessions-->>Store: Return OpenedRocksDB(null, handles)
+  else provider is topling but optionPath pre-validation fails
+    Provider->>Rocks: RocksDB.open(...)
   end
-  note over Store,Sessions: On shutdown, if repo exists, call repo.closeAllDB()
+  Loader-->>Store: Return RocksDB instance
+  note over Store,Loader: On shutdown, close through the active provider; Topling closes Repo when present.
 ```
 
 ## Involved Modules
@@ -168,19 +173,30 @@ Both `init-hugegraph.sh` and `start-hugegraph.sh` now invoke `preload-topling.sh
 
 ### HugeGraph Configuration Options for RocksDB
 
-Two new configuration options were added to `hugegraph.properties`: `option_path` for the YAML file and `open_http` to enable the Web Server.
+Three RocksDB provider options were added: `provider` selects standard RocksDB or ToplingDB,
+`option_path` points to the YAML file, and `open_http` enables the Web Server.
 
 ```properties
 # rocksdb backend config
 #rocksdb.data_path=/path/to/disk
 #rocksdb.wal_path=/path/to/disk
-#rocksdb.option_path=./conf/graphs/rocksdb_plus.yaml
+#rocksdb.provider=topling
+#rocksdb.option_path=./conf/graphs/rocksdb_server.yaml
 #rocksdb.open_http=true
 ```
 
 Java-side parsing and default values:
 
 ```java
+public static final ConfigOption<String> PROVIDER =
+        new ConfigOption<>(
+                "rocksdb.provider",
+                "The RocksDB engine provider. 'standard' for vanilla RocksDB, "
+                + "'topling' for ToplingDB (requires addon installation).",
+                allowValues("standard", "topling"),
+                "standard"
+        );
+
 public static final ConfigOption<String> OPTION_PATH =
         new ConfigOption<>(
                 "rocksdb.option_path",
@@ -200,29 +216,30 @@ public static final ConfigOption<Boolean> OPEN_HTTP =
 
 ### ToplingDB Startup Logic
 
-When `option_path` is configured and the JAR contains ToplingDB APIs, HugeGraph will load the YAML file and start ToplingDB. Otherwise, it falls back to standard RocksDB.
+When `rocksdb.provider=topling`, `option_path` is configured, pre-validation passes, and the JAR
+contains ToplingDB APIs, HugeGraph will load the YAML file and start ToplingDB. If
+`rocksdb.provider=standard`, HugeGraph uses standard RocksDB.
 
-To keep port configuration simple, the Web Server is only enabled for the `GRAPH_STORE` instance.
+For HugeGraph Server, the Web Server is only enabled for the `GRAPH_STORE` instance. PD and
+Store pass their component-level HTTP flag to the provider.
 
 ```mermaid
 flowchart LR
-    A[Start Initialization] --> B{Is optionPath provided?}
+    A[Start Initialization] --> P{rocksdb.provider}
+    P -- standard --> Z[Use StandardRocksDBProvider] --> O[Finish standard init]
+    P -- topling --> S{Is SidePluginRepo available?}
+    S -- No --> F[Fail startup]
+    S -- Yes --> B{Is optionPath provided and valid?}
 
-    B -- No --> Z[Use standard RocksDB to open DB] --> O[Finish standard init]
+    B -- No --> Z
+    B -- Yes --> E["ToplingRocksDBProvider calls importAutoFile(optionPath)"]
 
-    B -- Yes --> C{Is SidePluginRepo class available?}
-    C -- No --> Z
-
-    C -- Yes --> D[Set useTopling = true] --> E["Load SidePluginRepo class and call importAutoFile(optionPath)"]
-
-    E --> K{Is openHttp true?}
+    E --> K{Should this component start HTTP?}
     K -- No --> M[Finish Topling init]
-    K -- Yes --> L{Is dbName GRAPH_STORE?}
-    L -- No --> M
-    L -- Yes --> N["startHttpServer()"] --> M
+    K -- Yes --> N["startHttpServer()"] --> M
 ```
 
 ## Design Decisions and Rationale
 
-1. **Why is the Web Server only started for GRAPH_STORE?**
+1. **Why does HugeGraph Server only start the Web Server for GRAPH_STORE?**
     - All graph data is stored in GRAPH_STORE, and performance tuning and observability are primarily focused on this instance.

--- a/.specs/hugegraph-server/ToplingDB/task.md
+++ b/.specs/hugegraph-server/ToplingDB/task.md
@@ -12,7 +12,7 @@ When using an IDE such as IntelliJ IDEA, you need to configure the following env
 
 ```shell
 LD_LIBRARY_PATH=/path/to/your/library:$LD_LIBRARY_PATH
-LD_PRELOAD=libjemalloc.so:librocksdbjni-linux64.so
+LD_PRELOAD=/path/to/libjemalloc.so:/path/to/your/library/librocksdbjni-linux64.so
 ```
 
 When running from the terminal, simply use `init-store.sh` and `start-hugegraph.sh`, as `preload-topling.sh` is already embedded in these scripts.
@@ -25,9 +25,10 @@ When running from the terminal, simply use `init-store.sh` and `start-hugegraph.
 
 ## 2. Compatibility with ToplingDB and Standard RocksDB
 
-- [x] **2.1 Modify openRocksDB logic in RocksDBStdSession**
-  - Use reflection to detect whether the current JAR contains ToplingDB APIs; if so, start the storage engine using ToplingDB
-  - If not available, fall back to the standard RocksDB API for engine startup
+- [x] **2.1 Add a RocksDB provider SPI and route main open/close paths through it**
+  - Use `RocksDBProviderLoader` to discover standard RocksDB and ToplingDB providers
+  - Select the active provider explicitly with `rocksdb.provider`
+  - Use reflection in `ToplingRocksDBProvider` to detect whether the current JAR contains `org.rocksdb.SidePluginRepo`
 
 ## 3. Add Configuration Options for ToplingDB in HugeGraph
 
@@ -40,7 +41,12 @@ When running from the terminal, simply use `init-store.sh` and `start-hugegraph.
   - Type: boolean, used to specify whether to enable the ToplingDB Web Server
   - Allow users to configure Web Server activation via `rocksdb.open_http` in `hugegraph.properties`
   - The Web Server port is defined in the YAML file specified by `option_path`, under `http.listening_ports`
-  - For simplicity, the Web Server is only enabled for the `GRAPH_STORE` instance that stores graph data
+  - For HugeGraph Server, the Web Server is only enabled for the `GRAPH_STORE` instance that stores graph data
+
+- [x] **3.3 Add `rocksdb.provider` configuration**
+  - Type: string, valid values: `standard` and `topling`
+  - Default: `standard`
+  - Prevent ToplingDB from being enabled implicitly just because a ToplingDB-capable JAR is on the classpath
 
 ## 4. End-to-End Performance Testing
 

--- a/docs/toplingdb/toplingdb-troubleshooting.md
+++ b/docs/toplingdb/toplingdb-troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## Issues
 
-### Issue 1: Startup Failure Due to YAML Format Error
+### Issue 1: YAML Configuration Error
 
 Sample log output:
 
 ```java
-2025-10-15 01:55:50 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStdSessions - SidePluginRepo found. Will attempt to open multi CFs RocksDB using Topling plugin.
-21:1: (891B):ERROR: 
+2025-10-15 01:55:50 [db-open-1] [INFO] o.a.h.r.p.ToplingRocksDBProvider - SidePluginRepo found. Will attempt to open default CF RocksDB using Topling.
+21:1: (891B):ERROR:
 sideplugin/rockside/3rdparty/rapidyaml/src/c4/yml/parse.cpp:3310: ERROR parsing yml: parse error: incorrect indentation?
 ```
 
@@ -18,19 +18,49 @@ sideplugin/rockside/3rdparty/rapidyaml/src/c4/yml/parse.cpp:3310: ERROR parsing 
 2. Validate YAML syntax:
 
    ```bash
-   python -c "import yaml; yaml.safe_load(open('conf/graphs/rocksdb_plus.yaml'))"
+   python -c "import yaml; yaml.safe_load(open('conf/graphs/rocksdb_server.yaml'))"
    ```
 
 3. Review the specific error message in the logs for further clues.
 
+HugeGraph performs basic path and YAML validation before enabling ToplingDB. If this
+pre-validation fails, HugeGraph falls back to standard RocksDB behavior inside the ToplingDB
+provider. If the file passes basic YAML validation but `SidePluginRepo.importAutoFile()` or
+`openDB()` fails, startup fails with the corresponding ToplingDB error and the YAML file should
+be fixed.
+
 ---
 
-### Issue 2: Web Server Port Conflict
+### Issue 2: ToplingDB Provider Not Available
+
+When `rocksdb.provider=topling` is configured but the runtime `rocksdbjni` JAR does not contain
+`org.rocksdb.SidePluginRepo`, HugeGraph fails provider activation instead of silently switching
+to the standard provider.
+
+**Solution**:
+
+1. If you want standard RocksDB, set:
+
+   ```properties
+   rocksdb.provider=standard
+   ```
+
+2. If you want ToplingDB, confirm that Maven or the deployment addon provides a ToplingDB-capable
+   `rocksdbjni` artifact.
+3. Inspect the runtime JAR:
+
+   ```bash
+   jar tf lib/rocksdbjni-*.jar | grep org/rocksdb/SidePluginRepo.class
+   ```
+
+---
+
+### Issue 3: Web Server Port Conflict
 
 Sample log output:
 
 ```java
-2025-10-15 01:57:34 [db-open-1] [INFO] o.a.h.b.s.r.RocksDBStdSessions - SidePluginRepo found. Will attempt to open multi CFs RocksDB using Topling plugin.
+2025-10-15 01:57:34 [db-open-1] [INFO] o.a.h.r.p.ToplingRocksDBProvider - SidePluginRepo found. Will attempt to open default CF RocksDB using Topling.
 2025-10-15 01:57:34 [db-open-1] [ERROR] o.a.h.b.s.r.RocksDBStore - Failed to open RocksDB 'rocksdb-data/data/g'
 org.rocksdb.RocksDBException: rocksdb::Status rocksdb::SidePluginRepo::StartHttpServer(): null context when constructing CivetServer. Possible problem binding to port.
     at org.rocksdb.SidePluginRepo.startHttpServer(Native Method) ~[rocksdbjni-8.10.2-20250804.074027-4.jar:?]
@@ -49,7 +79,7 @@ org.rocksdb.RocksDBException: rocksdb::Status rocksdb::SidePluginRepo::StartHttp
 
 ---
 
-### Issue 3: Database Initialization Failure
+### Issue 4: Database Initialization Failure
 
 This error indicates the database lock file cannot be acquired, possibly due to insufficient write permissions or another process holding the lock:
 
@@ -64,7 +94,8 @@ Caused by: org.rocksdb.RocksDBException: While lock file: rocksdb-data/data/m/LO
 1. Confirm the configuration file path is correct:
 
    ```properties
-   rocksdb.option_path=./conf/graphs/rocksdb_plus.yaml
+   rocksdb.provider=topling
+   rocksdb.option_path=./conf/graphs/rocksdb_server.yaml
    ```
 
 2. Check permissions on the data directory to ensure the running user has read/write access.
@@ -73,6 +104,23 @@ Caused by: org.rocksdb.RocksDBException: While lock file: rocksdb-data/data/m/LO
    ```bash
    bin/init-store.sh 2>&1 | tee init.log
    ```
+
+---
+
+### Issue 5: Ubuntu 24.04+ libaio Compatibility
+
+Some ToplingDB native libraries may expect the legacy `libaio.so.1` name, while Ubuntu 24.04+
+ships the time64 library as `libaio.so.1t64`. The preload script currently creates a
+compatibility symlink when running on Ubuntu 24.04+ and `libaio.so.1` is missing.
+
+If startup fails with a missing `libaio.so.1` error, install the system package first:
+
+```bash
+sudo apt-get install libaio1t64
+```
+
+Then retry startup. If your environment does not allow scripts to use `sudo`, create the
+compatibility symlink manually or ask the system administrator to provide it.
 
 ---
 

--- a/docs/toplingdb/toplingdb.md
+++ b/docs/toplingdb/toplingdb.md
@@ -37,6 +37,11 @@ By supporting ToplingDB, HugeGraph empowers users with greater control over stor
 
 Enable users to select ToplingDB via configuration, allowing tuning parameters through YAML files without recompilation and real-time monitoring via Web Server—without sacrificing compatibility with existing RocksDB APIs.
 
+## Platform Scope
+
+The current ToplingDB native integration supports Linux x86_64 only.
+On macOS, Linux arm64/aarch64, and other non-x86_64 platforms, HugeGraph should continue to use the standard RocksDB `rocksdbjni` dependency instead of preloading ToplingDB native libraries.
+
 ## Design
 
 ### Provider Selection
@@ -79,7 +84,7 @@ This parameter allows users to specify a YAML file that defines ToplingDB settin
   ```yaml
   rocksdb:
     provider: topling
-    option-path: ./conf/graphs/rocksdb_pd.yaml
+    option-path: ./conf/rocksdb_pd.yaml
     open-http: true
   ```
 

--- a/docs/toplingdb/toplingdb.md
+++ b/docs/toplingdb/toplingdb.md
@@ -17,7 +17,7 @@ ToplingDB extends RocksDB with several advanced features:
 
 ## Motivation
 
-Introduce a new optional storage component in HugeGraph to support [ToplingDB](https://github.com/topling/toplingdb)), a configurable and observable extension of the RocksDB storage engine.
+Introduce a new optional storage component in HugeGraph to support [ToplingDB](https://github.com/topling/toplingdb), a configurable and observable extension of the RocksDB storage engine.
 
 ToplingDB resolves key limitations in HugeGraph’s  current `rocksdbjni` integration, which relies heavily on hard-coding parameters and lacks runtime configurability and observability.
 
@@ -39,9 +39,25 @@ Enable users to select ToplingDB via configuration, allowing tuning parameters t
 
 ## Design
 
+### Provider Selection
+
+HugeGraph uses the `hugegraph-rocksdb-provider` module to keep RocksDB and ToplingDB startup
+logic behind a shared provider interface. Providers are discovered through Java SPI, but the
+active provider is selected explicitly by configuration:
+
+```properties
+rocksdb.provider=standard
+```
+
+Use `standard` for vanilla RocksDB and `topling` for ToplingDB. ToplingDB also requires a valid
+`rocksdb.option_path` and a runtime `rocksdbjni` JAR that contains
+`org.rocksdb.SidePluginRepo`.
+
 ### Configuration Parameters
 
-To support ToplingDB in HugeGraph, two new configuration parameters have been introduced: `rocksdb.option_path` and `rocksdb.open_http`. These options allow users to configure RocksDB parameters and enable real-time observability.
+To support ToplingDB in HugeGraph, three configuration parameters have been introduced:
+`rocksdb.provider`, `rocksdb.option_path`, and `rocksdb.open_http`. These options allow users to
+select the provider, configure RocksDB parameters, and enable real-time observability.
 
 #### `rocksdb.option_path`: External YAML Configuration
 
@@ -52,18 +68,37 @@ This parameter allows users to specify a YAML file that defines ToplingDB settin
 - **Usage**: Add the following line to your `hugegraph.properties` file:
 
   ```properties
-  rocksdb.option_path=./conf/graphs/rocksdb_plus.yaml
+  rocksdb.provider=topling
+  rocksdb.option_path=./conf/graphs/rocksdb_server.yaml
   ```
 
   The specified YAML file will be automatically loaded during database initialization if ToplingDB is available.
 
-  For security reasons, HugeGraph only allows YAML files to be stored under the `$HUGEGRAPH_HOME/conf/graphs` directory.
+  PD and Store use their own YAML configuration files:
+
+  ```yaml
+  rocksdb:
+    provider: topling
+    option-path: ./conf/graphs/rocksdb_pd.yaml
+    open-http: true
+  ```
+
+  ```yaml
+  rocksdb:
+    provider: topling
+    option_path: ./conf/rocksdb_store.yaml
+    open_http: false
+  ```
+
+  For security reasons, HugeGraph only allows YAML files to be stored under the `$HUGEGRAPH_HOME/conf/` directory.
 
   For details on the YAML structure and supported configuration fields, please refer to [SidePlugin](https://github.com/topling/sideplugin-wiki-en/wiki).
 
 - **Implementation**: During initialization, HugeGraph checks whether the configured JAR contains ToplingDB APIs. If so, it uses reflection to load the SidePluginRepo class and calls `importAutoFile(optionPath)` to parse the YAML file. The resulting configuration is applied to the RocksDB instance.
 
-- **Fallback**: If the YAML file is not provided or ToplingDB is unavailable, HugeGraph will fall back to standard RocksDB behavior.
+- **Fallback**: If `rocksdb.provider=standard`, HugeGraph uses standard RocksDB. If
+  `rocksdb.provider=topling` is configured but ToplingDB is unavailable, startup fails with a
+  provider availability error instead of silently switching providers.
 
 #### `rocksdb.open_http`: Enable Web Server for Observability
 
@@ -89,9 +124,14 @@ This boolean flag controls whether the embedded Web Server in ToplingDB should b
   When adjusting this setting, users should carefully manage port and network access permissions to avoid potential security incidents.
   To preview the Web Server interface and its layout, see [Web Server](https://github.com/topling/sideplugin-wiki-en/wiki/WebView).
 
-- **Implementation**: If `open_http` is set to true and the database instance is `GRAPH_STORE`, HugeGraph invokes `startHttpServer()` on the ToplingDB repo object. This exposes a browser-accessible dashboard for monitoring RocksDB internals.
+- **Implementation**: For HugeGraph Server's RocksDB backend, `open_http=true` is forwarded to
+  the provider only when the opened database instance is `GRAPH_STORE`. The provider then invokes
+  `startHttpServer()` on the ToplingDB repo object. This exposes a browser-accessible dashboard
+  for monitoring RocksDB internals.
 
-- **Scope**: For simplicity, the Web Server is only enabled for the `GRAPH_STORE` instance, which holds the main graph data.
+- **Scope**: In HugeGraph Server, the Web Server is only enabled for the `GRAPH_STORE` instance,
+  which holds the main graph data. PD and Store pass their component-level `open-http` /
+  `open_http` setting to the provider.
 
 - **Security**: The Web Server does **not** provide built-in authentication. In production environments, configure firewalls or network access controls carefully to prevent unauthorized access.
 
@@ -99,14 +139,21 @@ This boolean flag controls whether the embedded Web Server in ToplingDB should b
 
 To support ToplingDB without introducing hard dependencies, HugeGraph uses Java reflection to detect and load enhanced APIs at runtime.
 
-During initialization, HugeGraph checks whether the current JAR contains the class `com.topling.sideplugin.SidePluginRepo`. If present, it assumes ToplingDB is available and proceeds to:
+During initialization, HugeGraph selects the configured provider. When `rocksdb.provider=topling`,
+it checks whether the current JAR contains the class `org.rocksdb.SidePluginRepo`. If present, it
+uses ToplingDB as follows:
 
-1. **Load the SidePluginRepo class via reflection**   This avoids compile-time coupling and allows fallback to standard RocksDB if the class is missing.
-   - If the ToplingDB API cannot be found, HugeGraph silently falls back to the standard RocksDB API for startup.
-2. **Invoke** `importAutoFile(optionPath)`   This method parses the YAML configuration file specified by `rocksdb.option_path` to configure storage engine parameters.
-   - If the `option_path` is incorrect or parsing fails, ToplingDB throws an error and terminates the startup process.
-3. **Call** `open()` **with a JSON descriptor**   The parsed configuration is converted to a JSON structure and passed to the ToplingDB engine to initialize the database.
-4. **Optionally start the Web Server**   If `rocksdb.open_http` is true and the instance is `GRAPH_STORE`, HugeGraph invokes `startHttpServer()` via reflection to enable observability.
+1. **Load the SidePluginRepo class via reflection**. This avoids compile-time coupling.
+   - If the ToplingDB API cannot be found while the ToplingDB provider is selected, startup fails.
+2. **Validate** `option_path` and the YAML file before enabling ToplingDB.
+   - If the path is missing, unsafe, unreadable, outside `conf/`, or fails basic YAML parsing,
+     HugeGraph falls back to standard RocksDB behavior inside the ToplingDB provider.
+3. **Invoke** `importAutoFile(optionPath)`. This method lets `SidePluginRepo` parse the YAML
+   configuration file specified by `rocksdb.option_path` and configure storage engine parameters.
+   - If ToplingDB initialization fails after this point, startup fails with the corresponding
+     RocksDB or SidePlugin error.
+4. **Call** `open()` **with a JSON descriptor**. The parsed configuration is converted to a JSON structure and passed to the ToplingDB engine to initialize the database.
+5. **Optionally start the Web Server**. In HugeGraph Server, if `rocksdb.open_http` is true and the instance is `GRAPH_STORE`, HugeGraph invokes `startHttpServer()` via reflection to enable observability. PD and Store pass their component-level HTTP flag to the provider.
    - If the Web Server cannot be started due to misconfiguration **or if the specified HTTP port is already in use**, ToplingDB throws an error and the startup process is terminated
 
 This design ensures that ToplingDB can be integrated as an optional enhancement, without breaking compatibility or requiring changes to the core HugeGraph codebase.
@@ -116,7 +163,7 @@ This design ensures that ToplingDB can be integrated as an optional enhancement,
 ### For Users
 
 The way users operate remains unchanged by default, and adding ToplingDB configuration provides additional functionality.
-The ToplingDB integration is fully embedded into the existing startup scripts (`init-store.sh` and `start-hugegraph.sh`). Users only need to set `rocksdb.option_path` to specify the YAML file path and adjust its contents as needed to tune the storage engine.
+The ToplingDB integration is fully embedded into the existing startup scripts (`init-store.sh` and `start-hugegraph.sh`). Users only need to set `rocksdb.provider=topling` and `rocksdb.option_path` to specify the YAML file path, then adjust its contents as needed to tune the storage engine.
 
 ### For Developers
 
@@ -167,7 +214,7 @@ Developers need to make two adjustments to enable ToplingDB during development:
 
    ```bash
    LD_LIBRARY_PATH="/path/to/your/library:${LD_LIBRARY_PATH}"
-   LD_PRELOAD="libjemalloc.so:librocksdbjni.so"
+   LD_PRELOAD="/path/to/libjemalloc.so:/path/to/your/library/librocksdbjni-linux64.so"
    ```
 
 These steps ensure that ToplingDB loads correctly in development environments and behaves consistently with production deployments.

--- a/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/config/PDConfig.java
+++ b/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/config/PDConfig.java
@@ -60,7 +60,7 @@ public class PDConfig {
 
     @Value("${rocksdb.provider:standard}")
     private String provider;
-    @Value("${rocksdb.option-path: ''}")
+    @Value("${rocksdb.option-path:}")
     private String optionPath;
     @Value("${rocksdb.open-http:false}")
     private Boolean openHttp;

--- a/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/config/PDConfig.java
+++ b/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/config/PDConfig.java
@@ -59,11 +59,11 @@ public class PDConfig {
     private String host;
 
     @Value("${rocksdb.provider:standard}")
-    private String provider;
+    private String provider = "standard";
     @Value("${rocksdb.option-path:}")
-    private String optionPath;
+    private String optionPath = "";
     @Value("${rocksdb.open-http:false}")
-    private Boolean openHttp;
+    private Boolean openHttp = false;
 
     @Value("${license.verify-path}")
     private String verifyPath;

--- a/hugegraph-pd/hg-pd-dist/src/assembly/static/conf/application.yml
+++ b/hugegraph-pd/hg-pd-dist/src/assembly/static/conf/application.yml
@@ -41,7 +41,7 @@ grpc:
   host: 127.0.0.1
 # rocksdb:
   # provider: topling
-  # option-path: ./conf/graphs/rocksdb_pd.yaml
+  # option-path: ./conf/rocksdb_pd.yaml
   # open-http: true
 
 server:

--- a/hugegraph-pd/hg-pd-dist/src/assembly/static/conf/application.yml
+++ b/hugegraph-pd/hg-pd-dist/src/assembly/static/conf/application.yml
@@ -40,6 +40,7 @@ grpc:
   # The service address of grpc needs to be changed to the actual local IPv4 address when deploying.
   host: 127.0.0.1
 # rocksdb:
+  # provider: topling
   # option-path: ./conf/graphs/rocksdb_pd.yaml
   # open-http: true
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/bin/common-topling.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/bin/common-topling.sh
@@ -153,27 +153,28 @@ function ensure_libaio_symlink() {
 function download_and_verify() {
     local url=$1
     local filepath=$2
-    local expected_md5=$3
+    local expected_sha256=$3
+    local actual_sha256
 
-    if [[ -f $filepath ]]; then
-        echo "File $filepath exists. Verifying MD5 checksum..."
-        actual_md5=$(md5sum $filepath | awk '{ print $1 }')
-        if [[ $actual_md5 != $expected_md5 ]]; then
-            echo "MD5 checksum verification failed for $filepath. Expected: $expected_md5, but got: $actual_md5"
+    if [[ -f "$filepath" ]]; then
+        echo "File $filepath exists. Verifying SHA-256 checksum..."
+        actual_sha256=$(sha256sum "$filepath" | awk '{ print $1 }')
+        if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+            echo "SHA-256 checksum verification failed for $filepath. Expected: $expected_sha256, but got: $actual_sha256"
             echo "Deleting $filepath..."
-            rm -f $filepath
+            rm -f "$filepath"
         else
-            echo "MD5 checksum verification succeeded for $filepath."
+            echo "SHA-256 checksum verification succeeded for $filepath."
             return 0
         fi
     fi
 
     echo "Downloading $filepath..."
-    curl -L -o $filepath $url
+    curl -fL -o "$filepath" "$url"
 
-    actual_md5=$(md5sum $filepath | awk '{ print $1 }')
-    if [[ $actual_md5 != $expected_md5 ]]; then
-        echo "MD5 checksum verification failed for $filepath after download. Expected: $expected_md5, but got: $actual_md5"
+    actual_sha256=$(sha256sum "$filepath" | awk '{ print $1 }')
+    if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+        echo "SHA-256 checksum verification failed for $filepath after download. Expected: $expected_sha256, but got: $actual_sha256"
         return 1
     fi
 
@@ -181,7 +182,7 @@ function download_and_verify() {
 }
 
 function download_and_setup_jemalloc() {
-    local arch lib_file download_url expected_md5 system_lib top
+    local arch lib_file download_url expected_sha256 system_lib top
     top=$1
 
     # Prefer system-installed jemalloc if available
@@ -224,19 +225,19 @@ function download_and_setup_jemalloc() {
     if [[ $arch == "aarch64" || $arch == "arm64" ]]; then
         lib_file="$top/bin/libjemalloc_aarch64.so"
         download_url="${GITHUB}/apache/hugegraph-doc/raw/binary-1.5/dist/server/libjemalloc_aarch64.so"
-        expected_md5="2a631d2f81837f9d5864586761c5e380"
+        expected_sha256="6b7e6099b6da798829c6ce6fcb55a787508841edd52446332a73300889dcd1dc"
     elif [[ $arch == "x86_64" ]]; then
         lib_file="$top/bin/libjemalloc.so"
         download_url="${GITHUB}/apache/hugegraph-doc/raw/binary-1.5/dist/server/libjemalloc.so"
-        expected_md5="fd61765eec3bfea961b646c269f298df"
+        expected_sha256="53b25e8626e1605cbd8b60befb3431cabc1b8851a54285e0dda412796feab67d"
     else
         echo "Unsupported architecture: $arch"
         return 1
     fi
 
     # Download and verify jemalloc library (fallback when system lib not found)
-    if download_and_verify "$download_url" "$lib_file" "$expected_md5"; then
-        if [[ ":${LD_PRELOAD:-}:" != *"libjemalloc.so:"* ]]; then
+    if download_and_verify "$download_url" "$lib_file" "$expected_sha256"; then
+        if [[ ":${LD_PRELOAD:-}:" != *":${lib_file}:"* ]]; then
             export LD_PRELOAD="${lib_file}${LD_PRELOAD:+:$LD_PRELOAD}"
         fi
     else
@@ -248,6 +249,25 @@ function download_and_setup_jemalloc() {
 function preload_toplingdb() {
     local lib_dir="$1"
     local dest_dir="$2"
+    local os_name machine_arch
+
+    # NOTE: The current ToplingDB rocksdbjni snapshot bundles Linux x86_64 native libraries.
+    # Linux arm64/aarch64 support requires a matching native rocksdbjni artifact.
+    os_name="$(uname -s)"
+    if [ "$os_name" != "Linux" ]; then
+        echo "[common-topling] Skip ToplingDB native preload on non-Linux platform: $os_name" >&2
+        return 0
+    fi
+    machine_arch="$(uname -m)"
+    case "$machine_arch" in
+        x86_64 | amd64)
+            ;;
+        *)
+            echo "[common-topling] Skip ToplingDB native preload on unsupported platform: $os_name/$machine_arch" >&2
+            return 0
+            ;;
+    esac
+
     local top="$(cd "$lib_dir"/../ && pwd)"
 
     local jar_file
@@ -275,7 +295,9 @@ function preload_toplingdb() {
             {
                 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
                 echo "LD_PRELOAD=$LD_PRELOAD"
-                echo "SERVER_VERSION_DIR=$SERVER_VERSION_DIR"
+                if [ -n "${SERVER_VERSION_DIR:-}" ]; then
+                    echo "SERVER_VERSION_DIR=$SERVER_VERSION_DIR"
+                fi
             } >> "$GITHUB_ENV" || true
             echo "[common-topling] Exported LD_LIBRARY_PATH and LD_PRELOAD to GITHUB_ENV" >&2 || true
         fi

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/graphs/hugegraph.properties
@@ -43,6 +43,7 @@ search.text_analyzer_mode=INDEX
 # rocksdb backend config
 #rocksdb.data_path=/path/to/disk
 #rocksdb.wal_path=/path/to/disk
+#rocksdb.provider=topling
 #rocksdb.option_path=./conf/graphs/rocksdb_server.yaml
 #rocksdb.open_http=true
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/install-rocksdb.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/install-rocksdb.sh
@@ -16,15 +16,23 @@
 # limitations under the License.
 #
 
-set -Eeuo pipefail
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "[install-rocksdb] Skip ToplingDB native preload on non-Linux platform: $(uname -s)"
+    return 0 2>/dev/null || exit 0
+fi
+
+ORIG_SHELL_FLAGS="$-"
+ORIG_PIPEFAIL="$(set -o | awk '$1 == "pipefail" { print $2 }')"
+ORIG_ERR_TRAP="$(trap -p ERR || true)"
 # Save original IFS to avoid leaking into parent shell when sourced
 ORIG_IFS="${IFS}"
+set -Eeuo pipefail
 IFS=$'\n\t'
 # Unified error capture for easy positioning
 trap 'echo "[install-rocksdb] error at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
 VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-SERVER_VERSION_DIR="$(pwd)/hugegraph-server/apache-hugegraph-server-incubating-$VERSION"
+SERVER_VERSION_DIR="$(pwd)/hugegraph-server/apache-hugegraph-server-$VERSION"
 SERVER_BIN="$SERVER_VERSION_DIR/bin"
 SERVER_LIB="$SERVER_VERSION_DIR/lib"
 INSTALL_DEST_DIR="$SERVER_VERSION_DIR/library"
@@ -46,8 +54,19 @@ source "$SERVER_BIN/common-topling.sh"
 type preload_toplingdb >/dev/null 2>&1 || { echo "Error: function preload_toplingdb not found" >&2; exit 1; }
 preload_toplingdb "$SERVER_LIB" "$INSTALL_DEST_DIR"
 
-# Reset shell options to prevent affecting the parent shell when sourced
-set +Eeuo pipefail
-trap - ERR
 # Restore original IFS
 IFS="$ORIG_IFS"
+if [ -n "$ORIG_ERR_TRAP" ]; then
+    eval "$ORIG_ERR_TRAP"
+else
+    trap - ERR
+fi
+# Reset shell options to prevent affecting the parent shell when sourced
+case "$ORIG_SHELL_FLAGS" in *e*) set -e ;; *) set +e ;; esac
+case "$ORIG_SHELL_FLAGS" in *u*) set -u ;; *) set +u ;; esac
+case "$ORIG_SHELL_FLAGS" in *E*) set -E ;; *) set +E ;; esac
+if [ "$ORIG_PIPEFAIL" = "on" ]; then
+    set -o pipefail
+else
+    set +o pipefail
+fi

--- a/hugegraph-store/hg-store-dist/src/assembly/static/conf/application-pd.yml
+++ b/hugegraph-store/hg-store-dist/src/assembly/static/conf/application-pd.yml
@@ -32,6 +32,8 @@ rocksdb:
   write_buffer_size: 32000000
   # For each rocksdb, the number of memtables reaches this value for writing to disk.
   min_write_buffer_number_to_merge: 16
+  # The RocksDB engine provider, optional values: standard, topling
+  # provider: topling
   # Configuration file path for rocksdb/toplingdb
   # option_path: ./conf/rocksdb_store.yaml
   # Whether to start Topling's HTTP service

--- a/install-dist/scripts/dependency/known-dependencies.txt
+++ b/install-dist/scripts/dependency/known-dependencies.txt
@@ -318,8 +318,6 @@ jnr-ffi-2.1.7.jar
 jnr-x86asm-1.0.2.jar
 joda-time-2.10.8.jar
 joni-2.2.1.jar
-jraft-core-1.3.11.jar
-jraft-core-1.3.13.jar
 jraft-core-1.3.14.jar
 jraft-core-1.3.9.jar
 json-path-2.5.0.jar
@@ -512,7 +510,7 @@ psjava-0.1.19.jar
 reporter-config-base-3.0.3.jar
 reporter-config3-3.0.3.jar
 rewriting-9.0-9.0.20190305.jar
-rocksdbjni-8.10.2-SNAPSHOT.jar
+rocksdbjni-8.10.2.jar
 scala-java8-compat_2.12-0.8.0.jar
 scala-library-2.12.7.jar
 scala-reflect-2.12.7.jar


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

Add ToplingDB support as an optional RocksDB-compatible storage path.

This PR rebases and prepares the existing ToplingDB adaptation work for review on the current `master`. ToplingDB is integrated as an optional provider for RocksDB-based storage, allowing users to enable RocksDB/ToplingDB configuration and the ToplingDB Web UI while preserving the standard RocksDB path.

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better and faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

- Add `hugegraph-rocksdb-provider` module
- Update HugeGraph Server RocksDB integration
- Add ToplingDB preload support in server dist
- Add PD / Store ToplingDB integration
- Add Maven / CI / dependency metadata updates
- Add ToplingDB docs and specs

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
    - Built packaged dist artifacts for Server / PD / Store
    - Verified packaged `rocksdbjni-8.10.2-SNAPSHOT.jar` contains ToplingDB resources including `org/rocksdb/SidePluginRepo.class`
    - Ran Server with ToplingDB enabled
    - Ran Server without `rocksdb.option_path`
    - Ran PD / Store with ToplingDB config

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [x]  Modify configurations
- [ ]  The public API
- [x]  Other affects (typed here)
  - Adds native library preload logic for ToplingDB-enabled RocksDB JNI runtime.
  - Adds optional ToplingDB Web UI support.
  - Adds RocksDB provider SPI and routes RocksDB opening through the provider loader.
- [ ]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [x]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [ ]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发布说明

* **新功能**
  * 可选集成 ToplingDB 引擎，支持外部参数文件与可选内置 HTTP 监控服务
  * 新增配置项用于指定 RocksDB 参数路径并控制 HTTP 服务开关

* **文档**
  * 新增 ToplingDB 的设计、需求、任务、运维、安全与故障排查等完整文档

* **Chores**
  * 启动/预加载/安装脚本与打包流程增强、依赖版本更新、CI 环境变量与权限调整、引入可插拔的 RocksDB 提供方机制

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hugegraph/hugegraph/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->