### PR TITLE
fix(toplingdb): align Easy Migrate runtime

### DIFF
--- a/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/store/HgKVStoreImpl.java
+++ b/hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/store/HgKVStoreImpl.java
@@ -67,7 +67,7 @@ public class HgKVStoreImpl implements HgKVStore {
         final Lock writeLock = this.readWriteLock.writeLock();
         writeLock.lock();
         try {
-            this.dbPath = config.getDataPath() + "/rocksdb/";
+            this.dbPath = config.getDataPath() + "/rocksdb";
             File file = new File(this.dbPath);
             if (!file.exists()) {
                 try {

--- a/hugegraph-pd/hg-pd-dist/src/assembly/static/bin/start-hugegraph-pd.sh
+++ b/hugegraph-pd/hg-pd-dist/src/assembly/static/bin/start-hugegraph-pd.sh
@@ -71,6 +71,9 @@ ensure_path_writable "$PLUGINS"
 
 # preload rocksdb/toplingdb
 if [ -n "$SERVER_VERSION_DIR" ] && [ -e "$SERVER_VERSION_DIR/bin/preload-topling.sh" ]; then
+    if [ -z "${TOPLINGDB_EASY_MIGRATE_CONF:-}" ]; then
+        TOPLINGDB_EASY_MIGRATE_CONF="$CONF/rocksdb_pd.yaml"
+    fi
     source "$SERVER_VERSION_DIR/bin/preload-topling.sh"
 fi
 

--- a/hugegraph-pd/hg-pd-dist/src/assembly/static/conf/rocksdb_pd.yaml
+++ b/hugegraph-pd/hg-pd-dist/src/assembly/static/conf/rocksdb_pd.yaml
@@ -18,7 +18,8 @@
 http:
   # normally parent path of db path
   document_root: /dev/shm/rocksdb_resource
-  listening_ports: '127.0.0.1:2011'
+  listening_ports: '127.0.0.1:2012'
+  auto_start_http: true
 setenv:
   StrSimpleEnvNameNotOverwrite: StringValue
   IntSimpleEnvNameNotOverwrite: 16384
@@ -139,7 +140,10 @@ CFOptions:
       - kSnappyCompression
       - kSnappyCompression
 DBOptions:
-  dbo:
+  log:
+    create_if_missing: true
+    create_missing_column_families: true
+  default:
     create_if_missing: true
     create_missing_column_families: false # this is important, must be false to hugegraph
     max_background_compactions: -1

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/bin/common-topling.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/bin/common-topling.sh
@@ -153,27 +153,28 @@ function ensure_libaio_symlink() {
 function download_and_verify() {
     local url=$1
     local filepath=$2
-    local expected_md5=$3
+    local expected_sha256=$3
+    local actual_sha256
 
     if [[ -f $filepath ]]; then
-        echo "File $filepath exists. Verifying MD5 checksum..."
-        actual_md5=$(md5sum $filepath | awk '{ print $1 }')
-        if [[ $actual_md5 != $expected_md5 ]]; then
-            echo "MD5 checksum verification failed for $filepath. Expected: $expected_md5, but got: $actual_md5"
+        echo "File $filepath exists. Verifying SHA-256 checksum..."
+        actual_sha256=$(sha256sum "$filepath" | awk '{ print $1 }')
+        if [[ $actual_sha256 != $expected_sha256 ]]; then
+            echo "SHA-256 checksum verification failed for $filepath. Expected: $expected_sha256, but got: $actual_sha256"
             echo "Deleting $filepath..."
-            rm -f $filepath
+            rm -f "$filepath"
         else
-            echo "MD5 checksum verification succeeded for $filepath."
+            echo "SHA-256 checksum verification succeeded for $filepath."
             return 0
         fi
     fi
 
     echo "Downloading $filepath..."
-    curl -L -o $filepath $url
+    curl -fL -o "$filepath" "$url"
 
-    actual_md5=$(md5sum $filepath | awk '{ print $1 }')
-    if [[ $actual_md5 != $expected_md5 ]]; then
-        echo "MD5 checksum verification failed for $filepath after download. Expected: $expected_md5, but got: $actual_md5"
+    actual_sha256=$(sha256sum "$filepath" | awk '{ print $1 }')
+    if [[ $actual_sha256 != $expected_sha256 ]]; then
+        echo "SHA-256 checksum verification failed for $filepath after download. Expected: $expected_sha256, but got: $actual_sha256"
         return 1
     fi
 
@@ -181,8 +182,12 @@ function download_and_verify() {
 }
 
 function download_and_setup_jemalloc() {
-    local arch lib_file download_url expected_md5 system_lib top
+    local arch lib_file download_url expected_sha256 system_lib top
     top=$1
+
+    if [[ "${LD_PRELOAD:-}" == *"libjemalloc"* ]]; then
+        return 0
+    fi
 
     # Prefer system-installed jemalloc if available
     # Try ldconfig first to locate the shared object
@@ -211,9 +216,7 @@ function download_and_setup_jemalloc() {
 
     # If found, set LD_PRELOAD and return immediately
     if [[ -n "$system_lib" ]]; then
-        if [[ ":${LD_PRELOAD:-}:" != *"libjemalloc"* ]]; then
-            export LD_PRELOAD="${system_lib}${LD_PRELOAD:+:$LD_PRELOAD}"
-        fi
+        export LD_PRELOAD="${system_lib}${LD_PRELOAD:+:$LD_PRELOAD}"
         return 0
     fi
 
@@ -221,24 +224,23 @@ function download_and_setup_jemalloc() {
     arch=$(uname -m)
 
     # System jemalloc not found, try to download the correct library for the architecture
+    # Checksums match apache/hugegraph-doc@567625c6ec66907fc60f1864146fbec91b5f6204.
     if [[ $arch == "aarch64" || $arch == "arm64" ]]; then
         lib_file="$top/bin/libjemalloc_aarch64.so"
         download_url="${GITHUB}/apache/hugegraph-doc/raw/binary-1.5/dist/server/libjemalloc_aarch64.so"
-        expected_md5="2a631d2f81837f9d5864586761c5e380"
+        expected_sha256="6b7e6099b6da798829c6ce6fcb55a787508841edd52446332a73300889dcd1dc"
     elif [[ $arch == "x86_64" ]]; then
         lib_file="$top/bin/libjemalloc.so"
         download_url="${GITHUB}/apache/hugegraph-doc/raw/binary-1.5/dist/server/libjemalloc.so"
-        expected_md5="fd61765eec3bfea961b646c269f298df"
+        expected_sha256="53b25e8626e1605cbd8b60befb3431cabc1b8851a54285e0dda412796feab67d"
     else
         echo "Unsupported architecture: $arch"
         return 1
     fi
 
     # Download and verify jemalloc library (fallback when system lib not found)
-    if download_and_verify "$download_url" "$lib_file" "$expected_md5"; then
-        if [[ ":${LD_PRELOAD:-}:" != *"libjemalloc.so:"* ]]; then
-            export LD_PRELOAD="${lib_file}${LD_PRELOAD:+:$LD_PRELOAD}"
-        fi
+    if download_and_verify "$download_url" "$lib_file" "$expected_sha256"; then
+        export LD_PRELOAD="${lib_file}${LD_PRELOAD:+:$LD_PRELOAD}"
     else
         echo "Failed to verify or download jemalloc for $arch, skipping"
         return 1
@@ -248,6 +250,17 @@ function download_and_setup_jemalloc() {
 function preload_toplingdb() {
     local lib_dir="$1"
     local dest_dir="$2"
+    local os_name machine_arch
+
+    os_name="$(uname -s)"
+    machine_arch="$(uname -m)"
+    if [ "$os_name" != "Linux" ] ||
+       [[ "$machine_arch" != "x86_64" ]]; then
+        echo "[common-topling] Skip native preload on unsupported platform: " \
+             "$os_name/$machine_arch" >&2
+        return 0
+    fi
+
     local top="$(cd "$lib_dir"/../ && pwd)"
 
     local jar_file
@@ -275,7 +288,9 @@ function preload_toplingdb() {
             {
                 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
                 echo "LD_PRELOAD=$LD_PRELOAD"
-                echo "SERVER_VERSION_DIR=$SERVER_VERSION_DIR"
+                if [ -n "${SERVER_VERSION_DIR:-}" ]; then
+                    echo "SERVER_VERSION_DIR=$SERVER_VERSION_DIR"
+                fi
             } >> "$GITHUB_ENV" || true
             echo "[common-topling] Exported LD_LIBRARY_PATH and LD_PRELOAD to GITHUB_ENV" >&2 || true
         fi

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/bin/common-topling.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/bin/common-topling.sh
@@ -247,19 +247,24 @@ function download_and_setup_jemalloc() {
     fi
 }
 
-function preload_toplingdb() {
-    local lib_dir="$1"
-    local dest_dir="$2"
+function require_topling_platform() {
     local os_name machine_arch
 
     os_name="$(uname -s)"
     machine_arch="$(uname -m)"
     if [ "$os_name" != "Linux" ] ||
        [[ "$machine_arch" != "x86_64" ]]; then
-        echo "[common-topling] Skip native preload on unsupported platform: " \
-             "$os_name/$machine_arch" >&2
-        return 0
+        printf 'Error: ToplingDB native runtime supports Linux x86_64 only; ' >&2
+        printf 'current platform is %s/%s\n' "$os_name" "$machine_arch" >&2
+        return 1
     fi
+}
+
+function preload_toplingdb() {
+    local lib_dir="$1"
+    local dest_dir="$2"
+
+    require_topling_platform || return 1
 
     local top="$(cd "$lib_dir"/../ && pwd)"
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/bin/preload-topling.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/bin/preload-topling.sh
@@ -49,6 +49,13 @@ fi
 if [ "$PROVIDER" = "topling" ]; then
     # --- ToplingDB mode: swap JAR and set up environment ---
 
+    source "$SERVER_BIN/common-topling.sh"
+    type require_topling_platform >/dev/null 2>&1 || {
+        echo "Error: function require_topling_platform not found" >&2
+        exit 1
+    }
+    require_topling_platform || exit 1
+
     TOPLING_JAR=$(ls -1 "$SERVER_LIB"/topling/rocksdbjni*.jar 2>/dev/null | sort -V | tail -1 || true)
     if [ -z "${TOPLING_JAR:-}" ]; then
         echo "Error: rocksdb.provider=topling but no ToplingDB JAR found in $SERVER_LIB/topling/" >&2
@@ -66,15 +73,17 @@ if [ "$PROVIDER" = "topling" ]; then
     echo "[preload-topling] Activated ToplingDB JAR: $(basename "$TOPLING_JAR")"
 
     # Run native library preload (extract .so, set LD_PRELOAD/LD_LIBRARY_PATH, jemalloc)
-    source "$SERVER_BIN/common-topling.sh"
     type preload_toplingdb >/dev/null 2>&1 || { echo "Error: function preload_toplingdb not found" >&2; exit 1; }
     preload_toplingdb "$SERVER_LIB" "$DEST_DIR"
 
-    # Set Easy Migrate environment variable
-    # Check both hugegraph-server and HStore config locations
-    CONF_FILE="$SERVER_TOP/conf/toplingdb.yaml"
-    if [ ! -f "$CONF_FILE" ]; then
-        CONF_FILE="$SERVER_TOP/conf/rocksdb_store.yaml"
+    # Prefer an Easy Migrate config supplied by the caller;
+    # otherwise check the existing Server and HStore config locations.
+    CONF_FILE="${TOPLINGDB_EASY_MIGRATE_CONF:-}"
+    if [ -z "$CONF_FILE" ]; then
+        CONF_FILE="$SERVER_TOP/conf/toplingdb.yaml"
+        if [ ! -f "$CONF_FILE" ]; then
+            CONF_FILE="$SERVER_TOP/conf/rocksdb_store.yaml"
+        fi
     fi
     if [ -f "$CONF_FILE" ]; then
         export TOPLINGDB_EASY_MIGRATE_CONF="$CONF_FILE"

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/toplingdb.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/toplingdb.yaml
@@ -140,6 +140,9 @@ CFOptions:
       - kSnappyCompression
       - kSnappyCompression
 DBOptions:
+  log:
+    create_if_missing: true
+    create_missing_column_families: true
   default:
     create_if_missing: true
     create_missing_column_families: false # this is important, must be false to hugegraph

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/install-rocksdb.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/install-rocksdb.sh
@@ -16,15 +16,23 @@
 # limitations under the License.
 #
 
-set -Eeuo pipefail
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "[install-rocksdb] Skip native preload on non-Linux platform: $(uname -s)"
+    return 0 2>/dev/null || exit 0
+fi
+
+ORIG_SHELL_FLAGS="$-"
+ORIG_PIPEFAIL="$(set -o | awk '$1 == "pipefail" { print $2 }')"
+ORIG_ERR_TRAP="$(trap -p ERR)"
 # Save original IFS to avoid leaking into parent shell when sourced
 ORIG_IFS="${IFS}"
+set -Eeuo pipefail
 IFS=$'\n\t'
 # Unified error capture for easy positioning
 trap 'echo "[install-rocksdb] error at line ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
 VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-SERVER_VERSION_DIR="$(pwd)/hugegraph-server/apache-hugegraph-server-incubating-$VERSION"
+SERVER_VERSION_DIR="$(pwd)/hugegraph-server/apache-hugegraph-server-$VERSION"
 SERVER_BIN="$SERVER_VERSION_DIR/bin"
 SERVER_LIB="$SERVER_VERSION_DIR/lib"
 INSTALL_DEST_DIR="$SERVER_VERSION_DIR/library"
@@ -46,8 +54,19 @@ source "$SERVER_BIN/common-topling.sh"
 type preload_toplingdb >/dev/null 2>&1 || { echo "Error: function preload_toplingdb not found" >&2; exit 1; }
 preload_toplingdb "$SERVER_LIB" "$INSTALL_DEST_DIR"
 
-# Reset shell options to prevent affecting the parent shell when sourced
-set +Eeuo pipefail
-trap - ERR
 # Restore original IFS
 IFS="$ORIG_IFS"
+if [ -n "$ORIG_ERR_TRAP" ]; then
+    eval "$ORIG_ERR_TRAP"
+else
+    trap - ERR
+fi
+# Reset shell options to prevent affecting the parent shell when sourced
+case "$ORIG_SHELL_FLAGS" in *e*) set -e ;; *) set +e ;; esac
+case "$ORIG_SHELL_FLAGS" in *u*) set -u ;; *) set +u ;; esac
+case "$ORIG_SHELL_FLAGS" in *E*) set -E ;; *) set +E ;; esac
+if [ "$ORIG_PIPEFAIL" = "on" ]; then
+    set -o pipefail
+else
+    set +o pipefail
+fi

--- a/hugegraph-store/hg-store-dist/src/assembly/static/bin/start-hugegraph-store.sh
+++ b/hugegraph-store/hg-store-dist/src/assembly/static/bin/start-hugegraph-store.sh
@@ -68,6 +68,9 @@ fi
 
 # preload rocksdb/toplingdb
 if [ -n "$SERVER_VERSION_DIR" ] && [ -e "$SERVER_VERSION_DIR/bin/preload-topling.sh" ]; then
+    if [ -z "${TOPLINGDB_EASY_MIGRATE_CONF:-}" ]; then
+        TOPLINGDB_EASY_MIGRATE_CONF="$CONF/rocksdb_store.yaml"
+    fi
     source "$SERVER_VERSION_DIR/bin/preload-topling.sh"
 fi
 

--- a/hugegraph-store/hg-store-dist/src/assembly/static/conf/rocksdb_store.yaml
+++ b/hugegraph-store/hg-store-dist/src/assembly/static/conf/rocksdb_store.yaml
@@ -18,7 +18,8 @@
 http:
   # normally parent path of db path
   document_root: /dev/shm/rocksdb_resource
-  listening_ports: '127.0.0.1:2011'
+  listening_ports: '127.0.0.1:2013'
+  auto_start_http: true
 setenv:
   StrSimpleEnvNameNotOverwrite: StringValue
   IntSimpleEnvNameNotOverwrite: 16384
@@ -139,7 +140,10 @@ CFOptions:
       - kSnappyCompression
       - kSnappyCompression
 DBOptions:
-  dbo:
+  log:
+    create_if_missing: true
+    create_missing_column_families: true
+  default:
     create_if_missing: true
     create_missing_column_families: false # this is important, must be false to hugegraph
     max_background_compactions: -1

--- a/install-dist/scripts/dependency/known-dependencies.txt
+++ b/install-dist/scripts/dependency/known-dependencies.txt
@@ -318,8 +318,6 @@ jnr-ffi-2.1.7.jar
 jnr-x86asm-1.0.2.jar
 joda-time-2.10.8.jar
 joni-2.2.1.jar
-jraft-core-1.3.11.jar
-jraft-core-1.3.13.jar
 jraft-core-1.3.14.jar
 jraft-core-1.3.9.jar
 json-path-2.5.0.jar
@@ -512,7 +510,7 @@ psjava-0.1.19.jar
 reporter-config-base-3.0.3.jar
 reporter-config3-3.0.3.jar
 rewriting-9.0-9.0.20190305.jar
-rocksdbjni-8.10.2-SNAPSHOT.jar
+rocksdbjni-8.10.2.jar
 scala-java8-compat_2.12-0.8.0.jar
 scala-library-2.12.7.jar
 scala-reflect-2.12.7.jar


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR fix/close an issue, type the message "close xxx" (xxx is the link of related 
issue) in the content, GitHub will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after 
published)
-->

## Purpose of the PR

Align ToplingDB Easy Migrate

<!--
Please explain more context in this section, clarify why the changes are needed. 
e.g:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should be associated with an issue.
-->

## Main Changes

<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better and faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->
- Align ToplingDB Easy Migrate configuration across Server, PD, and Store.
- Fix JRaft log column-family creation and PD path matching.
- Port required CI/runtime fixes for platform checks, SHA-256 verification, shell-state restoration, packaging paths, and dependency metadata.

## Verifying these changes

<!-- Please pick the proper options below -->

- [x] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [ ] Need tests and can be verified as follows:
    - xxx

## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh)) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)
- [x]  Nope


## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the ToplingDB Easy Migrate runtime across Server, PD, and Store by ensuring each component sets `TOPLINGDB_EASY_MIGRATE_CONF` to its own YAML config before sourcing `preload-topling.sh`, fixes the JRaft `log` column-family entry in all three YAML configs, and ports several CI/runtime hardening improvements.

- Each YAML config now has a unique HTTP listening port (2011/2012/2013) and an explicit `log` DBOptions entry with `create_missing_column_families: true` for JRaft, while keeping `create_missing_column_families: false` for the `default` entry.
- `common-topling.sh` upgrades checksum verification from MD5 to SHA-256, adds a new `require_topling_platform()` guard enforcing Linux x86_64, and adds a jemalloc early-exit check; `install-rocksdb.sh` now properly saves and restores all shell flags/traps and drops the `-incubating-` path segment.
- `HgKVStoreImpl.java` removes the trailing slash from the RocksDB path so that ToplingDB path-based YAML key matching works correctly for the PD store.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing one shell scripting issue in preload-topling.sh; all other changes are correct and well-structured.

In preload-topling.sh, when no YAML config file is found and the script runs inside a GitHub Actions workflow, the bare $TOPLINGDB_EASY_MIGRATE_CONF is unset while set -u is active, causing an unbound-variable abort before || true can suppress it. A one-character fix resolves it. All other changes are correct.

**Files Needing Attention:** hugegraph-server/hugegraph-dist/src/assembly/static/bin/preload-topling.sh (line 97 — unbound variable under set -u)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| hugegraph-pd/hg-pd-core/src/main/java/org/apache/hugegraph/pd/store/HgKVStoreImpl.java | Removes trailing slash from dbPath ("/rocksdb/" → "/rocksdb") so that the ToplingDB Easy Migrate path-based YAML key matching works correctly for the PD store. |
| hugegraph-pd/hg-pd-dist/src/assembly/static/conf/rocksdb_pd.yaml | Assigns unique port 2012 (was 2011), adds auto_start_http, renames DBOptions key from "dbo" to "default" and adds a "log" CF entry with create_missing_column_families=true for JRaft. |
| hugegraph-server/hugegraph-dist/src/assembly/static/bin/common-topling.sh | Upgrades hash verification from MD5 to SHA-256, adds jemalloc early-exit guard, adds require_topling_platform() enforcing Linux x86_64, and moves platform check into preload_toplingdb(); aarch64 jemalloc branch is now unreachable. |
| hugegraph-server/hugegraph-dist/src/assembly/static/bin/preload-topling.sh | Sources common-topling.sh and calls require_topling_platform before JAR swap; adds caller-supplied TOPLINGDB_EASY_MIGRATE_CONF override; has a potential set -u unbound-variable issue when no config file is found in CI. |
| hugegraph-server/hugegraph-dist/src/assembly/travis/install-rocksdb.sh | Adds non-Linux early exit, properly saves/restores shell flags (set -Eeuo pipefail) and ERR trap on return, and corrects the SERVER_VERSION_DIR path by removing the "-incubating-" component. |
| hugegraph-store/hg-store-dist/src/assembly/static/conf/rocksdb_store.yaml | Assigns unique port 2013 (was 2011), adds auto_start_http, renames DBOptions key from "dbo" to "default" and adds "log" CF entry — mirrors rocksdb_pd.yaml changes. |
| install-dist/scripts/dependency/known-dependencies.txt | Removes two obsolete jraft-core entries (1.3.11 and 1.3.13), and promotes rocksdbjni from the SNAPSHOT to the release artifact name. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `hugegraph-server/hugegraph-dist/src/assembly/static/bin/preload-topling.sh`, line 97 ([link](https://github.com/hugegraph/hugegraph/blob/c9ff5b50631888afb162ad71f1a9b3ab96883f92/hugegraph-server/hugegraph-dist/src/assembly/static/bin/preload-topling.sh#L97)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> If no config file is found, `TOPLINGDB_EASY_MIGRATE_CONF` is never exported in this script. With `set -u` active, the bare `$TOPLINGDB_EASY_MIGRATE_CONF` on this line will throw "unbound variable" before `|| true` can do anything, aborting the script in a CI environment where `GITHUB_ENV` is writable. Use the `:-` default operator to make the expansion safe.

   

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hugegraph%2Fhugegraph%22%20on%20the%20existing%20branch%20%22fix%2Ftoplingdb-easy-migrate-runtime%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftoplingdb-easy-migrate-runtime%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20hugegraph-server%2Fhugegraph-dist%2Fsrc%2Fassembly%2Fstatic%2Fbin%2Fpreload-topling.sh%0ALine%3A%2097%0A%0AComment%3A%0AIf%20no%20config%20file%20is%20found%2C%20%60TOPLINGDB_EASY_MIGRATE_CONF%60%20is%20never%20exported%20in%20this%20script.%20With%20%60set%20-u%60%20active%2C%20the%20bare%20%60%24TOPLINGDB_EASY_MIGRATE_CONF%60%20on%20this%20line%20will%20throw%20%22unbound%20variable%22%20before%20%60%7C%7C%20true%60%20can%20do%20anything%2C%20aborting%20the%20script%20in%20a%20CI%20environment%20where%20%60GITHUB_ENV%60%20is%20writable.%20Use%20the%20%60%3A-%60%20default%20operator%20to%20make%20the%20expansion%20safe.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20echo%20%22TOPLINGDB_EASY_MIGRATE_CONF%3D%24%7BTOPLINGDB_EASY_MIGRATE_CONF%3A-%7D%22%20%3E%3E%20%22%24GITHUB_ENV%22%20%7C%7C%20true%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=hugegraph%2Fhugegraph&pr=172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20hugegraph-server%2Fhugegraph-dist%2Fsrc%2Fassembly%2Fstatic%2Fbin%2Fpreload-topling.sh%0ALine%3A%2097%0A%0AComment%3A%0AIf%20no%20config%20file%20is%20found%2C%20%60TOPLINGDB_EASY_MIGRATE_CONF%60%20is%20never%20exported%20in%20this%20script.%20With%20%60set%20-u%60%20active%2C%20the%20bare%20%60%24TOPLINGDB_EASY_MIGRATE_CONF%60%20on%20this%20line%20will%20throw%20%22unbound%20variable%22%20before%20%60%7C%7C%20true%60%20can%20do%20anything%2C%20aborting%20the%20script%20in%20a%20CI%20environment%20where%20%60GITHUB_ENV%60%20is%20writable.%20Use%20the%20%60%3A-%60%20default%20operator%20to%20make%20the%20expansion%20safe.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20echo%20%22TOPLINGDB_EASY_MIGRATE_CONF%3D%24%7BTOPLINGDB_EASY_MIGRATE_CONF%3A-%7D%22%20%3E%3E%20%22%24GITHUB_ENV%22%20%7C%7C%20true%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=hugegraph%2Fhugegraph&pr=172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hugegraph%2Fhugegraph%22%20on%20the%20existing%20branch%20%22fix%2Ftoplingdb-easy-migrate-runtime%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ftoplingdb-easy-migrate-runtime%22.%0A%0A%23%23%23%20Issue%201%0Ahugegraph-server%2Fhugegraph-dist%2Fsrc%2Fassembly%2Fstatic%2Fbin%2Fpreload-topling.sh%3A97%0AIf%20no%20config%20file%20is%20found%2C%20%60TOPLINGDB_EASY_MIGRATE_CONF%60%20is%20never%20exported%20in%20this%20script.%20With%20%60set%20-u%60%20active%2C%20the%20bare%20%60%24TOPLINGDB_EASY_MIGRATE_CONF%60%20on%20this%20line%20will%20throw%20%22unbound%20variable%22%20before%20%60%7C%7C%20true%60%20can%20do%20anything%2C%20aborting%20the%20script%20in%20a%20CI%20environment%20where%20%60GITHUB_ENV%60%20is%20writable.%20Use%20the%20%60%3A-%60%20default%20operator%20to%20make%20the%20expansion%20safe.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20echo%20%22TOPLINGDB_EASY_MIGRATE_CONF%3D%24%7BTOPLINGDB_EASY_MIGRATE_CONF%3A-%7D%22%20%3E%3E%20%22%24GITHUB_ENV%22%20%7C%7C%20true%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=hugegraph%2Fhugegraph&pr=172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ahugegraph-server%2Fhugegraph-dist%2Fsrc%2Fassembly%2Fstatic%2Fbin%2Fpreload-topling.sh%3A97%0AIf%20no%20config%20file%20is%20found%2C%20%60TOPLINGDB_EASY_MIGRATE_CONF%60%20is%20never%20exported%20in%20this%20script.%20With%20%60set%20-u%60%20active%2C%20the%20bare%20%60%24TOPLINGDB_EASY_MIGRATE_CONF%60%20on%20this%20line%20will%20throw%20%22unbound%20variable%22%20before%20%60%7C%7C%20true%60%20can%20do%20anything%2C%20aborting%20the%20script%20in%20a%20CI%20environment%20where%20%60GITHUB_ENV%60%20is%20writable.%20Use%20the%20%60%3A-%60%20default%20operator%20to%20make%20the%20expansion%20safe.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20echo%20%22TOPLINGDB_EASY_MIGRATE_CONF%3D%24%7BTOPLINGDB_EASY_MIGRATE_CONF%3A-%7D%22%20%3E%3E%20%22%24GITHUB_ENV%22%20%7C%7C%20true%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=hugegraph%2Fhugegraph&pr=172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["fix(toplingdb): correct component preloa..."](https://github.com/hugegraph/hugegraph/commit/c9ff5b50631888afb162ad71f1a9b3ab96883f92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47816973)</sub>

<!-- /greptile_comment -->