### PR TITLE
fix(server): retry all PD peers while waiting for storage

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -9,6 +9,15 @@ on:
   pull_request:
 
 jobs:
+  wait-storage-shell-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run wait-storage.sh peer failover tests
+        run: hugegraph-server/hugegraph-dist/src/assembly/travis/test-wait-storage.sh
+
   build-server:
     # TODO: we need test & replace it to ubuntu-24.04 or ubuntu-latest
     runs-on: ubuntu-22.04

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-storage.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-storage.sh
@@ -97,9 +97,10 @@ if env | grep '^hugegraph\.' > /dev/null; then
 
               log() { echo '[wait-storage] '\"\$1\"; }
 
-              check_any_pd() {
+              check_any_pd_stores() {
                 for peer in \$(echo \"\$PD_REST_LIST\" | tr ',' ' '); do
-                  if curl ${PD_AUTH_ARGS} -f -s http://\${peer}/v1/health >/dev/null 2>&1; then
+                  if curl ${PD_AUTH_ARGS} -f -s http://\${peer}/v1/stores 2>/dev/null | \
+                     grep -qi '\"state\"[[:space:]]*:[[:space:]]*\"Up\"'; then
                     echo \"\$peer\"
                     return 0
                   fi
@@ -107,20 +108,11 @@ if env | grep '^hugegraph\.' > /dev/null; then
                 return 1
               }
 
-              until PD_REST=\$(check_any_pd); do
-                log 'No PD peer ready yet, retrying in 5s'
-                sleep 5
-              done
-              log \"PD health check PASSED via \$PD_REST\"
-
-              until curl ${PD_AUTH_ARGS} -f -s \
-                    http://\${PD_REST}/v1/stores 2>/dev/null | \
-                    grep -qi '\"state\"[[:space:]]*:[[:space:]]*\"Up\"'; do
+              until PD_REST=\$(check_any_pd_stores); do
                 log 'No Up store yet, retrying in 5s'
                 sleep 5
               done
-
-              log 'Store registration check PASSED'
+              log \"Store registration check PASSED via \$PD_REST\"
               log 'Storage backend is VIABLE'
             " || { echo "[wait-storage] ERROR: Timeout waiting for storage backend"; exit 1; }
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-wait-storage.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-wait-storage.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SOURCE_BIN="${1:-$(cd "${SCRIPT_DIR}/../static/bin" && pwd)}"
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/wait-storage-test.XXXXXX")
+DIST_ROOT="${TMP_DIR}/dist"
+MOCK_BIN="${TMP_DIR}/mock-bin"
+CALL_LOG="${TMP_DIR}/curl-calls"
+ARGS_LOG="${TMP_DIR}/curl-args"
+COUNT_FILE="${TMP_DIR}/store-call-count"
+TIMEOUT_LOG="${TMP_DIR}/timeout-arg"
+CASE_OUTPUT=""
+CASE_RC=0
+
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+fail() {
+    echo "FAIL: $1" >&2
+    [[ -z "${CASE_OUTPUT}" ]] || printf '%s\n' "${CASE_OUTPUT}" >&2
+    exit 1
+}
+
+assert_equal() {
+    local name="$1" expected="$2" actual="$3"
+    [[ "${actual}" == "${expected}" ]] || \
+        fail "${name}: expected '${expected}', got '${actual}'"
+}
+
+assert_output() {
+    local expected="$1"
+    [[ "${CASE_OUTPUT}" == *"${expected}"* ]] || \
+        fail "missing output '${expected}'"
+}
+
+assert_contract() {
+    ! grep -q '/v1/health' "${CALL_LOG}" || \
+        fail "/v1/health must not gate readiness"
+    [[ -s "${ARGS_LOG}" ]] || fail "curl was not called"
+    if grep -Fv -- '-u test-user:test-password' "${ARGS_LOG}" | grep -q .; then
+        fail "authentication arguments were not preserved"
+    fi
+    assert_equal "outer timeout" "300s" "$(cat "${TIMEOUT_LOG}")"
+}
+
+run_case() {
+    local scenario="$1" peers="$2" abort_after="$3"
+    : > "${CALL_LOG}"
+    : > "${ARGS_LOG}"
+    : > "${COUNT_FILE}"
+    : > "${TIMEOUT_LOG}"
+    : > "${DIST_ROOT}/conf/graphs/hugegraph.properties"
+
+    CASE_OUTPUT=$(env \
+        PATH="${MOCK_BIN}:${PATH}" \
+        MOCK_SCENARIO="${scenario}" \
+        MOCK_ABORT_AFTER="${abort_after}" \
+        MOCK_CALL_LOG="${CALL_LOG}" \
+        MOCK_ARGS_LOG="${ARGS_LOG}" \
+        MOCK_COUNT_FILE="${COUNT_FILE}" \
+        MOCK_TIMEOUT_LOG="${TIMEOUT_LOG}" \
+        HG_SERVER_PD_REST_ENDPOINT="${peers}" \
+        PD_AUTH_USER="test-user" \
+        PD_AUTH_PASSWORD="test-password" \
+        'hugegraph.backend=hstore' \
+        'hugegraph.pd.peers=config-only:8686' \
+        "${DIST_ROOT}/bin/wait-storage.sh" 2>&1)
+    CASE_RC=$?
+}
+
+if [[ ! -f "${SOURCE_BIN}/wait-storage.sh" || ! -f "${SOURCE_BIN}/util.sh" ]]; then
+    fail "wait-storage.sh or util.sh not found under ${SOURCE_BIN}"
+fi
+
+mkdir -p "${DIST_ROOT}/bin" "${DIST_ROOT}/conf/graphs" "${MOCK_BIN}"
+cp "${SOURCE_BIN}/wait-storage.sh" "${SOURCE_BIN}/util.sh" "${DIST_ROOT}/bin/"
+: > "${DIST_ROOT}/conf/graphs/hugegraph.properties"
+
+cat > "${MOCK_BIN}/timeout" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$1" > "${MOCK_TIMEOUT_LOG}"
+shift
+"$@" &
+command_pid=$!
+ticks=0
+while kill -0 "${command_pid}" 2>/dev/null; do
+    count=$(cat "${MOCK_COUNT_FILE}" 2>/dev/null || true)
+    count=${count:-0}
+    ticks=$((ticks + 1))
+    if [[ "${count}" -ge "${MOCK_ABORT_AFTER}" || "${ticks}" -ge 500 ]]; then
+        kill -TERM "${command_pid}" 2>/dev/null || true
+        wait "${command_pid}" 2>/dev/null || true
+        exit 124
+    fi
+    /bin/sleep 0.01
+done
+wait "${command_pid}"
+EOF
+
+cat > "${MOCK_BIN}/sleep" <<'EOF'
+#!/bin/bash
+/bin/sleep 0.02
+EOF
+
+cat > "${MOCK_BIN}/curl" <<'EOF'
+#!/bin/bash
+set -u
+url="${!#}"
+printf '%s\n' "$*" >> "${MOCK_ARGS_LOG}"
+printf '%s\n' "${url}" >> "${MOCK_CALL_LOG}"
+
+if [[ "${url}" == */v1/health ]]; then
+    printf '{}\n'
+    exit 0
+fi
+
+count=$(cat "${MOCK_COUNT_FILE}" 2>/dev/null || true)
+count=$((${count:-0} + 1))
+printf '%s\n' "${count}" > "${MOCK_COUNT_FILE}"
+
+if [[ "${MOCK_SCENARIO}" == "pd1-up" && \
+      "${url}" == "http://pd1:8620/v1/stores" ]]; then
+    printf '{"stores":[{"state":"Up"}]}\n'
+elif [[ "${MOCK_SCENARIO}" == "retry" && "${count}" -eq 3 && \
+        "${url}" == "http://pd0:8620/v1/stores" ]]; then
+    exit 7
+elif [[ "${MOCK_SCENARIO}" == "retry" && "${count}" -eq 4 && \
+        "${url}" == "http://pd1:8620/v1/stores" ]]; then
+    printf '{"stores":[{"state":"Up"}]}\n'
+else
+    printf '{"stores":[]}\n'
+fi
+EOF
+
+chmod +x "${MOCK_BIN}/timeout" "${MOCK_BIN}/sleep" "${MOCK_BIN}/curl"
+
+PD0='http://pd0:8620/v1/stores'
+PD1='http://pd1:8620/v1/stores'
+TWO_CALLS="${PD0}"$'\n'"${PD1}"
+FOUR_CALLS="${TWO_CALLS}"$'\n'"${TWO_CALLS}"
+
+echo "wait-storage.sh peer failover tests"
+
+run_case "pd1-up" "pd0:8620,pd1:8620" 6
+assert_equal "storeless first peer rc" "0" "${CASE_RC}"
+assert_equal "configured peer order" "${TWO_CALLS}" "$(cat "${CALL_LOG}")"
+assert_output "Store registration check PASSED via pd1:8620"
+assert_contract
+echo "  PASS storeless first peer"
+
+run_case "pd1-up" "pd1:8620,pd0:8620" 6
+assert_equal "reversed peer order rc" "0" "${CASE_RC}"
+assert_equal "stop after first Up peer" "${PD1}" "$(cat "${CALL_LOG}")"
+assert_contract
+echo "  PASS reversed peer order"
+
+run_case "retry" "pd0:8620,pd1:8620" 8
+assert_equal "retry rc" "0" "${CASE_RC}"
+assert_equal "complete peer rescan" "${FOUR_CALLS}" "$(cat "${CALL_LOG}")"
+assert_output "Storage backend is VIABLE"
+assert_contract
+echo "  PASS unavailable peer retry"
+
+run_case "none" "pd0:8620,pd1:8620" 4
+[[ "${CASE_RC}" -ne 0 ]] || fail "all-unready peers must fail closed"
+assert_equal "all-unready rescan" "${FOUR_CALLS}" "$(cat "${CALL_LOG}")"
+assert_output "ERROR: Timeout waiting for storage backend"
+assert_contract
+echo "  PASS all-unready timeout"
+
+echo "4 passed, 0 failed"


### PR DESCRIPTION
> Kept in sync with https://github.com/apache/hugegraph/pull/3129

## Purpose of the PR

- Tracks https://github.com/apache/hugegraph/issues/3123

`wait-storage.sh` selected the first PD answering `/v1/health`, then polled
`/v1/stores` only on that peer. Since the health endpoint can succeed before
the peer has raft-backed store state, a storeless first peer could block Server
startup even when another configured PD already reported an `Up` store.

## Main Changes

- Probe `/v1/stores` across every configured PD peer on every retry.
- Succeed as soon as any peer reports a store in state `Up`, without a separate
  `/v1/health` selection stage.
- Preserve authentication, configured peer order, custom REST endpoints, retry
  timing, and the existing outer timeout failure.
- Add a deterministic shell regression suite and an isolated Server CI job.

## Verifying these changes

- [x] Need tests and can be verified as follows:
  - `test-wait-storage.sh`: 4 scenarios passed, 0 failed.
  - The same suite fails against the unmodified script on the pinned first peer.
  - `bash -n` passed for the production and test scripts.
  - Server CI workflow YAML parsing and `git diff --check` passed.
  - Apache RAT and EditorConfig checks passed for the 20-module dependency set.

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [ ] Modify configurations
- [ ] The public API
- [x] Other affects (HStore Server startup readiness)
- [ ] Nope

## Documentation Status

- [ ] `Doc - TODO`
- [ ] `Doc - Done`
- [x] `Doc - No Need`

## Out of scope

- PD and Store health endpoint semantics
- `wait-partition.sh`
- Environment-variable and timeout configurability cleanup
- Docker Compose health checks and documentation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a startup race condition where `wait-storage.sh` could block HugeGraph Server indefinitely if the first reachable PD peer answered `/v1/health` but had no raft-backed store state yet, while another peer already reported an `Up` store.

- **`wait-storage.sh`**: Replaces the two-stage approach (find a healthy peer via `/v1/health`, then poll only that peer's `/v1/stores`) with a single-stage loop that probes `/v1/stores` across every configured PD peer on each retry, succeeding as soon as any peer reports an `Up` store.
- **`test-wait-storage.sh`**: New deterministic regression suite (4 scenarios: storeless first peer, reversed order, transient peer failure, all-peers-down timeout) using mock `curl`/`sleep`/`timeout` binaries for fast, isolated execution.
- **`server-ci.yml`**: New standalone `wait-storage-shell-test` CI job that runs the script suite on every push/PR without requiring a Maven build.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The production script change is a clean, self-contained fix to the startup wait logic with no impact on Java code paths, APIs, or configuration format.

The production fix correctly eliminates the broken two-stage polling pattern and the test suite validates all four meaningful scenarios. The only concern is a style issue in the test's retry scenario, where magic counter values are silently coupled to peer call order — a future edit adding or reordering peers could break test coverage without producing a clear error. This does not affect correctness of the shipped script.

**Files Needing Attention:** The retry scenario in `test-wait-storage.sh` (lines 141-149) uses implicit global counter values that should be documented to prevent future confusion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| hugegraph-server/hugegraph-dist/src/assembly/static/bin/wait-storage.sh | Core fix: eliminates the two-stage health-check/stores-check approach; now polls /v1/stores across every configured PD peer on each retry cycle and succeeds as soon as any peer reports an Up store. Authentication, peer order, timeout, and error path are all preserved correctly. |
| hugegraph-server/hugegraph-dist/src/assembly/travis/test-wait-storage.sh | New deterministic regression suite with 4 scenarios (storeless first peer, reversed order, peer failure then retry, all-peers-down timeout). Mock binaries correctly isolate the test from real network calls. Minor: the retry scenario's call counter magic numbers (3, 4) are implicitly coupled to peer call order. |
| .github/workflows/server-ci.yml | Adds an isolated wait-storage-shell-test job (ubuntu-22.04, checkout + script run) that runs independently from build-server. Uses actions/checkout@v4, consistent with the rest of the workflow. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22hugegraph%2Fhugegraph%22%20on%20the%20existing%20branch%20%22fix%2Fwait-storage-pd-failover-3123%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fwait-storage-pd-failover-3123%22.%0A%0A%23%23%23%20Issue%201%0Ahugegraph-server%2Fhugegraph-dist%2Fsrc%2Fassembly%2Ftravis%2Ftest-wait-storage.sh%3A141-149%0A**Retry%20scenario%20couples%20counter%20values%20to%20call%20order%20implicitly**%0A%0AThe%20%60retry%60%20scenario's%20success%20depends%20on%20%60count%20-eq%203%60%20landing%20exactly%20on%20pd0%20and%20%60count%20-eq%204%60%20landing%20exactly%20on%20pd1.%20The%20counter%20is%20global%20and%20monotonic%20across%20all%20curl%20calls%2C%20so%20these%20values%20are%20tightly%20coupled%20to%20the%20test's%20two-peer%20list%20always%20being%20iterated%20in%20the%20same%20order%20%28pd0%20first%29.%20Adding%20a%20third%20peer%2C%20or%20reordering%20peers%2C%20would%20silently%20shift%20the%20counts%20and%20cause%20the%20%60exit%207%60%20to%20misfire%20on%20a%20different%20peer%20%E2%80%94%20or%20never%20trigger%20%E2%80%94%20while%20the%20test%20still%20claims%20to%20pass.%20A%20comment%20or%20named%20constant%20documenting%20*why*%20these%20specific%20values%20are%20expected%20would%20make%20the%20coupling%20explicit%20and%20easier%20to%20maintain.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=hugegraph%2Fhugegraph&pr=175&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ahugegraph-server%2Fhugegraph-dist%2Fsrc%2Fassembly%2Ftravis%2Ftest-wait-storage.sh%3A141-149%0A**Retry%20scenario%20couples%20counter%20values%20to%20call%20order%20implicitly**%0A%0AThe%20%60retry%60%20scenario's%20success%20depends%20on%20%60count%20-eq%203%60%20landing%20exactly%20on%20pd0%20and%20%60count%20-eq%204%60%20landing%20exactly%20on%20pd1.%20The%20counter%20is%20global%20and%20monotonic%20across%20all%20curl%20calls%2C%20so%20these%20values%20are%20tightly%20coupled%20to%20the%20test's%20two-peer%20list%20always%20being%20iterated%20in%20the%20same%20order%20%28pd0%20first%29.%20Adding%20a%20third%20peer%2C%20or%20reordering%20peers%2C%20would%20silently%20shift%20the%20counts%20and%20cause%20the%20%60exit%207%60%20to%20misfire%20on%20a%20different%20peer%20%E2%80%94%20or%20never%20trigger%20%E2%80%94%20while%20the%20test%20still%20claims%20to%20pass.%20A%20comment%20or%20named%20constant%20documenting%20*why*%20these%20specific%20values%20are%20expected%20would%20make%20the%20coupling%20explicit%20and%20easier%20to%20maintain.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=hugegraph%2Fhugegraph&pr=175&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(server): retry all PD peers while wa..."](https://github.com/hugegraph/hugegraph/commit/575a112233e29ed58115ab2db0f83660f750648c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48485657)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->