### PR TITLE
fix(store): refresh gRPC channels after address changes

### DIFF
--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
@@ -18,9 +18,12 @@
 package org.apache.hugegraph.store.client.grpc;
 
 import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -28,7 +31,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -41,18 +44,42 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.AbstractAsyncStub;
 import io.grpc.stub.AbstractBlockingStub;
 import io.grpc.stub.AbstractStub;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public abstract class AbstractGrpcClient {
 
     protected static Map<String, ManagedChannel[]> channels = new ConcurrentHashMap<>();
     private static final Map<String, String> resolvedTargets = new ConcurrentHashMap<>();
     private static final Map<String, AtomicLong> nextResolutions = new ConcurrentHashMap<>();
-    private static final Map<String, ReentrantLock> refreshLocks = new ConcurrentHashMap<>();
-    private static final ScheduledThreadPoolExecutor CHANNEL_CLEANUP_EXECUTOR =
+    private static final Map<String, CompletableFuture<Void>> refreshTasks =
+            new ConcurrentHashMap<>();
+    /*
+     * Refresh runs here rather than on a request thread: a caller of getChannels() may hold a
+     * Gremlin worker stack, which HugeSecurityManager denies socket access to. Creating the very
+     * first pool for a target is still done by the caller, so that path stays exposed.
+     */
+    private static final ScheduledThreadPoolExecutor CHANNEL_MAINTENANCE_EXECUTOR =
             new ScheduledThreadPoolExecutor(
-                    1, ExecutorPool.newThreadFactory("channel-cleanup"));
+                    2, ExecutorPool.newThreadFactory("channel-maintenance"));
     private static final long DEFAULT_CHANNEL_REFRESH_INTERVAL_NANOS =
             TimeUnit.SECONDS.toNanos(5L);
+    private static final long DEFAULT_INITIAL_RESOLUTION_TIMEOUT_NANOS =
+            TimeUnit.SECONDS.toNanos(1L);
+    private static final String DNS_SCHEME = "dns:";
+
+    static {
+        try {
+            // Create the maintenance threads eagerly, so no request thread ever creates one.
+            CHANNEL_MAINTENANCE_EXECUTOR.prestartAllCoreThreads();
+        } catch (Throwable e) {
+            // A denied prestart must not leave this class permanently uninitializable, but a
+            // request thread has to create the thread instead, where it may be denied again.
+            log.warn("Failed to start the channel maintenance threads eagerly, " +
+                     "channel refresh may be delayed until a permitted thread submits one", e);
+        }
+    }
+
     private static final int n = 5;
     protected static int concurrency = 1 << n;
     private static final AtomicLong counter = new AtomicLong(0);
@@ -72,14 +99,22 @@ public abstract class AbstractGrpcClient {
 
     }
 
-    public ManagedChannel[] getChannels(String target) {
-        this.refreshChannelsIfAddressChanged(target);
-        ManagedChannel[] tc;
-        if ((tc = channels.get(target)) == null) {
-            synchronized (channels) {
-                if ((tc = channels.get(target)) == null) {
-                    channels.put(target, tc = this.createChannels(target));
-                }
+    protected ManagedChannel[] getChannels(String target) {
+        CompletableFuture<Void> refresh = this.triggerChannelRefresh(target);
+        ManagedChannel[] tc = channels.get(target);
+        if (tc != null) {
+            return tc;
+        }
+
+        /*
+         * Only the very first pool for a target waits, and only for a bounded time: building it
+         * before its address is known makes the resolution that lands next rebuild it. Waiting
+         * avoids that in the common case; if the wait expires the rebuild still happens.
+         */
+        this.awaitInitialResolution(refresh);
+        synchronized (channels) {
+            if ((tc = channels.get(target)) == null) {
+                channels.put(target, tc = this.createChannels(target));
             }
         }
         return tc;
@@ -88,44 +123,58 @@ public abstract class AbstractGrpcClient {
     public abstract AbstractBlockingStub getBlockingStub(ManagedChannel channel);
 
     public AbstractBlockingStub getBlockingStub(String target) {
+        return this.acquireStub(target, this.blockingStubs, this::getBlockingStub,
+                                stub -> (AbstractBlockingStub) this.setBlockingStubOption(stub));
+    }
+
+    /**
+     * Returns a cached stub bound to a channel of the target's current pool, rebuilding the
+     * cache when the pool has been replaced. The stub comes from the pool that was published at
+     * the last check; a refresh landing immediately afterwards can still retire that pool, so
+     * callers are not shielded from an in-flight replacement.
+     *
+     * <p>The pool check needs no lock: the pool is published before the previous one is retired,
+     * so reading the current pool from the map is enough to know retirement has not started.
+     */
+    @SuppressWarnings("unchecked")
+    private <S> S acquireStub(String target,
+                              Map<String, HgPair<ManagedChannel, S>[]> stubCache,
+                              Function<ManagedChannel, S> stubFactory,
+                              Function<S, S> stubOption) {
         while (true) {
-            ManagedChannel[] targetChannels = getChannels(target);
-            HgPair<ManagedChannel, AbstractBlockingStub>[] pairs = blockingStubs.get(target);
-            long l = counter.getAndIncrement();
-            if (l >= limit) {
-                counter.set(0);
-            }
-            int index = (int) (l & (concurrency - 1));
+            ManagedChannel[] targetChannels = this.getChannels(target);
+            HgPair<ManagedChannel, S>[] pairs = stubCache.get(target);
+            int index = nextStubIndex();
             if (!usesChannels(pairs, targetChannels)) {
-                synchronized (blockingStubs) {
-                    pairs = blockingStubs.get(target);
+                synchronized (stubCache) {
+                    pairs = stubCache.get(target);
                     if (!usesChannels(pairs, targetChannels)) {
-                        HgPair<ManagedChannel, AbstractBlockingStub>[] value =
-                                new HgPair[concurrency];
+                        HgPair<ManagedChannel, S>[] value = new HgPair[concurrency];
                         IntStream.range(0, concurrency).forEach(i -> {
                             ManagedChannel channel = targetChannels[i];
-                            AbstractBlockingStub stub = getBlockingStub(channel);
-                            value[i] = new HgPair<>(channel, stub);
-                            // log.info("create channel for {}",target);
+                            value[i] = new HgPair<>(channel, stubFactory.apply(channel));
                         });
-                        synchronized (channels) {
-                            if (channels.get(target) != targetChannels) {
-                                continue;
-                            }
-                            blockingStubs.put(target, value);
-                            AbstractBlockingStub stub = value[index].getValue();
-                            return (AbstractBlockingStub) setBlockingStubOption(stub);
+                        if (channels.get(target) != targetChannels) {
+                            continue;
                         }
+                        stubCache.put(target, value);
+                        return stubOption.apply(value[index].getValue());
                     }
                 }
             }
-            synchronized (channels) {
-                if (channels.get(target) != targetChannels) {
-                    continue;
-                }
-                return (AbstractBlockingStub) setBlockingStubOption(pairs[index].getValue());
+            if (channels.get(target) != targetChannels) {
+                continue;
             }
+            return stubOption.apply(pairs[index].getValue());
         }
+    }
+
+    private static int nextStubIndex() {
+        long l = counter.getAndIncrement();
+        if (l >= limit) {
+            counter.set(0);
+        }
+        return (int) (l & (concurrency - 1));
     }
 
     private AbstractStub setBlockingStubOption(AbstractBlockingStub stub) {
@@ -141,49 +190,8 @@ public abstract class AbstractGrpcClient {
     }
 
     public AbstractAsyncStub getAsyncStub(String target) {
-        while (true) {
-            ManagedChannel[] targetChannels = getChannels(target);
-            HgPair<ManagedChannel, AbstractAsyncStub>[] pairs = asyncStubs.get(target);
-            long l = counter.getAndIncrement();
-            if (l >= limit) {
-                counter.set(0);
-            }
-            int index = (int) (l & (concurrency - 1));
-            if (!usesChannels(pairs, targetChannels)) {
-                synchronized (asyncStubs) {
-                    pairs = asyncStubs.get(target);
-                    if (!usesChannels(pairs, targetChannels)) {
-                        HgPair<ManagedChannel, AbstractAsyncStub>[] value =
-                                new HgPair[concurrency];
-                        IntStream.range(0, concurrency).parallel().forEach(i -> {
-                            ManagedChannel channel = targetChannels[i];
-                            AbstractAsyncStub stub = getAsyncStub(channel);
-                            // stub.withMaxInboundMessageSize(
-                            //         config.getGrpcMaxInboundMessageSize())
-                            //     .withMaxOutboundMessageSize(
-                            //         config.getGrpcMaxOutboundMessageSize());
-                            value[i] = new HgPair<>(channel, stub);
-                            // log.info("create channel for {}",target);
-                        });
-                        synchronized (channels) {
-                            if (channels.get(target) != targetChannels) {
-                                continue;
-                            }
-                            asyncStubs.put(target, value);
-                            AbstractAsyncStub stub =
-                                    (AbstractAsyncStub) setStubOption(value[index].getValue());
-                            return stub;
-                        }
-                    }
-                }
-            }
-            synchronized (channels) {
-                if (channels.get(target) != targetChannels) {
-                    continue;
-                }
-                return (AbstractAsyncStub) setStubOption(pairs[index].getValue());
-            }
-        }
+        return this.acquireStub(target, this.asyncStubs, this::getAsyncStub,
+                                stub -> (AbstractAsyncStub) this.setStubOption(stub));
     }
 
     protected AbstractStub setStubOption(AbstractStub value) {
@@ -207,66 +215,125 @@ public abstract class AbstractGrpcClient {
         return true;
     }
 
-    private void refreshChannelsIfAddressChanged(String target) {
+    /**
+     * Submits a refresh for the target unless one is already in flight or the refresh interval
+     * has not elapsed. Returns the in-flight refresh, or null when none is running.
+     */
+    private CompletableFuture<Void> triggerChannelRefresh(String target) {
+        CompletableFuture<Void> inFlight = refreshTasks.get(target);
+        if (inFlight != null) {
+            return inFlight;
+        }
         if (!this.shouldRefreshChannels(target)) {
-            return;
+            return null;
         }
 
-        ReentrantLock refreshLock = refreshLocks.computeIfAbsent(target,
-                                                                 key -> new ReentrantLock());
-        if (!refreshLock.tryLock()) {
-            return;
+        CompletableFuture<Void> refresh = new CompletableFuture<>();
+        CompletableFuture<Void> running = refreshTasks.putIfAbsent(target, refresh);
+        if (running != null) {
+            return running;
         }
 
+        // Throttle before submitting, so that a failing resolver cannot be retried in a loop.
+        this.postponeNextRefresh(target);
         try {
-            if (!this.shouldRefreshChannels(target)) {
-                return;
-            }
-
-            String resolvedTarget = this.resolveTarget(target);
-            this.postponeNextRefresh(target);
-            if (resolvedTarget.isEmpty()) {
-                return;
-            }
-
-            ManagedChannel[] staleChannels = channels.get(target);
-            String previousTarget = resolvedTargets.get(target);
-            if (previousTarget == null && staleChannels == null) {
-                resolvedTargets.put(target, resolvedTarget);
-                return;
-            }
-            if (resolvedTarget.equals(previousTarget)) {
-                return;
-            }
-            if (staleChannels == null) {
-                resolvedTargets.put(target, resolvedTarget);
-                return;
-            }
-
-            ManagedChannel[] replacementChannels;
-            try {
-                replacementChannels = this.createChannels(target);
-            } catch (RuntimeException ignored) {
-                return;
-            }
-
-            boolean replaced = false;
-            synchronized (channels) {
-                if (channels.get(target) == staleChannels) {
-                    channels.put(target, replacementChannels);
-                    resolvedTargets.put(target, resolvedTarget);
-                    replaced = true;
+            this.submitChannelRefresh(() -> {
+                try {
+                    this.refreshChannelsIfAddressChanged(target);
+                } catch (Throwable e) {
+                    // The executor discards what a task throws, so report it here.
+                    log.warn("Failed to refresh channels of target {}", target, e);
+                } finally {
+                    this.completeRefresh(target, refresh);
                 }
-            }
-
-            if (replaced) {
-                this.retireChannels(staleChannels);
-            } else {
-                this.retireChannels(replacementChannels);
-            }
-        } finally {
-            refreshLock.unlock();
+            });
+        } catch (Throwable e) {
+            // Includes a thread creation denied on this thread; never leave the entry behind.
+            log.warn("Failed to submit a channel refresh for target {}", target, e);
+            this.completeRefresh(target, refresh);
         }
+        return refresh;
+    }
+
+    private void completeRefresh(String target, CompletableFuture<Void> refresh) {
+        /*
+         * Throttle from completion as well as from submission: a resolver that is slow rather
+         * than failing can outlast its own interval, which would let every later call queue
+         * another lookup behind it.
+         */
+        this.postponeNextRefresh(target);
+        refreshTasks.remove(target, refresh);
+        refresh.complete(null);
+    }
+
+    private void submitChannelRefresh(Runnable task) {
+        CHANNEL_MAINTENANCE_EXECUTOR.execute(task);
+    }
+
+    private void awaitInitialResolution(CompletableFuture<Void> refresh) {
+        if (refresh == null) {
+            return;
+        }
+        try {
+            refresh.get(Math.max(0L, this.initialResolutionTimeoutNanos()),
+                        TimeUnit.NANOSECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Exception ignored) {
+            // A slow or failing resolver must not delay the first pool any further.
+        }
+    }
+
+    /**
+     * Runs on a maintenance thread, never on a request thread. At most one runs per target at a
+     * time — that comes from the refreshTasks entry, not from the size of the executor. Replaces
+     * the target's pool when its resolved address set has changed, publishing the replacement
+     * before retiring the previous pool.
+     */
+    private void refreshChannelsIfAddressChanged(String target) {
+        String resolvedTarget = this.resolveTarget(target);
+        if (resolvedTarget.isEmpty()) {
+            return;
+        }
+
+        ManagedChannel[] staleChannels = channels.get(target);
+        String previousTarget = resolvedTargets.get(target);
+        if (resolvedTarget.equals(previousTarget)) {
+            return;
+        }
+        if (staleChannels == null) {
+            /*
+             * Nothing to replace yet. Recording the address here is what lets the common path
+             * build its first pool already knowing the address, instead of rebuilding it.
+             */
+            resolvedTargets.put(target, resolvedTarget);
+            return;
+        }
+
+        ManagedChannel[] replacementChannels;
+        try {
+            replacementChannels = this.createChannels(target);
+        } catch (RuntimeException e) {
+            // Keep serving from the last healthy pool.
+            log.warn("Failed to create replacement channels of target {}, " +
+                     "keeping the current pool", target, e);
+            return;
+        }
+
+        boolean replaced = false;
+        synchronized (channels) {
+            if (channels.get(target) == staleChannels) {
+                channels.put(target, replacementChannels);
+                resolvedTargets.put(target, resolvedTarget);
+                replaced = true;
+            }
+        }
+        if (replaced) {
+            log.info("Replaced the channel pool of target {}, address changed from {} to {}",
+                     target, previousTarget, resolvedTarget);
+        }
+
+        this.retireChannels(replaced ? staleChannels : replacementChannels);
     }
 
     private boolean shouldRefreshChannels(String target) {
@@ -283,6 +350,10 @@ public abstract class AbstractGrpcClient {
 
     protected long channelRefreshIntervalNanos() {
         return DEFAULT_CHANNEL_REFRESH_INTERVAL_NANOS;
+    }
+
+    private long initialResolutionTimeoutNanos() {
+        return DEFAULT_INITIAL_RESOLUTION_TIMEOUT_NANOS;
     }
 
     protected long channelDrainTimeoutNanos() {
@@ -334,7 +405,7 @@ public abstract class AbstractGrpcClient {
               .forEach(ManagedChannel::shutdown);
 
         long timeout = Math.max(0L, this.channelDrainTimeoutNanos());
-        CHANNEL_CLEANUP_EXECUTOR.schedule(
+        CHANNEL_MAINTENANCE_EXECUTOR.schedule(
                 () -> forceTerminateChannels(retiredChannels), timeout,
                 TimeUnit.NANOSECONDS);
     }
@@ -347,14 +418,20 @@ public abstract class AbstractGrpcClient {
         }
     }
 
+    /**
+     * Extracts the host that a gRPC target resolves through, covering the plain {@code host:port}
+     * form and the {@code dns:} scheme in both its {@code dns:host:port} and
+     * {@code dns://authority/host:port} spellings. Any other resolver scheme returns an empty
+     * host, leaving that target to gRPC instead of monitoring the wrong endpoint.
+     */
     private static String targetHost(String target) {
         if (target == null || target.isEmpty()) {
             return "";
         }
 
         String endpoint = target;
-        if (target.startsWith("dns://")) {
-            endpoint = target.substring("dns://".length());
+        if (target.regionMatches(true, 0, DNS_SCHEME, 0, DNS_SCHEME.length())) {
+            endpoint = target.substring(DNS_SCHEME.length());
             while (endpoint.startsWith("/")) {
                 endpoint = endpoint.substring(1);
             }
@@ -362,34 +439,30 @@ public abstract class AbstractGrpcClient {
             if (pathStart >= 0) {
                 endpoint = endpoint.substring(pathStart + 1);
             }
-        } else if (target.contains("://")) {
+        } else if (hasResolverScheme(target)) {
             return "";
         }
 
-        return endpointHost(endpoint);
-    }
-
-    private static String endpointHost(String endpoint) {
-        if (endpoint == null || endpoint.isEmpty()) {
-            return "";
-        }
-
-        if (endpoint.charAt(0) == '[') {
-            int hostEnd = endpoint.indexOf(']');
-            if (hostEnd <= 1) {
+        try {
+            // The authority parser handles ports and bracketed IPv6 literals.
+            String host = new URI("//" + endpoint).getHost();
+            if (host == null) {
                 return "";
             }
-            return endpoint.substring(1, hostEnd);
+            return host.startsWith("[") ? host.substring(1, host.length() - 1) : host;
+        } catch (URISyntaxException ignored) {
+            return "";
         }
+    }
 
-        int lastColon = endpoint.lastIndexOf(':');
-        if (lastColon < 0) {
-            return endpoint;
-        }
-        if (endpoint.indexOf(':') != lastColon) {
-            return endpoint;
-        }
-        return endpoint.substring(0, lastColon);
+    /**
+     * Tells a resolver scheme from the port of a plain {@code host:port} target: a scheme is
+     * followed by a path, so {@code unix:/var/run/store.sock} is a scheme while
+     * {@code store:8500} is not.
+     */
+    private static boolean hasResolverScheme(String target) {
+        int scheme = target.indexOf(':');
+        return scheme >= 0 && scheme + 1 < target.length() && target.charAt(scheme + 1) == '/';
     }
 
     protected InetAddress[] resolveHost(String host) throws UnknownHostException {

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
@@ -18,7 +18,6 @@
 package org.apache.hugegraph.store.client.grpc;
 
 import java.net.InetAddress;
-import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Map;
@@ -27,6 +26,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -44,8 +45,10 @@ public abstract class AbstractGrpcClient {
 
     protected static Map<String, ManagedChannel[]> channels = new ConcurrentHashMap<>();
     private static final Map<String, String> resolvedTargets = new ConcurrentHashMap<>();
-    private static final Map<String, AtomicLong> resolutionRequests = new ConcurrentHashMap<>();
-    private static final Map<String, Long> appliedResolutions = new ConcurrentHashMap<>();
+    private static final Map<String, AtomicLong> nextResolutions = new ConcurrentHashMap<>();
+    private static final Map<String, ReentrantLock> refreshLocks = new ConcurrentHashMap<>();
+    private static final long DEFAULT_CHANNEL_REFRESH_INTERVAL_NANOS =
+            TimeUnit.SECONDS.toNanos(5L);
     private static final int n = 5;
     protected static int concurrency = 1 << n;
     private static final AtomicLong counter = new AtomicLong(0);
@@ -71,26 +74,7 @@ public abstract class AbstractGrpcClient {
         if ((tc = channels.get(target)) == null) {
             synchronized (channels) {
                 if ((tc = channels.get(target)) == null) {
-                    try {
-                        ManagedChannel[] value = new ManagedChannel[concurrency];
-                        CountDownLatch latch = new CountDownLatch(concurrency);
-                        for (int i = 0; i < concurrency; i++) {
-                            int fi = i;
-                            executor.execute(() -> {
-                                try {
-                                    value[fi] = createChannel(target);
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                } finally {
-                                    latch.countDown();
-                                }
-                            });
-                        }
-                        latch.await();
-                        channels.put(target, tc = value);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
+                    channels.put(target, tc = this.createChannels(target));
                 }
             }
         }
@@ -115,7 +99,7 @@ public abstract class AbstractGrpcClient {
                         HgPair<ManagedChannel, AbstractBlockingStub>[] value =
                                 new HgPair[concurrency];
                         IntStream.range(0, concurrency).forEach(i -> {
-                            ManagedChannel channel = targetChannels[index];
+                            ManagedChannel channel = targetChannels[i];
                             AbstractBlockingStub stub = getBlockingStub(channel);
                             value[i] = new HgPair<>(channel, stub);
                             // log.info("create channel for {}",target);
@@ -168,7 +152,7 @@ public abstract class AbstractGrpcClient {
                         HgPair<ManagedChannel, AbstractAsyncStub>[] value =
                                 new HgPair[concurrency];
                         IntStream.range(0, concurrency).parallel().forEach(i -> {
-                            ManagedChannel channel = targetChannels[index];
+                            ManagedChannel channel = targetChannels[i];
                             AbstractAsyncStub stub = getAsyncStub(channel);
                             // stub.withMaxInboundMessageSize(
                             //         config.getGrpcMaxInboundMessageSize())
@@ -225,46 +209,208 @@ public abstract class AbstractGrpcClient {
     }
 
     private void refreshChannelsIfAddressChanged(String target) {
-        long resolutionRequest = resolutionRequests.computeIfAbsent(target,
-                                                                    key -> new AtomicLong())
-                                                   .incrementAndGet();
-        String resolvedTarget = this.resolveTarget(target);
-        if (resolvedTarget.isEmpty()) {
+        if (!this.shouldRefreshChannels(target)) {
             return;
         }
-        synchronized (channels) {
-            Long appliedResolution = appliedResolutions.get(target);
-            if (appliedResolution != null && appliedResolution >= resolutionRequest) {
+
+        ReentrantLock refreshLock = refreshLocks.computeIfAbsent(target,
+                                                                 key -> new ReentrantLock());
+        if (!refreshLock.tryLock()) {
+            return;
+        }
+
+        try {
+            if (!this.shouldRefreshChannels(target)) {
                 return;
             }
-            appliedResolutions.put(target, resolutionRequest);
-            String previousTarget = resolvedTargets.put(target, resolvedTarget);
-            if (previousTarget == null && !channels.containsKey(target)) {
+
+            String resolvedTarget = this.resolveTarget(target);
+            this.postponeNextRefresh(target);
+            if (resolvedTarget.isEmpty()) {
+                return;
+            }
+
+            ManagedChannel[] staleChannels = channels.get(target);
+            String previousTarget = resolvedTargets.get(target);
+            if (previousTarget == null && staleChannels == null) {
+                resolvedTargets.put(target, resolvedTarget);
                 return;
             }
             if (resolvedTarget.equals(previousTarget)) {
                 return;
             }
-            ManagedChannel[] staleChannels = channels.remove(target);
-            if (staleChannels != null) {
-                Arrays.stream(staleChannels)
-                      .filter(channel -> channel != null && !channel.isShutdown())
-                      .forEach(ManagedChannel::shutdownNow);
+            if (staleChannels == null) {
+                resolvedTargets.put(target, resolvedTarget);
+                return;
             }
+
+            ManagedChannel[] replacementChannels;
+            try {
+                replacementChannels = this.createChannels(target);
+            } catch (RuntimeException ignored) {
+                return;
+            }
+
+            boolean replaced = false;
+            synchronized (channels) {
+                if (channels.get(target) == staleChannels) {
+                    channels.put(target, replacementChannels);
+                    resolvedTargets.put(target, resolvedTarget);
+                    replaced = true;
+                }
+            }
+
+            if (replaced) {
+                this.retireChannels(staleChannels);
+            } else {
+                this.retireChannels(replacementChannels);
+            }
+        } finally {
+            refreshLock.unlock();
         }
     }
 
-    protected String resolveTarget(String target) {
+    private boolean shouldRefreshChannels(String target) {
+        AtomicLong nextResolution = nextResolutions.computeIfAbsent(target,
+                                                                    key -> new AtomicLong());
+        return System.nanoTime() - nextResolution.get() >= 0L;
+    }
+
+    private void postponeNextRefresh(String target) {
+        long interval = Math.max(0L, this.channelRefreshIntervalNanos());
+        nextResolutions.computeIfAbsent(target, key -> new AtomicLong())
+                       .set(System.nanoTime() + interval);
+    }
+
+    protected long channelRefreshIntervalNanos() {
+        return DEFAULT_CHANNEL_REFRESH_INTERVAL_NANOS;
+    }
+
+    protected long channelDrainTimeoutNanos() {
+        return TimeUnit.SECONDS.toNanos(config.getGrpcTimeoutSeconds());
+    }
+
+    private ManagedChannel[] createChannels(String target) {
         try {
-            String host = URI.create("dns://" + target).getHost();
-            if (host == null) {
+            ManagedChannel[] value = new ManagedChannel[concurrency];
+            CountDownLatch latch = new CountDownLatch(concurrency);
+            AtomicReference<RuntimeException> failure = new AtomicReference<>();
+            for (int i = 0; i < concurrency; i++) {
+                int fi = i;
+                executor.execute(() -> {
+                    try {
+                        value[fi] = createChannel(target);
+                    } catch (Exception e) {
+                        failure.compareAndSet(null, new RuntimeException(e));
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+            if (failure.get() != null) {
+                throw failure.get();
+            }
+            return value;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void retireChannels(ManagedChannel[] retiredChannels) {
+        Arrays.stream(retiredChannels)
+              .filter(channel -> channel != null && !channel.isShutdown())
+              .forEach(ManagedChannel::shutdown);
+
+        executor.execute(() -> forceTerminateChannels(retiredChannels));
+    }
+
+    private void forceTerminateChannels(ManagedChannel[] retiredChannels) {
+        long deadline = System.nanoTime() + Math.max(0L, this.channelDrainTimeoutNanos());
+        boolean interrupted = false;
+
+        for (ManagedChannel channel : retiredChannels) {
+            if (channel == null || channel.isTerminated()) {
+                continue;
+            }
+            try {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0L ||
+                    !channel.awaitTermination(remaining, TimeUnit.NANOSECONDS)) {
+                    channel.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                interrupted = true;
+                channel.shutdownNow();
+            }
+        }
+
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static String targetHost(String target) {
+        if (target == null || target.isEmpty()) {
+            return "";
+        }
+
+        String endpoint = target;
+        if (target.startsWith("dns://")) {
+            endpoint = target.substring("dns://".length());
+            while (endpoint.startsWith("/")) {
+                endpoint = endpoint.substring(1);
+            }
+            int pathStart = endpoint.indexOf('/');
+            if (pathStart >= 0) {
+                endpoint = endpoint.substring(pathStart + 1);
+            }
+        } else if (target.contains("://")) {
+            return "";
+        }
+
+        return endpointHost(endpoint);
+    }
+
+    private static String endpointHost(String endpoint) {
+        if (endpoint == null || endpoint.isEmpty()) {
+            return "";
+        }
+
+        if (endpoint.charAt(0) == '[') {
+            int hostEnd = endpoint.indexOf(']');
+            if (hostEnd <= 1) {
                 return "";
             }
-            return Arrays.stream(InetAddress.getAllByName(host))
+            return endpoint.substring(1, hostEnd);
+        }
+
+        int lastColon = endpoint.lastIndexOf(':');
+        if (lastColon < 0) {
+            return endpoint;
+        }
+        if (endpoint.indexOf(':') != lastColon) {
+            return endpoint;
+        }
+        return endpoint.substring(0, lastColon);
+    }
+
+    protected InetAddress[] resolveHost(String host) throws UnknownHostException {
+        return InetAddress.getAllByName(host);
+    }
+
+    protected String resolveTarget(String target) {
+        String host = targetHost(target);
+        if (host.isEmpty()) {
+            return "";
+        }
+        try {
+            return Arrays.stream(this.resolveHost(host))
                          .map(InetAddress::getHostAddress)
                          .sorted()
                          .collect(Collectors.joining(","));
-        } catch (IllegalArgumentException | UnknownHostException ignored) {
+        } catch (UnknownHostException ignored) {
             return "";
         }
     }

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
@@ -511,6 +511,7 @@ public abstract class AbstractGrpcClient {
         try {
             return Arrays.stream(this.resolveHost(host))
                          .map(InetAddress::getHostAddress)
+                         .distinct()
                          .sorted()
                          .collect(Collectors.joining(","));
         } catch (UnknownHostException ignored) {

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
@@ -51,7 +51,9 @@ public abstract class AbstractGrpcClient {
 
     protected static Map<String, ManagedChannel[]> channels = new ConcurrentHashMap<>();
     private static final Map<String, String> resolvedTargets = new ConcurrentHashMap<>();
-    private static final Map<String, AtomicLong> nextResolutions = new ConcurrentHashMap<>();
+    // A null deadline is the explicit "never scheduled" state; every long is a valid clock value.
+    private static final Map<String, AtomicReference<Long>> nextResolutions =
+            new ConcurrentHashMap<>();
     private static final Map<String, CompletableFuture<Void>> refreshTasks =
             new ConcurrentHashMap<>();
     /*
@@ -62,6 +64,9 @@ public abstract class AbstractGrpcClient {
     private static final ScheduledThreadPoolExecutor CHANNEL_MAINTENANCE_EXECUTOR =
             new ScheduledThreadPoolExecutor(
                     2, ExecutorPool.newThreadFactory("channel-maintenance"));
+    private static final ScheduledThreadPoolExecutor CHANNEL_RETIREMENT_EXECUTOR =
+            new ScheduledThreadPoolExecutor(
+                    1, ExecutorPool.newThreadFactory("channel-retirement"));
     private static final long DEFAULT_CHANNEL_REFRESH_INTERVAL_NANOS =
             TimeUnit.SECONDS.toNanos(5L);
     private static final long DEFAULT_INITIAL_RESOLUTION_TIMEOUT_NANOS =
@@ -69,14 +74,20 @@ public abstract class AbstractGrpcClient {
     private static final String DNS_SCHEME = "dns:";
 
     static {
+        prestartExecutor(CHANNEL_MAINTENANCE_EXECUTOR, "channel maintenance");
+        prestartExecutor(CHANNEL_RETIREMENT_EXECUTOR, "channel retirement");
+    }
+
+    private static void prestartExecutor(ScheduledThreadPoolExecutor executor,
+                                         String executorName) {
         try {
-            // Create the maintenance threads eagerly, so no request thread ever creates one.
-            CHANNEL_MAINTENANCE_EXECUTOR.prestartAllCoreThreads();
+            // Create maintenance threads eagerly, so no request thread ever creates one.
+            executor.prestartAllCoreThreads();
         } catch (Throwable e) {
             // A denied prestart must not leave this class permanently uninitializable, but a
             // request thread has to create the thread instead, where it may be denied again.
-            log.warn("Failed to start the channel maintenance threads eagerly, " +
-                     "channel refresh may be delayed until a permitted thread submits one", e);
+            log.warn("Failed to start the {} threads eagerly; work may be delayed until a " +
+                     "permitted thread submits it", executorName, e);
         }
     }
 
@@ -99,7 +110,7 @@ public abstract class AbstractGrpcClient {
 
     }
 
-    protected ManagedChannel[] getChannels(String target) {
+    public ManagedChannel[] getChannels(String target) {
         CompletableFuture<Void> refresh = this.triggerChannelRefresh(target);
         ManagedChannel[] tc = channels.get(target);
         if (tc != null) {
@@ -154,18 +165,20 @@ public abstract class AbstractGrpcClient {
                             ManagedChannel channel = targetChannels[i];
                             value[i] = new HgPair<>(channel, stubFactory.apply(channel));
                         });
+                        S configuredStub = stubOption.apply(value[index].getValue());
                         if (channels.get(target) != targetChannels) {
                             continue;
                         }
                         stubCache.put(target, value);
-                        return stubOption.apply(value[index].getValue());
+                        return configuredStub;
                     }
                 }
             }
+            S configuredStub = stubOption.apply(pairs[index].getValue());
             if (channels.get(target) != targetChannels) {
                 continue;
             }
-            return stubOption.apply(pairs[index].getValue());
+            return configuredStub;
         }
     }
 
@@ -266,7 +279,7 @@ public abstract class AbstractGrpcClient {
         refresh.complete(null);
     }
 
-    private void submitChannelRefresh(Runnable task) {
+    void submitChannelRefresh(Runnable task) {
         CHANNEL_MAINTENANCE_EXECUTOR.execute(task);
     }
 
@@ -337,15 +350,20 @@ public abstract class AbstractGrpcClient {
     }
 
     private boolean shouldRefreshChannels(String target) {
-        AtomicLong nextResolution = nextResolutions.computeIfAbsent(target,
-                                                                    key -> new AtomicLong());
-        return System.nanoTime() - nextResolution.get() >= 0L;
+        AtomicReference<Long> nextResolution =
+                nextResolutions.computeIfAbsent(target, key -> new AtomicReference<>());
+        Long deadline = nextResolution.get();
+        return deadline == null || this.nanoTime() - deadline >= 0L;
     }
 
     private void postponeNextRefresh(String target) {
         long interval = Math.max(0L, this.channelRefreshIntervalNanos());
-        nextResolutions.computeIfAbsent(target, key -> new AtomicLong())
-                       .set(System.nanoTime() + interval);
+        nextResolutions.computeIfAbsent(target, key -> new AtomicReference<>())
+                       .set(this.nanoTime() + interval);
+    }
+
+    protected long nanoTime() {
+        return System.nanoTime();
     }
 
     protected long channelRefreshIntervalNanos() {
@@ -366,15 +384,20 @@ public abstract class AbstractGrpcClient {
         AtomicReference<RuntimeException> failure = new AtomicReference<>();
         for (int i = 0; i < concurrency; i++) {
             int fi = i;
-            executor.execute(() -> {
-                try {
-                    value[fi] = createChannel(target);
-                } catch (Exception e) {
-                    failure.compareAndSet(null, new RuntimeException(e));
-                } finally {
-                    latch.countDown();
-                }
-            });
+            try {
+                this.submitChannelCreation(() -> {
+                    try {
+                        value[fi] = createChannel(target);
+                    } catch (Exception e) {
+                        failure.compareAndSet(null, new RuntimeException(e));
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            } catch (RuntimeException e) {
+                failure.compareAndSet(null, e);
+                latch.countDown();
+            }
         }
 
         InterruptedException interruption = null;
@@ -399,15 +422,26 @@ public abstract class AbstractGrpcClient {
         return value;
     }
 
+    void submitChannelCreation(Runnable task) {
+        this.executor.execute(task);
+    }
+
     private void retireChannels(ManagedChannel[] retiredChannels) {
         Arrays.stream(retiredChannels)
               .filter(channel -> channel != null && !channel.isShutdown())
               .forEach(ManagedChannel::shutdown);
 
         long timeout = Math.max(0L, this.channelDrainTimeoutNanos());
-        CHANNEL_MAINTENANCE_EXECUTOR.schedule(
-                () -> forceTerminateChannels(retiredChannels), timeout,
-                TimeUnit.NANOSECONDS);
+        try {
+            this.scheduleChannelRetirement(() -> forceTerminateChannels(retiredChannels), timeout);
+        } catch (RuntimeException e) {
+            log.warn("Failed to schedule forced retirement, forcing channels immediately", e);
+            forceTerminateChannels(retiredChannels);
+        }
+    }
+
+    void scheduleChannelRetirement(Runnable task, long timeoutNanos) {
+        CHANNEL_RETIREMENT_EXECUTOR.schedule(task, timeoutNanos, TimeUnit.NANOSECONDS);
     }
 
     private void forceTerminateChannels(ManagedChannel[] retiredChannels) {

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
@@ -17,12 +17,17 @@
 
 package org.apache.hugegraph.store.client.grpc;
 
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.hugegraph.store.client.util.ExecutorPool;
@@ -38,6 +43,9 @@ import io.grpc.stub.AbstractStub;
 public abstract class AbstractGrpcClient {
 
     protected static Map<String, ManagedChannel[]> channels = new ConcurrentHashMap<>();
+    private static final Map<String, String> resolvedTargets = new ConcurrentHashMap<>();
+    private static final Map<String, AtomicLong> resolutionRequests = new ConcurrentHashMap<>();
+    private static final Map<String, Long> appliedResolutions = new ConcurrentHashMap<>();
     private static final int n = 5;
     protected static int concurrency = 1 << n;
     private static final AtomicLong counter = new AtomicLong(0);
@@ -58,6 +66,7 @@ public abstract class AbstractGrpcClient {
     }
 
     public ManagedChannel[] getChannels(String target) {
+        this.refreshChannelsIfAddressChanged(target);
         ManagedChannel[] tc;
         if ((tc = channels.get(target)) == null) {
             synchronized (channels) {
@@ -91,31 +100,44 @@ public abstract class AbstractGrpcClient {
     public abstract AbstractBlockingStub getBlockingStub(ManagedChannel channel);
 
     public AbstractBlockingStub getBlockingStub(String target) {
-        ManagedChannel[] channels = getChannels(target);
-        HgPair<ManagedChannel, AbstractBlockingStub>[] pairs = blockingStubs.get(target);
-        long l = counter.getAndIncrement();
-        if (l >= limit) {
-            counter.set(0);
-        }
-        int index = (int) (l & (concurrency - 1));
-        if (pairs == null) {
-            synchronized (blockingStubs) {
-                pairs = blockingStubs.get(target);
-                if (pairs == null) {
-                    HgPair<ManagedChannel, AbstractBlockingStub>[] value = new HgPair[concurrency];
-                    IntStream.range(0, concurrency).forEach(i -> {
-                        ManagedChannel channel = channels[i];
-                        AbstractBlockingStub stub = getBlockingStub(channel);
-                        value[i] = new HgPair<>(channel, stub);
-                        // log.info("create channel for {}",target);
-                    });
-                    blockingStubs.put(target, value);
-                    AbstractBlockingStub stub = value[index].getValue();
-                    return (AbstractBlockingStub) setBlockingStubOption(stub);
+        while (true) {
+            ManagedChannel[] targetChannels = getChannels(target);
+            HgPair<ManagedChannel, AbstractBlockingStub>[] pairs = blockingStubs.get(target);
+            long l = counter.getAndIncrement();
+            if (l >= limit) {
+                counter.set(0);
+            }
+            int index = (int) (l & (concurrency - 1));
+            if (!usesChannels(pairs, targetChannels)) {
+                synchronized (blockingStubs) {
+                    pairs = blockingStubs.get(target);
+                    if (!usesChannels(pairs, targetChannels)) {
+                        HgPair<ManagedChannel, AbstractBlockingStub>[] value =
+                                new HgPair[concurrency];
+                        IntStream.range(0, concurrency).forEach(i -> {
+                            ManagedChannel channel = targetChannels[index];
+                            AbstractBlockingStub stub = getBlockingStub(channel);
+                            value[i] = new HgPair<>(channel, stub);
+                            // log.info("create channel for {}",target);
+                        });
+                        synchronized (channels) {
+                            if (channels.get(target) != targetChannels) {
+                                continue;
+                            }
+                            blockingStubs.put(target, value);
+                            AbstractBlockingStub stub = value[index].getValue();
+                            return (AbstractBlockingStub) setBlockingStubOption(stub);
+                        }
+                    }
                 }
             }
+            synchronized (channels) {
+                if (channels.get(target) != targetChannels) {
+                    continue;
+                }
+                return (AbstractBlockingStub) setBlockingStubOption(pairs[index].getValue());
+            }
         }
-        return (AbstractBlockingStub) setBlockingStubOption(pairs[index].getValue());
     }
 
     private AbstractStub setBlockingStubOption(AbstractBlockingStub stub) {
@@ -131,35 +153,49 @@ public abstract class AbstractGrpcClient {
     }
 
     public AbstractAsyncStub getAsyncStub(String target) {
-        ManagedChannel[] channels = getChannels(target);
-        HgPair<ManagedChannel, AbstractAsyncStub>[] pairs = asyncStubs.get(target);
-        long l = counter.getAndIncrement();
-        if (l >= limit) {
-            counter.set(0);
-        }
-        int index = (int) (l & (concurrency - 1));
-        if (pairs == null) {
-            synchronized (asyncStubs) {
-                pairs = asyncStubs.get(target);
-                if (pairs == null) {
-                    HgPair<ManagedChannel, AbstractAsyncStub>[] value = new HgPair[concurrency];
-                    IntStream.range(0, concurrency).parallel().forEach(i -> {
-                        ManagedChannel channel = channels[i];
-                        AbstractAsyncStub stub = getAsyncStub(channel);
-                        // stub.withMaxInboundMessageSize(config.getGrpcMaxInboundMessageSize())
-                        //    .withMaxOutboundMessageSize(config.getGrpcMaxOutboundMessageSize());
-                        value[i] = new HgPair<>(channel, stub);
-                        // log.info("create channel for {}",target);
-                    });
-                    asyncStubs.put(target, value);
-                    AbstractAsyncStub stub =
-                            (AbstractAsyncStub) setStubOption(value[index].getValue());
-                    return stub;
+        while (true) {
+            ManagedChannel[] targetChannels = getChannels(target);
+            HgPair<ManagedChannel, AbstractAsyncStub>[] pairs = asyncStubs.get(target);
+            long l = counter.getAndIncrement();
+            if (l >= limit) {
+                counter.set(0);
+            }
+            int index = (int) (l & (concurrency - 1));
+            if (!usesChannels(pairs, targetChannels)) {
+                synchronized (asyncStubs) {
+                    pairs = asyncStubs.get(target);
+                    if (!usesChannels(pairs, targetChannels)) {
+                        HgPair<ManagedChannel, AbstractAsyncStub>[] value =
+                                new HgPair[concurrency];
+                        IntStream.range(0, concurrency).parallel().forEach(i -> {
+                            ManagedChannel channel = targetChannels[index];
+                            AbstractAsyncStub stub = getAsyncStub(channel);
+                            // stub.withMaxInboundMessageSize(
+                            //         config.getGrpcMaxInboundMessageSize())
+                            //     .withMaxOutboundMessageSize(
+                            //         config.getGrpcMaxOutboundMessageSize());
+                            value[i] = new HgPair<>(channel, stub);
+                            // log.info("create channel for {}",target);
+                        });
+                        synchronized (channels) {
+                            if (channels.get(target) != targetChannels) {
+                                continue;
+                            }
+                            asyncStubs.put(target, value);
+                            AbstractAsyncStub stub =
+                                    (AbstractAsyncStub) setStubOption(value[index].getValue());
+                            return stub;
+                        }
+                    }
                 }
             }
+            synchronized (channels) {
+                if (channels.get(target) != targetChannels) {
+                    continue;
+                }
+                return (AbstractAsyncStub) setStubOption(pairs[index].getValue());
+            }
         }
-        return (AbstractAsyncStub) setStubOption(pairs[index].getValue());
-
     }
 
     protected AbstractStub setStubOption(AbstractStub value) {
@@ -167,6 +203,70 @@ public abstract class AbstractGrpcClient {
                             config.getGrpcMaxInboundMessageSize())
                     .withMaxOutboundMessageSize(
                             config.getGrpcMaxOutboundMessageSize());
+    }
+
+    private static boolean usesChannels(HgPair<ManagedChannel, ?>[] pairs,
+                                        ManagedChannel[] channels) {
+        if (pairs == null || pairs.length != channels.length) {
+            return false;
+        }
+        for (HgPair<ManagedChannel, ?> pair : pairs) {
+            if (pair == null || pair.getKey() == null ||
+                !containsChannel(channels, pair.getKey())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean containsChannel(ManagedChannel[] channels,
+                                           ManagedChannel expected) {
+        return Arrays.stream(channels).anyMatch(channel -> channel == expected);
+    }
+
+    private void refreshChannelsIfAddressChanged(String target) {
+        long resolutionRequest = resolutionRequests.computeIfAbsent(target,
+                                                                    key -> new AtomicLong())
+                                                   .incrementAndGet();
+        String resolvedTarget = this.resolveTarget(target);
+        if (resolvedTarget.isEmpty()) {
+            return;
+        }
+        synchronized (channels) {
+            Long appliedResolution = appliedResolutions.get(target);
+            if (appliedResolution != null && appliedResolution >= resolutionRequest) {
+                return;
+            }
+            appliedResolutions.put(target, resolutionRequest);
+            String previousTarget = resolvedTargets.put(target, resolvedTarget);
+            if (previousTarget == null && !channels.containsKey(target)) {
+                return;
+            }
+            if (resolvedTarget.equals(previousTarget)) {
+                return;
+            }
+            ManagedChannel[] staleChannels = channels.remove(target);
+            if (staleChannels != null) {
+                Arrays.stream(staleChannels)
+                      .filter(channel -> channel != null && !channel.isShutdown())
+                      .forEach(ManagedChannel::shutdownNow);
+            }
+        }
+    }
+
+    protected String resolveTarget(String target) {
+        try {
+            String host = URI.create("dns://" + target).getHost();
+            if (host == null) {
+                return "";
+            }
+            return Arrays.stream(InetAddress.getAllByName(host))
+                         .map(InetAddress::getHostAddress)
+                         .sorted()
+                         .collect(Collectors.joining(","));
+        } catch (IllegalArgumentException | UnknownHostException ignored) {
+            return "";
+        }
     }
 
     protected ManagedChannel createChannel(String target) {

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.hugegraph.store.client.util.ExecutorPool;
 import org.apache.hugegraph.store.client.util.HgStoreClientConfig;
@@ -56,6 +57,8 @@ public abstract class AbstractGrpcClient {
             new ConcurrentHashMap<>();
     private static final Map<String, CompletableFuture<Void>> refreshTasks =
             new ConcurrentHashMap<>();
+    private static final Map<String, ReentrantReadWriteLock> channelLocks =
+            new ConcurrentHashMap<>();
     /*
      * Refresh runs here rather than on a request thread: a caller of getChannels() may hold a
      * Gremlin worker stack, which HugeSecurityManager denies socket access to. Creating the very
@@ -63,7 +66,7 @@ public abstract class AbstractGrpcClient {
      */
     private static final ScheduledThreadPoolExecutor CHANNEL_MAINTENANCE_EXECUTOR =
             new ScheduledThreadPoolExecutor(
-                    2, ExecutorPool.newThreadFactory("channel-maintenance"));
+                    64, ExecutorPool.newThreadFactory("channel-maintenance"));
     private static final ScheduledThreadPoolExecutor CHANNEL_RETIREMENT_EXECUTOR =
             new ScheduledThreadPoolExecutor(
                     1, ExecutorPool.newThreadFactory("channel-retirement"));
@@ -156,30 +159,45 @@ public abstract class AbstractGrpcClient {
             ManagedChannel[] targetChannels = this.getChannels(target);
             HgPair<ManagedChannel, S>[] pairs = stubCache.get(target);
             int index = nextStubIndex();
+            S configuredStub;
+            HgPair<ManagedChannel, S>[] value = null;
             if (!usesChannels(pairs, targetChannels)) {
                 synchronized (stubCache) {
                     pairs = stubCache.get(target);
                     if (!usesChannels(pairs, targetChannels)) {
-                        HgPair<ManagedChannel, S>[] value = new HgPair[concurrency];
+                        final HgPair<ManagedChannel, S>[] newValue = new HgPair[concurrency];
                         IntStream.range(0, concurrency).forEach(i -> {
                             ManagedChannel channel = targetChannels[i];
-                            value[i] = new HgPair<>(channel, stubFactory.apply(channel));
+                            newValue[i] = new HgPair<>(channel, stubFactory.apply(channel));
                         });
-                        S configuredStub = stubOption.apply(value[index].getValue());
-                        if (channels.get(target) != targetChannels) {
-                            continue;
-                        }
-                        stubCache.put(target, value);
-                        return configuredStub;
+                        value = newValue;
+                        configuredStub = stubOption.apply(newValue[index].getValue());
+                    } else {
+                        configuredStub = stubOption.apply(pairs[index].getValue());
                     }
                 }
+            } else {
+                configuredStub = stubOption.apply(pairs[index].getValue());
             }
-            S configuredStub = stubOption.apply(pairs[index].getValue());
-            if (channels.get(target) != targetChannels) {
-                continue;
+
+            ReentrantReadWriteLock.ReadLock readLock = channelLock(target).readLock();
+            readLock.lock();
+            try {
+                if (channels.get(target) != targetChannels) {
+                    continue;
+                }
+                if (value != null) {
+                    stubCache.put(target, value);
+                }
+                return configuredStub;
+            } finally {
+                readLock.unlock();
             }
-            return configuredStub;
         }
+    }
+
+    private static ReentrantReadWriteLock channelLock(String target) {
+        return channelLocks.computeIfAbsent(target, key -> new ReentrantReadWriteLock());
     }
 
     private static int nextStubIndex() {
@@ -333,20 +351,25 @@ public abstract class AbstractGrpcClient {
             return;
         }
 
-        boolean replaced = false;
-        synchronized (channels) {
-            if (channels.get(target) == staleChannels) {
-                channels.put(target, replacementChannels);
-                resolvedTargets.put(target, resolvedTarget);
-                replaced = true;
+        ReentrantReadWriteLock.WriteLock writeLock = channelLock(target).writeLock();
+        writeLock.lock();
+        try {
+            boolean replaced = false;
+            synchronized (channels) {
+                if (channels.get(target) == staleChannels) {
+                    channels.put(target, replacementChannels);
+                    resolvedTargets.put(target, resolvedTarget);
+                    replaced = true;
+                }
             }
+            if (replaced) {
+                log.info("Replaced the channel pool of target {}, address changed from {} to {}",
+                         target, previousTarget, resolvedTarget);
+            }
+            this.retireChannels(replaced ? staleChannels : replacementChannels);
+        } finally {
+            writeLock.unlock();
         }
-        if (replaced) {
-            log.info("Replaced the channel pool of target {}, address changed from {} to {}",
-                     target, previousTarget, resolvedTarget);
-        }
-
-        this.retireChannels(replaced ? staleChannels : replacementChannels);
     }
 
     private boolean shouldRefreshChannels(String target) {

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClient.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -47,6 +48,9 @@ public abstract class AbstractGrpcClient {
     private static final Map<String, String> resolvedTargets = new ConcurrentHashMap<>();
     private static final Map<String, AtomicLong> nextResolutions = new ConcurrentHashMap<>();
     private static final Map<String, ReentrantLock> refreshLocks = new ConcurrentHashMap<>();
+    private static final ScheduledThreadPoolExecutor CHANNEL_CLEANUP_EXECUTOR =
+            new ScheduledThreadPoolExecutor(
+                    1, ExecutorPool.newThreadFactory("channel-cleanup"));
     private static final long DEFAULT_CHANNEL_REFRESH_INTERVAL_NANOS =
             TimeUnit.SECONDS.toNanos(5L);
     private static final int n = 5;
@@ -194,18 +198,13 @@ public abstract class AbstractGrpcClient {
         if (pairs == null || pairs.length != channels.length) {
             return false;
         }
-        for (HgPair<ManagedChannel, ?> pair : pairs) {
-            if (pair == null || pair.getKey() == null ||
-                !containsChannel(channels, pair.getKey())) {
+        for (int i = 0; i < pairs.length; i++) {
+            HgPair<ManagedChannel, ?> pair = pairs[i];
+            if (pair == null || pair.getKey() != channels[i]) {
                 return false;
             }
         }
         return true;
-    }
-
-    private static boolean containsChannel(ManagedChannel[] channels,
-                                           ManagedChannel expected) {
-        return Arrays.stream(channels).anyMatch(channel -> channel == expected);
     }
 
     private void refreshChannelsIfAddressChanged(String target) {
@@ -291,31 +290,42 @@ public abstract class AbstractGrpcClient {
     }
 
     private ManagedChannel[] createChannels(String target) {
-        try {
-            ManagedChannel[] value = new ManagedChannel[concurrency];
-            CountDownLatch latch = new CountDownLatch(concurrency);
-            AtomicReference<RuntimeException> failure = new AtomicReference<>();
-            for (int i = 0; i < concurrency; i++) {
-                int fi = i;
-                executor.execute(() -> {
-                    try {
-                        value[fi] = createChannel(target);
-                    } catch (Exception e) {
-                        failure.compareAndSet(null, new RuntimeException(e));
-                    } finally {
-                        latch.countDown();
-                    }
-                });
-            }
-            latch.await();
-            if (failure.get() != null) {
-                throw failure.get();
-            }
-            return value;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
+        ManagedChannel[] value = new ManagedChannel[concurrency];
+        CountDownLatch latch = new CountDownLatch(concurrency);
+        AtomicReference<RuntimeException> failure = new AtomicReference<>();
+        for (int i = 0; i < concurrency; i++) {
+            int fi = i;
+            executor.execute(() -> {
+                try {
+                    value[fi] = createChannel(target);
+                } catch (Exception e) {
+                    failure.compareAndSet(null, new RuntimeException(e));
+                } finally {
+                    latch.countDown();
+                }
+            });
         }
+
+        InterruptedException interruption = null;
+        while (latch.getCount() > 0L) {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                interruption = e;
+            }
+        }
+
+        if (failure.get() != null || interruption != null) {
+            forceTerminateChannels(value);
+        }
+        if (interruption != null) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(interruption);
+        }
+        if (failure.get() != null) {
+            throw failure.get();
+        }
+        return value;
     }
 
     private void retireChannels(ManagedChannel[] retiredChannels) {
@@ -323,31 +333,17 @@ public abstract class AbstractGrpcClient {
               .filter(channel -> channel != null && !channel.isShutdown())
               .forEach(ManagedChannel::shutdown);
 
-        executor.execute(() -> forceTerminateChannels(retiredChannels));
+        long timeout = Math.max(0L, this.channelDrainTimeoutNanos());
+        CHANNEL_CLEANUP_EXECUTOR.schedule(
+                () -> forceTerminateChannels(retiredChannels), timeout,
+                TimeUnit.NANOSECONDS);
     }
 
     private void forceTerminateChannels(ManagedChannel[] retiredChannels) {
-        long deadline = System.nanoTime() + Math.max(0L, this.channelDrainTimeoutNanos());
-        boolean interrupted = false;
-
         for (ManagedChannel channel : retiredChannels) {
-            if (channel == null || channel.isTerminated()) {
-                continue;
-            }
-            try {
-                long remaining = deadline - System.nanoTime();
-                if (remaining <= 0L ||
-                    !channel.awaitTermination(remaining, TimeUnit.NANOSECONDS)) {
-                    channel.shutdownNow();
-                }
-            } catch (InterruptedException e) {
-                interrupted = true;
+            if (channel != null && !channel.isTerminated()) {
                 channel.shutdownNow();
             }
-        }
-
-        if (interrupted) {
-            Thread.currentThread().interrupt();
         }
     }
 

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/query/QueryV2Client.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/query/QueryV2Client.java
@@ -17,8 +17,6 @@
 
 package org.apache.hugegraph.store.client.query;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.hugegraph.store.client.grpc.AbstractGrpcClient;
 import org.apache.hugegraph.store.grpc.query.QueryServiceGrpc;
 
@@ -30,8 +28,6 @@ import io.grpc.stub.AbstractBlockingStub;
 public class QueryV2Client extends AbstractGrpcClient {
 
     private volatile static ManagedChannel channel = null;
-
-    private final AtomicInteger seq = new AtomicInteger(0);
 
     @Override
     public AbstractBlockingStub<?> getBlockingStub(ManagedChannel channel) {
@@ -48,13 +44,7 @@ public class QueryV2Client extends AbstractGrpcClient {
     }
 
     public QueryServiceGrpc.QueryServiceStub getQueryServiceStub(String target) {
-        return (QueryServiceGrpc.QueryServiceStub) setStubOption(
-                QueryServiceGrpc.newStub(getManagedChannel(target)));
-        // return (QueryServiceGrpc.QueryServiceStub) getAsyncStub(target);
-    }
-
-    private ManagedChannel getManagedChannel(String target) {
-        return getChannels(target)[Math.abs(seq.getAndIncrement() % concurrency)];
+        return (QueryServiceGrpc.QueryServiceStub) getAsyncStub(target);
     }
 
     public static void setTestChannel(ManagedChannel directChannel) {

--- a/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/query/QueryV2Client.java
+++ b/hugegraph-store/hg-store-client/src/main/java/org/apache/hugegraph/store/client/query/QueryV2Client.java
@@ -53,6 +53,12 @@ public class QueryV2Client extends AbstractGrpcClient {
     }
 
     @Override
+    protected String resolveTarget(String target) {
+        // A directly injected test channel has no DNS lifecycle to refresh.
+        return channel == null ? super.resolveTarget(target) : "";
+    }
+
+    @Override
     protected ManagedChannel createChannel(String target) {
         return channel == null ? ManagedChannelBuilder.forTarget(target).usePlaintext().build() :
                channel;

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/ClientSuiteTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/ClientSuiteTest.java
@@ -21,6 +21,10 @@ import org.apache.hugegraph.store.client.grpc.AbstractGrpcClientTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
+/**
+ * Entry point of the {@code store-client-test} profile. Cluster-dependent tests are deliberately
+ * excluded.
+ */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
         AbstractGrpcClientTest.class

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/ClientSuiteTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/ClientSuiteTest.java
@@ -21,10 +21,6 @@ import org.apache.hugegraph.store.client.grpc.AbstractGrpcClientTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-/**
- * Entry point of the {@code store-client-test} profile. Cluster-dependent tests are deliberately
- * excluded.
- */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
         AbstractGrpcClientTest.class

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
@@ -19,15 +19,18 @@ package org.apache.hugegraph.store.client.grpc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -42,8 +45,7 @@ import io.grpc.stub.AbstractAsyncStub;
 import io.grpc.stub.AbstractBlockingStub;
 
 /**
- * Verifies that the stub pools of {@link AbstractGrpcClient} spread their entries over every
- * channel created for a target, instead of binding all of them to a single channel.
+ * Verifies that Store address changes replace channels and their cached stubs safely.
  */
 public class AbstractGrpcClientTest {
 
@@ -53,49 +55,135 @@ public class AbstractGrpcClientTest {
         return prefix + "-" + TARGET_SEQ.incrementAndGet() + ":8500";
     }
 
-    private static Set<ManagedChannel> identitySet(Collection<ManagedChannel> channels) {
-        Set<ManagedChannel> set = Collections.newSetFromMap(new IdentityHashMap<>());
-        set.addAll(channels);
-        return set;
+    private static boolean belongsToPool(Channel channel,
+                                         ManagedChannel[] channels) {
+        return Arrays.stream(channels).anyMatch(current -> current == channel);
     }
 
     @Test
-    public void testBlockingStubPoolCoversEveryChannel() {
-        String target = uniqueTarget("blocking");
+    public void testAddressChangeReplacesChannelAndStubPools() {
+        String target = uniqueTarget("address-change");
         RecordingGrpcClient client = new RecordingGrpcClient();
-        ManagedChannel[] channels = client.getChannels(target);
-        assertTrue("pool must hold more than one channel", channels.length > 1);
-
-        // Pool initialisation: one stub per channel, each bound to a different channel.
+        ManagedChannel[] oldChannels = client.getChannels(target);
         assertNotNull(client.getBlockingStub(target));
-        assertEquals("one stub per channel", channels.length, client.blockingStubChannels.size());
-        Set<ManagedChannel> bound = identitySet(client.blockingStubChannels);
-        assertEquals("stubs must not share a channel", channels.length, bound.size());
-        assertTrue("stubs must cover the channels of the target",
-                   bound.containsAll(Arrays.asList(channels)));
+        assertNotNull(client.getAsyncStub(target));
+
+        client.resolvedTarget = "10.0.0.2";
+        ManagedChannel[] newChannels = client.getChannels(target);
+        assertNotSame("an address change must replace the channel pool",
+                      oldChannels, newChannels);
+        assertTrue("every stale channel must be shut down",
+                   Arrays.stream(oldChannels).allMatch(ManagedChannel::isShutdown));
+
+        client.blockingStubChannels.clear();
+        client.asyncStubChannels.clear();
+        assertNotNull(client.getBlockingStub(target));
+        assertNotNull(client.getAsyncStub(target));
+        assertEquals("the blocking stub pool must be rebuilt",
+                     newChannels.length, client.blockingStubChannels.size());
+        assertTrue("replacement blocking stubs must use the new channel pool",
+                   client.blockingStubChannels.stream()
+                                              .allMatch(channel ->
+                                                        belongsToPool(channel, newChannels)));
+        assertEquals("the async stub pool must be rebuilt",
+                     newChannels.length, client.asyncStubChannels.size());
+        assertTrue("replacement async stubs must use the new channel pool",
+                   client.asyncStubChannels.stream()
+                                           .allMatch(channel ->
+                                                     belongsToPool(channel, newChannels)));
     }
 
     @Test
-    public void testAsyncStubPoolCoversEveryChannel() {
-        String target = uniqueTarget("async");
+    public void testFirstSuccessfulResolutionReplacesUnknownChannels() {
+        String target = uniqueTarget("first-successful-resolution");
         RecordingGrpcClient client = new RecordingGrpcClient();
-        ManagedChannel[] channels = client.getChannels(target);
-        assertTrue("pool must hold more than one channel", channels.length > 1);
+        client.resolvedTarget = "";
+        ManagedChannel[] unknownChannels = client.getChannels(target);
 
-        assertNotNull(client.getAsyncStub(target));
-        assertEquals("one stub per channel", channels.length, client.asyncStubChannels.size());
-        Set<ManagedChannel> bound = identitySet(client.asyncStubChannels);
-        assertEquals("stubs must not share a channel", channels.length, bound.size());
-        assertTrue("stubs must cover the channels of the target",
-                   bound.containsAll(Arrays.asList(channels)));
+        client.resolvedTarget = "10.0.0.1";
+        ManagedChannel[] resolvedChannels = client.getChannels(target);
+        assertNotSame("a pool with unknown addresses must be replaced",
+                      unknownChannels, resolvedChannels);
+        assertTrue("every channel from the unknown pool must be shut down",
+                   Arrays.stream(unknownChannels).allMatch(ManagedChannel::isShutdown));
+        assertTrue("the resolved channel pool must remain live",
+                   Arrays.stream(resolvedChannels).noneMatch(ManagedChannel::isShutdown));
     }
 
-    /**
-     * A client whose channels and stubs are local fakes, so the test needs no PD or store node.
-     */
+    @Test
+    public void testOlderResolutionCannotReplaceNewerChannels() throws Exception {
+        String target = uniqueTarget("concurrent-address-change");
+        OutOfOrderResolverGrpcClient client = new OutOfOrderResolverGrpcClient();
+        ManagedChannel[] oldChannels = client.getChannels(target);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<ManagedChannel[]> staleResolution =
+                    executor.submit(() -> client.getChannels(target));
+            assertTrue("the stale resolution must be in flight",
+                       client.staleResolutionStarted.await(5, TimeUnit.SECONDS));
+            Future<ManagedChannel[]> freshResolution =
+                    executor.submit(() -> client.getChannels(target));
+            ManagedChannel[] freshChannels = freshResolution.get(5, TimeUnit.SECONDS);
+
+            assertNotSame("the newer address must replace the old channel pool",
+                          oldChannels, freshChannels);
+            client.releaseStaleResolution.countDown();
+            assertSame("the late stale result must retain the newer channel pool",
+                       freshChannels, staleResolution.get(5, TimeUnit.SECONDS));
+            assertTrue("the replaced channel pool must be shut down",
+                       Arrays.stream(oldChannels).allMatch(ManagedChannel::isShutdown));
+            assertTrue("the newer channel pool must remain live",
+                       Arrays.stream(freshChannels).noneMatch(ManagedChannel::isShutdown));
+        } finally {
+            client.releaseStaleResolution.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testStubBuildRetriesAfterChannelRefresh() throws Exception {
+        String target = uniqueTarget("concurrent-stub-refresh");
+        StubInterleavingGrpcClient client = new StubInterleavingGrpcClient();
+        ManagedChannel[] oldChannels = client.getChannels(target);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<AbstractBlockingStub> staleStub =
+                    executor.submit(() -> client.getBlockingStub(target));
+            assertTrue("the old stub pool build must be in flight",
+                       client.staleStubBuildStarted.await(5, TimeUnit.SECONDS));
+            client.resolvedTarget = "10.0.0.2";
+            Future<AbstractBlockingStub> freshStub =
+                    executor.submit(() -> client.getBlockingStub(target));
+            for (int i = 0; i < 500 &&
+                            Arrays.stream(oldChannels).anyMatch(channel -> !channel.isShutdown());
+                 i++) {
+                Thread.sleep(10L);
+            }
+            assertTrue("refresh must shut down the old channel pool",
+                       Arrays.stream(oldChannels).allMatch(ManagedChannel::isShutdown));
+            client.releaseStaleStubBuild.countDown();
+
+            AbstractBlockingStub staleResult = staleStub.get(5, TimeUnit.SECONDS);
+            AbstractBlockingStub freshResult = freshStub.get(5, TimeUnit.SECONDS);
+            ManagedChannel[] currentChannels = client.getChannels(target);
+            assertTrue("the stale build must retry against the current pool",
+                       belongsToPool(staleResult.getChannel(), currentChannels));
+            assertTrue("the concurrent build must use the current pool",
+                       belongsToPool(freshResult.getChannel(), currentChannels));
+            assertTrue("the current channel pool must remain live",
+                       Arrays.stream(currentChannels).noneMatch(ManagedChannel::isShutdown));
+        } finally {
+            client.releaseStaleStubBuild.countDown();
+            executor.shutdownNow();
+        }
+    }
+
     private static class RecordingGrpcClient extends AbstractGrpcClient {
 
         private final AtomicInteger channelSeq = new AtomicInteger();
+        protected volatile String resolvedTarget = "10.0.0.1";
         private final List<ManagedChannel> blockingStubChannels =
                 Collections.synchronizedList(new ArrayList<>());
         private final List<ManagedChannel> asyncStubChannels =
@@ -103,7 +191,12 @@ public class AbstractGrpcClientTest {
 
         @Override
         protected ManagedChannel createChannel(String target) {
-            return new FakeManagedChannel(target + "#" + channelSeq.getAndIncrement());
+            return new FakeManagedChannel(target + "#" + this.channelSeq.getAndIncrement());
+        }
+
+        @Override
+        protected String resolveTarget(String target) {
+            return this.resolvedTarget;
         }
 
         @Override
@@ -116,6 +209,55 @@ public class AbstractGrpcClientTest {
         public AbstractAsyncStub getAsyncStub(ManagedChannel channel) {
             this.asyncStubChannels.add(channel);
             return new FakeAsyncStub(channel, CallOptions.DEFAULT);
+        }
+    }
+
+    private static class OutOfOrderResolverGrpcClient extends RecordingGrpcClient {
+
+        private final AtomicInteger resolutionSeq = new AtomicInteger();
+        private final CountDownLatch staleResolutionStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseStaleResolution = new CountDownLatch(1);
+
+        @Override
+        protected String resolveTarget(String target) {
+            int sequence = this.resolutionSeq.incrementAndGet();
+            if (sequence == 1) {
+                return "10.0.0.1";
+            }
+            if (sequence == 2) {
+                this.staleResolutionStarted.countDown();
+                try {
+                    assertTrue("the stale resolution must be released",
+                               this.releaseStaleResolution.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+                return "10.0.0.1";
+            }
+            return "10.0.0.2";
+        }
+    }
+
+    private static class StubInterleavingGrpcClient extends RecordingGrpcClient {
+
+        private final AtomicInteger blockingStubSeq = new AtomicInteger();
+        private final CountDownLatch staleStubBuildStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseStaleStubBuild = new CountDownLatch(1);
+
+        @Override
+        public AbstractBlockingStub getBlockingStub(ManagedChannel channel) {
+            if (this.blockingStubSeq.incrementAndGet() == 1) {
+                this.staleStubBuildStarted.countDown();
+                try {
+                    assertTrue("the stale stub build must be released",
+                               this.releaseStaleStubBuild.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            return super.getBlockingStub(channel);
         }
     }
 
@@ -171,7 +313,7 @@ public class AbstractGrpcClientTest {
 
         @Override
         public ManagedChannel shutdownNow() {
-            return shutdown();
+            return this.shutdown();
         }
 
         @Override

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
@@ -602,6 +602,48 @@ public class AbstractGrpcClientTest {
     }
 
     @Test
+    public void testBlockedResolutionsDoNotStarveAnotherTarget() throws Exception {
+        String firstTarget = uniqueTarget("isolated-refresh");
+        String secondTarget = uniqueTarget("isolated-refresh");
+        String thirdTarget = uniqueTarget("isolated-refresh");
+        RecordingGrpcClient first = new RecordingGrpcClient();
+        RecordingGrpcClient second = new RecordingGrpcClient();
+        RecordingGrpcClient third = new RecordingGrpcClient();
+        ManagedChannel[] firstChannels = first.getChannels(firstTarget);
+        ManagedChannel[] secondChannels = second.getChannels(secondTarget);
+        ManagedChannel[] thirdChannels = third.getChannels(thirdTarget);
+        awaitCondition("initial refreshes must settle", () -> refreshIsIdle(first, firstTarget) &&
+                                                             refreshIsIdle(second, secondTarget) &&
+                                                             refreshIsIdle(third, thirdTarget));
+
+        first.delayResolution = true;
+        second.delayResolution = true;
+        first.delayedResolutionTimeoutSeconds = 30L;
+        second.delayedResolutionTimeoutSeconds = 30L;
+        first.resolvedTarget = "10.0.0.2";
+        second.resolvedTarget = "10.0.0.2";
+        third.resolvedTarget = "10.0.0.2";
+        try {
+            assertSame(firstChannels, first.getChannels(firstTarget));
+            assertTrue(first.delayedResolutionStarted.await(5, TimeUnit.SECONDS));
+            assertSame(secondChannels, second.getChannels(secondTarget));
+            assertTrue(second.delayedResolutionStarted.await(5, TimeUnit.SECONDS));
+
+            ManagedChannel[] replacement = awaitPoolReplacement(third, thirdTarget, thirdChannels);
+            assertNotSame("the third target must refresh while two lookups are blocked",
+                          thirdChannels, replacement);
+            assertTrue("the third target replacement must remain live",
+                       allChannelsAreLive(replacement));
+        } finally {
+            first.releaseDelayedResolution.countDown();
+            second.releaseDelayedResolution.countDown();
+            awaitCondition("blocked refreshes must settle",
+                           () -> refreshIsIdle(first, firstTarget) &&
+                                 refreshIsIdle(second, secondTarget));
+        }
+    }
+
+    @Test
     public void testPartialChannelsAreRetiredAfterMixedCreationFailure() {
         String target = uniqueTarget("partial-creation-failure");
         CreationControlGrpcClient client = new CreationControlGrpcClient();

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
@@ -56,6 +56,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.stub.AbstractAsyncStub;
 import io.grpc.stub.AbstractBlockingStub;
+import io.grpc.stub.AbstractStub;
 
 /**
  * Verifies that Store address changes replace channels and cached stubs safely, and that the
@@ -64,6 +65,7 @@ import io.grpc.stub.AbstractBlockingStub;
 public class AbstractGrpcClientTest {
 
     private static final String MAINTENANCE_THREAD_PREFIX = "channel-maintenance";
+    private static final String RETIREMENT_THREAD_PREFIX = "channel-retirement";
     private static final AtomicInteger TARGET_SEQ = new AtomicInteger();
 
     private static String uniqueTarget(String prefix) {
@@ -103,7 +105,14 @@ public class AbstractGrpcClientTest {
     }
 
     private static void awaitCondition(String message, Condition condition) throws Exception {
-        for (int i = 0; i < 500; i++) {
+        awaitCondition(message, 5L, TimeUnit.SECONDS, condition);
+    }
+
+    private static void awaitCondition(String message, long timeout, TimeUnit unit,
+                                       Condition condition) throws Exception {
+        long start = System.nanoTime();
+        long timeoutNanos = unit.toNanos(timeout);
+        while (System.nanoTime() - start < timeoutNanos) {
             if (condition.isTrue()) {
                 return;
             }
@@ -219,6 +228,44 @@ public class AbstractGrpcClientTest {
     }
 
     @Test
+    public void testInitialRefreshRunsWhenNanoTimeIsNegative() throws Exception {
+        String target = uniqueTarget("negative-nano-time");
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        client.currentNanoTime = -1L;
+        client.refreshIntervalNanos = 5L;
+
+        ManagedChannel[] initialChannels = client.getChannels(target);
+        awaitCondition("the initial refresh must settle", () -> refreshIsIdle(client, target));
+
+        assertEquals("a negative clock value must not suppress the initial refresh",
+                     1, client.resolutionCount.get());
+        assertTrue("the initial pool must remain healthy", allChannelsAreLive(initialChannels));
+    }
+
+    @Test
+    public void testRefreshDeadlineSurvivesNanoTimeWraparound() throws Exception {
+        String target = uniqueTarget("wrapped-nano-time");
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        client.currentNanoTime = Long.MAX_VALUE - 2L;
+        client.refreshIntervalNanos = 5L;
+
+        client.getChannels(target);
+        awaitCondition("the initial refresh must settle", () -> refreshIsIdle(client, target));
+        assertEquals(1, client.resolutionCount.get());
+
+        client.currentNanoTime = Long.MAX_VALUE - 1L;
+        client.getChannels(target);
+        assertEquals("the wrapped deadline must not fire early", 1,
+                     client.resolutionCount.get());
+
+        client.currentNanoTime = Long.MIN_VALUE + 2L;
+        client.getChannels(target);
+        awaitCondition("the wrapped deadline must eventually fire",
+                       () -> client.resolutionCount.get() == 2 &&
+                             refreshIsIdle(client, target));
+    }
+
+    @Test
     public void testUnknownAddressPoolIsReplacedOnFirstSuccessfulResolution() throws Exception {
         String target = uniqueTarget("first-successful-resolution");
         RecordingGrpcClient client = new RecordingGrpcClient();
@@ -242,12 +289,19 @@ public class AbstractGrpcClientTest {
      * A refresh triggered by such a caller must therefore resolve somewhere else entirely.
      */
     @Test
-    public void testRefreshSucceedsWhenTheCallerThreadIsDeniedSocketAccess() throws Exception {
+    public void testRefreshSucceedsWhenCallerIsDeniedSocketAndThreadAccess() throws Exception {
         String target = uniqueTarget("denied-caller");
         HostCapturingGrpcClient client = new HostCapturingGrpcClient();
         client.checkSocketPermission = true;
+        client.activeCallsFinished = new CountDownLatch(1);
+        client.drainTimeoutNanos = 0L;
         ManagedChannel[] oldChannels = client.getChannels(target);
         assertNotNull(client.getBlockingStub(target));
+        awaitCondition("the initial refresh must settle before installing the security manager",
+                       () -> refreshIsIdle(client, target));
+        client.resolutionThreads.clear();
+        client.creationThreads.clear();
+        client.retirementThreads.clear();
 
         SecurityManager previous = System.getSecurityManager();
         System.setSecurityManager(new DenyingWorkerSecurityManager());
@@ -271,15 +325,178 @@ public class AbstractGrpcClientTest {
             assertTrue("a denied caller must not observe a security failure: " + failure.get(),
                        failure.get() == null);
             awaitCondition("the refresh must still publish a replacement pool",
-                           () -> client.getChannels(target) != oldChannels);
+                           () -> AbstractGrpcClient.channels.get(target) != oldChannels);
+            awaitCondition("forced retirement must finish on the maintenance executor",
+                           () -> fakeChannels(oldChannels).stream()
+                                                        .allMatch(FakeManagedChannel::isTerminated));
             assertFalse("the assertion below is vacuous unless something resolved",
                         client.resolutionThreads.isEmpty());
             assertTrue("every resolution must run on the channel maintenance thread",
                        client.resolutionThreads.stream()
                                                .allMatch(name -> name.startsWith(
                                                        MAINTENANCE_THREAD_PREFIX)));
+            assertEquals("the replacement must include every channel",
+                         AbstractGrpcClient.concurrency, client.creationThreads.size());
+            assertTrue("replacement construction must stay off the denied caller",
+                       client.creationThreads.stream().noneMatch(
+                               name -> name.startsWith("gremlin-server-exec")));
+            assertFalse("the retirement assertion must observe lifecycle work",
+                        client.retirementThreads.isEmpty());
+            assertTrue("graceful retirement must run on the maintenance thread",
+                       client.retirementThreads.stream().anyMatch(
+                               name -> name.startsWith(MAINTENANCE_THREAD_PREFIX)));
+            assertTrue("forced retirement must run on the retirement thread",
+                       client.retirementThreads.stream().anyMatch(
+                               name -> name.startsWith(RETIREMENT_THREAD_PREFIX)));
+            assertTrue("retirement must stay off the denied caller",
+                       client.retirementThreads.stream().noneMatch(
+                               name -> name.startsWith("gremlin-server-exec")));
         } finally {
+            client.activeCallsFinished.countDown();
             System.setSecurityManager(previous);
+        }
+    }
+
+    @Test
+    public void testResolutionFailureKeepsHealthyPoolAndAllowsRetry() throws Exception {
+        String target = uniqueTarget("resolution-failure");
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        ManagedChannel[] healthyChannels = client.getChannels(target);
+        awaitCondition("the initial refresh must settle", () -> refreshIsIdle(client, target));
+
+        client.resolutionFailure = new IllegalStateException("injected resolution failure");
+        client.getChannels(target);
+        awaitCondition("the failed refresh must clear its single-flight entry",
+                       () -> refreshIsIdle(client, target));
+        assertSame("a resolution failure must preserve the published pool", healthyChannels,
+                   AbstractGrpcClient.channels.get(target));
+        assertTrue("a resolution failure must leave the published pool live",
+                   allChannelsAreLive(healthyChannels));
+
+        client.resolutionFailure = null;
+        client.resolvedTarget = "10.0.0.2";
+        ManagedChannel[] replacement = awaitPoolReplacement(client, target, healthyChannels);
+        assertTrue("a later successful refresh must replace the pool",
+                   allChannelsAreLive(replacement));
+    }
+
+    @Test
+    public void testRejectedRefreshSubmissionKeepsHealthyPoolAndAllowsRetry() throws Exception {
+        String target = uniqueTarget("refresh-submission-failure");
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        ManagedChannel[] healthyChannels = client.getChannels(target);
+        awaitCondition("the initial refresh must settle", () -> refreshIsIdle(client, target));
+
+        client.rejectNextRefreshSubmission.set(true);
+        client.resolvedTarget = "10.0.0.2";
+        client.getChannels(target);
+        assertTrue("a rejected refresh must clear its single-flight entry",
+                   refreshIsIdle(client, target));
+        assertSame("a rejected refresh must preserve the published pool", healthyChannels,
+                   AbstractGrpcClient.channels.get(target));
+        assertTrue("a rejected refresh must leave the published pool live",
+                   allChannelsAreLive(healthyChannels));
+
+        ManagedChannel[] replacement = awaitPoolReplacement(client, target, healthyChannels);
+        assertTrue("a later refresh submission must still succeed",
+                   allChannelsAreLive(replacement));
+    }
+
+    @Test
+    public void testReplacementCreationFailureKeepsHealthyPoolAndAllowsRetry() throws Exception {
+        String target = uniqueTarget("replacement-creation-failure");
+        CreationControlGrpcClient client = new CreationControlGrpcClient();
+        ManagedChannel[] healthyChannels = client.getChannels(target);
+        awaitCondition("the initial refresh must settle", () -> refreshIsIdle(client, target));
+        int createdBeforeFailure = client.createdChannels.size();
+
+        client.failedAttempt = client.attempt.get() + 5;
+        client.resolvedTarget = "10.0.0.2";
+        client.getChannels(target);
+        awaitCondition("the failed replacement must clear its single-flight entry",
+                       () -> refreshIsIdle(client, target));
+
+        assertSame("a replacement failure must preserve the published pool", healthyChannels,
+                   AbstractGrpcClient.channels.get(target));
+        assertTrue("a replacement failure must leave the published pool live",
+                   allChannelsAreLive(healthyChannels));
+        List<ManagedChannel> partialChannels =
+                client.createdChannels.subList(createdBeforeFailure,
+                                               client.createdChannels.size());
+        assertEquals("all successful replacement tasks must converge before failure returns",
+                     AbstractGrpcClient.concurrency - 1, partialChannels.size());
+        assertTrue("every partial replacement channel must be force terminated",
+                   partialChannels.stream().allMatch(channel ->
+                           channel.isTerminated() &&
+                           ((FakeManagedChannel) channel).isForceShutdown()));
+
+        client.failedAttempt = -1;
+        ManagedChannel[] replacement = awaitPoolReplacement(client, target, healthyChannels);
+        assertTrue("a later replacement attempt must still succeed",
+                   allChannelsAreLive(replacement));
+    }
+
+    @Test
+    public void testRejectedChannelCreationSubmissionRetiresPartialPool() throws Exception {
+        String target = uniqueTarget("channel-submission-failure");
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        ManagedChannel[] healthyChannels = client.getChannels(target);
+        awaitCondition("the initial refresh must settle", () -> refreshIsIdle(client, target));
+        int createdBeforeFailure = client.createdChannels.size();
+
+        client.rejectNextChannelSubmission.set(true);
+        client.resolvedTarget = "10.0.0.2";
+        client.getChannels(target);
+        awaitCondition("the failed replacement must clear its single-flight entry",
+                       () -> refreshIsIdle(client, target));
+
+        assertSame("a task-submission failure must preserve the published pool", healthyChannels,
+                   AbstractGrpcClient.channels.get(target));
+        List<ManagedChannel> partialChannels =
+                client.createdChannels.subList(createdBeforeFailure,
+                                               client.createdChannels.size());
+        assertEquals("one rejected task must not prevent the others from converging",
+                     AbstractGrpcClient.concurrency - 1, partialChannels.size());
+        assertTrue("partial channels must be retired after a task-submission failure",
+                   partialChannels.stream().allMatch(channel ->
+                           channel.isTerminated() &&
+                           ((FakeManagedChannel) channel).isForceShutdown()));
+
+        ManagedChannel[] replacement = awaitPoolReplacement(client, target, healthyChannels);
+        assertTrue("a later replacement attempt must still succeed",
+                   allChannelsAreLive(replacement));
+    }
+
+    @Test
+    public void testRejectedRetirementSchedulingKeepsReplacementAndAllowsRetry()
+            throws Exception {
+        String target = uniqueTarget("retirement-submission-failure");
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        client.activeCallsFinished = new CountDownLatch(1);
+        ManagedChannel[] firstChannels = client.getChannels(target);
+        awaitCondition("the initial refresh must settle", () -> refreshIsIdle(client, target));
+
+        try {
+            client.rejectNextRetirementSubmission.set(true);
+            client.resolvedTarget = "10.0.0.2";
+            client.getChannels(target);
+            awaitCondition("the replacement must be published despite cleanup rejection",
+                           () -> AbstractGrpcClient.channels.get(target) != firstChannels);
+            awaitCondition("the cleanup rejection must clear its single-flight entry",
+                           () -> refreshIsIdle(client, target));
+            ManagedChannel[] secondChannels = AbstractGrpcClient.channels.get(target);
+            assertTrue("the replacement must remain live after cleanup rejection",
+                       allChannelsAreLive(secondChannels));
+            assertTrue("the unscheduled pool must be force terminated immediately",
+                       fakeChannels(firstChannels).stream().allMatch(channel ->
+                               channel.isTerminated() && channel.isForceShutdown()));
+
+            client.resolvedTarget = "10.0.0.3";
+            ManagedChannel[] thirdChannels = awaitPoolReplacement(client, target, secondChannels);
+            assertTrue("a later refresh must still replace the pool",
+                       allChannelsAreLive(thirdChannels));
+        } finally {
+            client.activeCallsFinished.countDown();
         }
     }
 
@@ -320,6 +537,66 @@ public class AbstractGrpcClientTest {
         } finally {
             releaseWorkers.countDown();
             client.activeCallsFinished.countDown();
+        }
+    }
+
+    @Test
+    public void testRetirementDeadlineSurvivesBlockedRefreshWorkers() throws Exception {
+        String retiringTarget = uniqueTarget("isolated-retirement");
+        String firstBlockedTarget = uniqueTarget("blocked-refresh");
+        String secondBlockedTarget = uniqueTarget("blocked-refresh");
+        RecordingGrpcClient retiringClient = new RecordingGrpcClient();
+        RecordingGrpcClient firstBlockedClient = new RecordingGrpcClient();
+        RecordingGrpcClient secondBlockedClient = new RecordingGrpcClient();
+        ManagedChannel[] firstBlockedChannels = firstBlockedClient.getChannels(firstBlockedTarget);
+        ManagedChannel[] secondBlockedChannels =
+                secondBlockedClient.getChannels(secondBlockedTarget);
+        awaitCondition("the first blocking client must initialize",
+                       () -> refreshIsIdle(firstBlockedClient, firstBlockedTarget));
+        awaitCondition("the second blocking client must initialize",
+                       () -> refreshIsIdle(secondBlockedClient, secondBlockedTarget));
+
+        retiringClient.activeCallsFinished = new CountDownLatch(1);
+        retiringClient.drainTimeoutNanos = TimeUnit.SECONDS.toNanos(2L);
+        ManagedChannel[] retiredChannels = retiringClient.getChannels(retiringTarget);
+        awaitCondition("the retiring client must initialize",
+                       () -> refreshIsIdle(retiringClient, retiringTarget));
+        retiringClient.resolvedTarget = "10.0.0.2";
+        ManagedChannel[] replacement =
+                awaitPoolReplacement(retiringClient, retiringTarget, retiredChannels);
+        awaitCondition("the replacement refresh must settle",
+                       () -> refreshIsIdle(retiringClient, retiringTarget));
+
+        firstBlockedClient.delayResolution = true;
+        firstBlockedClient.delayedResolutionTimeoutSeconds = 30L;
+        firstBlockedClient.resolvedTarget = "10.0.0.2";
+        secondBlockedClient.delayResolution = true;
+        secondBlockedClient.delayedResolutionTimeoutSeconds = 30L;
+        secondBlockedClient.resolvedTarget = "10.0.0.2";
+        try {
+            assertSame(firstBlockedChannels, firstBlockedClient.getChannels(firstBlockedTarget));
+            assertTrue("the first maintenance worker must block in resolution",
+                       firstBlockedClient.delayedResolutionStarted.await(5, TimeUnit.SECONDS));
+            assertSame(secondBlockedChannels, secondBlockedClient.getChannels(secondBlockedTarget));
+            assertTrue("the second maintenance worker must block in resolution",
+                       secondBlockedClient.delayedResolutionStarted.await(5, TimeUnit.SECONDS));
+            assertFalse("the drain deadline must still be pending after workers are blocked",
+                        fakeChannels(retiredChannels).stream()
+                                                     .anyMatch(FakeManagedChannel::isForceShutdown));
+
+            awaitCondition("blocked refresh workers must not delay forced retirement",
+                           4L, TimeUnit.SECONDS,
+                           () -> fakeChannels(retiredChannels).stream().allMatch(channel ->
+                                   channel.isTerminated() && channel.isForceShutdown()));
+            assertTrue("the replacement pool must remain live", allChannelsAreLive(replacement));
+        } finally {
+            firstBlockedClient.releaseDelayedResolution.countDown();
+            secondBlockedClient.releaseDelayedResolution.countDown();
+            retiringClient.activeCallsFinished.countDown();
+            awaitCondition("the first blocked refresh must settle",
+                           () -> refreshIsIdle(firstBlockedClient, firstBlockedTarget));
+            awaitCondition("the second blocked refresh must settle",
+                           () -> refreshIsIdle(secondBlockedClient, secondBlockedTarget));
         }
     }
 
@@ -624,11 +901,23 @@ public class AbstractGrpcClientTest {
         protected final AtomicInteger resolutionCount = new AtomicInteger();
         protected final List<String> resolutionThreads =
                 Collections.synchronizedList(new ArrayList<>());
+        protected final List<String> creationThreads =
+                Collections.synchronizedList(new ArrayList<>());
+        protected final List<String> retirementThreads =
+                Collections.synchronizedList(new ArrayList<>());
+        protected final List<ManagedChannel> createdChannels =
+                Collections.synchronizedList(new ArrayList<>());
+        protected final AtomicBoolean rejectNextRefreshSubmission = new AtomicBoolean();
+        protected final AtomicBoolean rejectNextChannelSubmission = new AtomicBoolean();
+        protected final AtomicBoolean rejectNextRetirementSubmission = new AtomicBoolean();
         protected final CountDownLatch delayedResolutionStarted = new CountDownLatch(1);
         protected final CountDownLatch releaseDelayedResolution = new CountDownLatch(1);
         protected volatile String resolvedTarget = "10.0.0.1";
         protected volatile long refreshIntervalNanos = 0L;
+        protected volatile Long currentNanoTime;
+        protected volatile RuntimeException resolutionFailure;
         protected volatile boolean delayResolution;
+        protected volatile long delayedResolutionTimeoutSeconds = 5L;
         /** Resolves through the real implementation instead of returning resolvedTarget. */
         protected volatile boolean useRealResolution;
         /** Null keeps the inherited drain deadline. */
@@ -646,6 +935,12 @@ public class AbstractGrpcClientTest {
         }
 
         @Override
+        protected long nanoTime() {
+            Long time = this.currentNanoTime;
+            return time == null ? super.nanoTime() : time;
+        }
+
+        @Override
         protected long channelDrainTimeoutNanos() {
             Long timeout = this.drainTimeoutNanos;
             return timeout == null ? super.channelDrainTimeoutNanos() : timeout;
@@ -653,19 +948,51 @@ public class AbstractGrpcClientTest {
 
         @Override
         protected ManagedChannel createChannel(String target) {
-            return new FakeManagedChannel(target + "#" + this.channelSeq.getAndIncrement(),
-                                          this.activeCallsFinished);
+            this.creationThreads.add(Thread.currentThread().getName());
+            ManagedChannel channel =
+                    new FakeManagedChannel(target + "#" + this.channelSeq.getAndIncrement(),
+                                           this.activeCallsFinished, this.retirementThreads);
+            this.createdChannels.add(channel);
+            return channel;
+        }
+
+        @Override
+        void submitChannelRefresh(Runnable task) {
+            if (this.rejectNextRefreshSubmission.compareAndSet(true, false)) {
+                throw new IllegalStateException("injected refresh submission failure");
+            }
+            super.submitChannelRefresh(task);
+        }
+
+        @Override
+        void submitChannelCreation(Runnable task) {
+            if (this.rejectNextChannelSubmission.compareAndSet(true, false)) {
+                throw new IllegalStateException("injected channel submission failure");
+            }
+            super.submitChannelCreation(task);
+        }
+
+        @Override
+        void scheduleChannelRetirement(Runnable task, long timeoutNanos) {
+            if (this.rejectNextRetirementSubmission.compareAndSet(true, false)) {
+                throw new IllegalStateException("injected retirement submission failure");
+            }
+            super.scheduleChannelRetirement(task, timeoutNanos);
         }
 
         @Override
         protected String resolveTarget(String target) {
             this.resolutionCount.incrementAndGet();
             this.resolutionThreads.add(Thread.currentThread().getName());
+            if (this.resolutionFailure != null) {
+                throw this.resolutionFailure;
+            }
             if (this.delayResolution) {
                 this.delayedResolutionStarted.countDown();
                 try {
                     assertTrue("the delayed resolution must be released",
-                               this.releaseDelayedResolution.await(5, TimeUnit.SECONDS));
+                               this.releaseDelayedResolution.await(
+                                       this.delayedResolutionTimeoutSeconds, TimeUnit.SECONDS));
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new AssertionError(e);
@@ -757,7 +1084,7 @@ public class AbstractGrpcClientTest {
         }
 
         @Override
-        public AbstractAsyncStub<?> getAsyncStub(ManagedChannel channel) {
+        protected AbstractStub<?> setStubOption(AbstractStub value) {
             if (this.stubSeq.incrementAndGet() == 1) {
                 this.stubBuildStarted.countDown();
                 try {
@@ -768,7 +1095,7 @@ public class AbstractGrpcClientTest {
                     throw new AssertionError(e);
                 }
             }
-            return super.getAsyncStub(channel);
+            return super.setStubOption(value);
         }
 
         @Override
@@ -871,17 +1198,24 @@ public class AbstractGrpcClientTest {
 
         private final String authority;
         private final CountDownLatch activeCallsFinished;
+        private final List<String> retirementThreads;
         private volatile boolean shutdown;
         private volatile boolean forceShutdown;
         private volatile boolean terminated;
 
         FakeManagedChannel(String authority) {
-            this(authority, null);
+            this(authority, null, null);
         }
 
         FakeManagedChannel(String authority, CountDownLatch activeCallsFinished) {
+            this(authority, activeCallsFinished, null);
+        }
+
+        FakeManagedChannel(String authority, CountDownLatch activeCallsFinished,
+                           List<String> retirementThreads) {
             this.authority = authority;
             this.activeCallsFinished = activeCallsFinished;
+            this.retirementThreads = retirementThreads;
         }
 
         @Override
@@ -897,6 +1231,9 @@ public class AbstractGrpcClientTest {
 
         @Override
         public ManagedChannel shutdown() {
+            if (this.retirementThreads != null) {
+                this.retirementThreads.add(Thread.currentThread().getName());
+            }
             this.shutdown = true;
             if (this.activeCallsFinished == null) {
                 this.terminated = true;
@@ -906,6 +1243,9 @@ public class AbstractGrpcClientTest {
 
         @Override
         public ManagedChannel shutdownNow() {
+            if (this.retirementThreads != null) {
+                this.retirementThreads.add(Thread.currentThread().getName());
+            }
             this.shutdown = true;
             this.forceShutdown = true;
             this.terminated = true;

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
@@ -43,6 +44,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import org.apache.hugegraph.store.client.query.QueryV2Client;
+import org.apache.hugegraph.store.grpc.query.QueryServiceGrpc;
 import org.apache.hugegraph.store.term.HgPair;
 import org.junit.Test;
 
@@ -55,18 +58,19 @@ import io.grpc.stub.AbstractAsyncStub;
 import io.grpc.stub.AbstractBlockingStub;
 
 /**
- * Verifies that Store address changes replace channels and cached stubs safely.
+ * Verifies that Store address changes replace channels and cached stubs safely, and that the
+ * refresh never resolves or creates channels on the thread that asked for a stub.
  */
 public class AbstractGrpcClientTest {
 
+    private static final String MAINTENANCE_THREAD_PREFIX = "channel-maintenance";
     private static final AtomicInteger TARGET_SEQ = new AtomicInteger();
 
     private static String uniqueTarget(String prefix) {
         return prefix + "-" + TARGET_SEQ.incrementAndGet() + ":8500";
     }
 
-    private static boolean belongsToPool(Channel channel,
-                                         ManagedChannel[] channels) {
+    private static boolean belongsToPool(Channel channel, ManagedChannel[] channels) {
         return Arrays.stream(channels).anyMatch(current -> current == channel);
     }
 
@@ -108,6 +112,30 @@ public class AbstractGrpcClientTest {
         assertTrue(message, condition.isTrue());
     }
 
+    /**
+     * Refresh runs on the maintenance thread, so a replacement pool becomes visible some time
+     * after the address changes rather than on the call that observes the change. Retirement
+     * deliberately trails publication, so waiting for both is what marks a refresh complete.
+     */
+    private static ManagedChannel[] awaitPoolReplacement(RecordingGrpcClient client,
+                                                         String target,
+                                                         ManagedChannel[] staleChannels)
+            throws Exception {
+        awaitCondition("refresh must publish a replacement pool",
+                       () -> client.getChannels(target) != staleChannels);
+        awaitCondition("refresh must retire the previous pool after publishing",
+                       () -> allChannelsAreShutdown(staleChannels));
+        return client.getChannels(target);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean refreshIsIdle(AbstractGrpcClient client, String target)
+            throws Exception {
+        Field field = AbstractGrpcClient.class.getDeclaredField("refreshTasks");
+        field.setAccessible(true);
+        return !((Map<String, ?>) field.get(client)).containsKey(target);
+    }
+
     @SuppressWarnings("unchecked")
     private static List<ManagedChannel> cachedAsyncStubChannels(AbstractGrpcClient client,
                                                                 String target)
@@ -121,18 +149,6 @@ public class AbstractGrpcClientTest {
         return Arrays.stream(pairs).map(HgPair::getKey).collect(Collectors.toList());
     }
 
-    @SuppressWarnings("unchecked")
-    private static HgPair<ManagedChannel, AbstractBlockingStub>[] cachedBlockingStubs(
-            AbstractGrpcClient client, String target) throws Exception {
-        Field field = AbstractGrpcClient.class.getDeclaredField("blockingStubs");
-        field.setAccessible(true);
-        Map<String, HgPair<ManagedChannel, AbstractBlockingStub>[]> stubs =
-                (Map<String, HgPair<ManagedChannel, AbstractBlockingStub>[]>) field.get(client);
-        HgPair<ManagedChannel, AbstractBlockingStub>[] pairs = stubs.get(target);
-        assertNotNull("the blocking stub cache must exist", pairs);
-        return pairs;
-    }
-
     private static ThreadPoolExecutor channelCreationExecutor(AbstractGrpcClient client)
             throws Exception {
         Field field = AbstractGrpcClient.class.getDeclaredField("executor");
@@ -141,7 +157,7 @@ public class AbstractGrpcClientTest {
     }
 
     @Test
-    public void testAddressChangeReplacesChannelAndStubPools() {
+    public void testAddressChangeReplacesChannelAndStubPools() throws Exception {
         String target = uniqueTarget("address-change");
         RecordingGrpcClient client = new RecordingGrpcClient();
         ManagedChannel[] oldChannels = client.getChannels(target);
@@ -149,9 +165,7 @@ public class AbstractGrpcClientTest {
         assertNotNull(client.getAsyncStub(target));
 
         client.resolvedTarget = "10.0.0.2";
-        ManagedChannel[] newChannels = client.getChannels(target);
-        assertNotSame("an address change must replace the channel pool",
-                      oldChannels, newChannels);
+        ManagedChannel[] newChannels = awaitPoolReplacement(client, target, oldChannels);
         assertTrue("every stale channel must be gracefully shut down",
                    allChannelsAreShutdown(oldChannels));
         assertFalse("refresh must not force close stale channels immediately",
@@ -162,35 +176,57 @@ public class AbstractGrpcClientTest {
         client.asyncStubChannels.clear();
         assertNotNull(client.getBlockingStub(target));
         assertNotNull(client.getAsyncStub(target));
-        assertEquals("the blocking stub pool must be rebuilt",
-                     newChannels.length, client.blockingStubChannels.size());
-        assertTrue("replacement blocking stubs must use the new channel pool",
-                   client.blockingStubChannels.stream()
-                                              .allMatch(channel ->
-                                                        belongsToPool(channel, newChannels)));
+        assertCachedChannelsCurrentAndLive("the blocking stub pool must be rebuilt on the new pool",
+                                           client.blockingStubChannels, newChannels);
         assertUsesEveryChannel("blocking stubs must be spread across the pool",
                                client.blockingStubChannels, newChannels);
-        assertEquals("the async stub pool must be rebuilt",
-                     newChannels.length, client.asyncStubChannels.size());
-        assertTrue("replacement async stubs must use the new channel pool",
-                   client.asyncStubChannels.stream()
-                                           .allMatch(channel ->
-                                                     belongsToPool(channel, newChannels)));
+        assertCachedChannelsCurrentAndLive("the async stub pool must be rebuilt on the new pool",
+                                           client.asyncStubChannels, newChannels);
         assertUsesEveryChannel("async stubs must be spread across the pool",
                                client.asyncStubChannels, newChannels);
     }
 
     @Test
-    public void testFirstSuccessfulResolutionReplacesUnknownChannels() {
+    public void testStubPoolsCoverEveryChannelOnFirstBuild() {
+        String target = uniqueTarget("initial-stub-spread");
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        ManagedChannel[] channels = client.getChannels(target);
+
+        assertNotNull(client.getBlockingStub(target));
+        assertNotNull(client.getAsyncStub(target));
+        assertUsesEveryChannel("the first blocking stub pool must cover every channel",
+                               client.blockingStubChannels, channels);
+        assertUsesEveryChannel("the first async stub pool must cover every channel",
+                               client.asyncStubChannels, channels);
+    }
+
+    @Test
+    public void testFirstPoolIsBuiltAfterItsAddressIsKnown() throws Exception {
+        String target = uniqueTarget("initial-resolution");
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        ManagedChannel[] initialChannels = client.getChannels(target);
+
+        assertEquals("the first pool must be built once its address is known",
+                     1, client.resolutionCount.get());
+        // Let every refresh settle first, otherwise the assertions below race the swap.
+        awaitCondition("the refresh must settle", () -> refreshIsIdle(client, target));
+        assertSame("a pool built with a known address must not be replaced",
+                   initialChannels, client.getChannels(target));
+        awaitCondition("the settled refresh must leave no further work",
+                       () -> refreshIsIdle(client, target));
+        assertTrue("the first pool must not be retired by its own resolution",
+                   allChannelsAreLive(initialChannels));
+    }
+
+    @Test
+    public void testUnknownAddressPoolIsReplacedOnFirstSuccessfulResolution() throws Exception {
         String target = uniqueTarget("first-successful-resolution");
         RecordingGrpcClient client = new RecordingGrpcClient();
         client.resolvedTarget = "";
         ManagedChannel[] unknownChannels = client.getChannels(target);
 
         client.resolvedTarget = "10.0.0.1";
-        ManagedChannel[] resolvedChannels = client.getChannels(target);
-        assertNotSame("a pool with unknown addresses must be replaced",
-                      unknownChannels, resolvedChannels);
+        ManagedChannel[] resolvedChannels = awaitPoolReplacement(client, target, unknownChannels);
         assertTrue("every channel from the unknown pool must be gracefully shut down",
                    allChannelsAreShutdown(unknownChannels));
         assertFalse("unknown channels must not be force closed immediately",
@@ -200,16 +236,63 @@ public class AbstractGrpcClientTest {
                    allChannelsAreLive(resolvedChannels));
     }
 
+    /**
+     * HugeSecurityManager denies socket connection and thread creation on Gremlin worker stacks,
+     * and InetAddress.getAllByName() performs exactly the checkConnect(host, -1) simulated here.
+     * A refresh triggered by such a caller must therefore resolve somewhere else entirely.
+     */
     @Test
-    public void testRetirementDoesNotBlockWhenCreationExecutorIsSaturated()
-            throws Exception {
+    public void testRefreshSucceedsWhenTheCallerThreadIsDeniedSocketAccess() throws Exception {
+        String target = uniqueTarget("denied-caller");
+        HostCapturingGrpcClient client = new HostCapturingGrpcClient();
+        client.checkSocketPermission = true;
+        ManagedChannel[] oldChannels = client.getChannels(target);
+        assertNotNull(client.getBlockingStub(target));
+
+        SecurityManager previous = System.getSecurityManager();
+        System.setSecurityManager(new DenyingWorkerSecurityManager());
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<AbstractBlockingStub> stub = new AtomicReference<>();
+        try {
+            client.resolvedAddress = "10.0.0.2";
+            // The name is what HugeSecurityManager keys its Gremlin worker check on.
+            Thread worker = new Thread(() -> {
+                try {
+                    stub.set(client.getBlockingStub(target));
+                } catch (Throwable e) {
+                    failure.set(e);
+                }
+            }, "gremlin-server-exec-1");
+            worker.start();
+            worker.join(TimeUnit.SECONDS.toMillis(10L));
+
+            assertFalse("the denied caller must finish", worker.isAlive());
+            assertNotNull("a denied caller must still receive a stub", stub.get());
+            assertTrue("a denied caller must not observe a security failure: " + failure.get(),
+                       failure.get() == null);
+            awaitCondition("the refresh must still publish a replacement pool",
+                           () -> client.getChannels(target) != oldChannels);
+            assertFalse("the assertion below is vacuous unless something resolved",
+                        client.resolutionThreads.isEmpty());
+            assertTrue("every resolution must run on the channel maintenance thread",
+                       client.resolutionThreads.stream()
+                                               .allMatch(name -> name.startsWith(
+                                                       MAINTENANCE_THREAD_PREFIX)));
+        } finally {
+            System.setSecurityManager(previous);
+        }
+    }
+
+    @Test
+    public void testRetirementDoesNotBlockWhenCreationExecutorIsSaturated() throws Exception {
         String target = uniqueTarget("saturated-retirement");
-        ActiveRetirementGrpcClient client = new ActiveRetirementGrpcClient();
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        client.activeCallsFinished = new CountDownLatch(1);
+        client.drainTimeoutNanos = TimeUnit.SECONDS.toNanos(5L);
         ManagedChannel[] oldChannels = client.getChannels(target);
         ThreadPoolExecutor channelExecutor = channelCreationExecutor(client);
         CountDownLatch workersStarted = new CountDownLatch(AbstractGrpcClient.concurrency);
         CountDownLatch releaseWorkers = new CountDownLatch(1);
-        ExecutorService caller = Executors.newSingleThreadExecutor();
 
         try {
             for (int i = 0; i < AbstractGrpcClient.concurrency; i++) {
@@ -226,29 +309,25 @@ public class AbstractGrpcClientTest {
                        workersStarted.await(5, TimeUnit.SECONDS));
 
             client.resolvedTarget = "10.0.0.2";
-            Future<ManagedChannel[]> refreshed =
-                    caller.submit(() -> client.getChannels(target));
-            ManagedChannel[] newChannels = refreshed.get(1, TimeUnit.SECONDS);
+            ManagedChannel[] newChannels = awaitPoolReplacement(client, target, oldChannels);
 
-            assertNotSame("refresh must publish the replacement pool",
-                          oldChannels, newChannels);
-            assertTrue("the retired pool must be shut down before refresh returns",
+            assertNotSame("refresh must publish the replacement pool", oldChannels, newChannels);
+            assertTrue("the retired pool must be shut down once refresh completes",
                        allChannelsAreShutdown(oldChannels));
             assertFalse("the scheduled cleanup must preserve the drain window",
                         fakeChannels(oldChannels).stream()
                                                  .anyMatch(FakeManagedChannel::isForceShutdown));
         } finally {
             releaseWorkers.countDown();
-            client.finishActiveCalls();
-            caller.shutdownNow();
+            client.activeCallsFinished.countDown();
         }
     }
 
     @Test
-    public void testPartialChannelsAreRetiredAfterMixedCreationFailure()
-            throws Exception {
+    public void testPartialChannelsAreRetiredAfterMixedCreationFailure() {
         String target = uniqueTarget("partial-creation-failure");
-        FailingCreationGrpcClient client = new FailingCreationGrpcClient(5);
+        CreationControlGrpcClient client = new CreationControlGrpcClient();
+        client.failedAttempt = 5;
 
         try {
             client.getChannels(target);
@@ -266,10 +345,10 @@ public class AbstractGrpcClientTest {
     }
 
     @Test
-    public void testInterruptedCreationWaitsAndRetiresPartialChannels()
-            throws Exception {
+    public void testInterruptedCreationWaitsAndRetiresPartialChannels() throws Exception {
         String target = uniqueTarget("interrupted-creation");
-        DelayedCreationGrpcClient client = new DelayedCreationGrpcClient();
+        CreationControlGrpcClient client = new CreationControlGrpcClient();
+        client.releaseCreation = new CountDownLatch(1);
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicBoolean interrupted = new AtomicBoolean();
         Thread caller = new Thread(() -> {
@@ -309,13 +388,14 @@ public class AbstractGrpcClientTest {
     @Test
     public void testDrainDeadlineForceTerminatesRetiredChannels() throws Exception {
         String target = uniqueTarget("drain-deadline");
-        ImmediateRetirementGrpcClient client = new ImmediateRetirementGrpcClient();
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        client.activeCallsFinished = new CountDownLatch(1);
+        client.drainTimeoutNanos = 0L;
         ManagedChannel[] oldChannels = client.getChannels(target);
 
         client.resolvedTarget = "10.0.0.2";
-        ManagedChannel[] newChannels = client.getChannels(target);
+        ManagedChannel[] newChannels = awaitPoolReplacement(client, target, oldChannels);
 
-        assertNotSame("refresh must publish a replacement pool", oldChannels, newChannels);
         awaitCondition("expired drain deadline must force terminate the retired pool",
                        () -> fakeChannels(oldChannels).stream().allMatch(channel ->
                                channel.isTerminated() && channel.isForceShutdown()));
@@ -323,34 +403,9 @@ public class AbstractGrpcClientTest {
     }
 
     @Test
-    public void testStubCacheRequiresIndexIdentityMapping() throws Exception {
-        String target = uniqueTarget("index-mapping");
-        RecordingGrpcClient client = new RecordingGrpcClient();
-        ManagedChannel[] targetChannels = client.getChannels(target);
-        assertNotNull(client.getBlockingStub(target));
-        HgPair<ManagedChannel, AbstractBlockingStub>[] pairs =
-                cachedBlockingStubs(client, target);
-        HgPair<ManagedChannel, AbstractBlockingStub> first = pairs[0];
-        pairs[0] = pairs[1];
-        pairs[1] = first;
-        client.blockingStubChannels.clear();
-
-        assertNotNull(client.getBlockingStub(target));
-
-        assertEquals("a permuted cache must be rebuilt instead of reused",
-                     AbstractGrpcClient.concurrency, client.blockingStubChannels.size());
-        HgPair<ManagedChannel, AbstractBlockingStub>[] rebuilt =
-                cachedBlockingStubs(client, target);
-        for (int i = 0; i < targetChannels.length; i++) {
-            assertTrue("each cached stub must map to the channel at the same index",
-                       rebuilt[i].getKey() == targetChannels[i]);
-        }
-    }
-
-    @Test
-    public void testStubAcquisitionReusesResolutionWithinRefreshInterval() {
+    public void testStubAcquisitionReusesResolutionWithinRefreshInterval() throws Exception {
         String target = uniqueTarget("throttled-refresh");
-        CountingResolverGrpcClient client = new CountingResolverGrpcClient();
+        RecordingGrpcClient client = new RecordingGrpcClient();
         client.refreshIntervalNanos = TimeUnit.HOURS.toNanos(1L);
 
         assertNotNull(client.getBlockingStub(target));
@@ -360,6 +415,7 @@ public class AbstractGrpcClientTest {
             assertNotNull(client.getAsyncStub(target));
         }
 
+        Thread.sleep(100L);
         assertEquals("stub acquisition must not resolve again inside the refresh interval",
                      1, client.resolutionCount.get());
     }
@@ -368,14 +424,16 @@ public class AbstractGrpcClientTest {
     public void testConcurrentStubAcquisitionRetainsHealthyPoolDuringDelayedRefresh()
             throws Exception {
         String target = uniqueTarget("delayed-refresh");
-        DelayedResolverGrpcClient client = new DelayedResolverGrpcClient();
-        client.refreshIntervalNanos = 0L;
+        RecordingGrpcClient client = new RecordingGrpcClient();
         ManagedChannel[] oldChannels = client.getChannels(target);
         assertNotNull(client.getBlockingStub(target));
+        // Let any refresh already in flight settle, so the resolution count below is stable.
+        awaitCondition("the initial refresh must settle before the count is captured",
+                       () -> refreshIsIdle(client, target));
         int resolutionsBeforeConcurrentCalls = client.resolutionCount.get();
 
         client.resolvedTarget = "10.0.0.2";
-        client.delayChangedResolution = true;
+        client.delayResolution = true;
         client.refreshIntervalNanos = TimeUnit.HOURS.toNanos(1L);
 
         ExecutorService executor = Executors.newFixedThreadPool(6);
@@ -386,24 +444,21 @@ public class AbstractGrpcClientTest {
             }
             assertTrue("one refresh should be waiting in the delayed resolver",
                        client.delayedResolutionStarted.await(5, TimeUnit.SECONDS));
-            awaitCondition("callers that miss the refresh lock must keep using the cache",
-                           () -> futures.stream().anyMatch(Future::isDone));
+            for (Future<AbstractBlockingStub> future : futures) {
+                assertNotNull("no caller may block on the delayed refresh",
+                              future.get(5, TimeUnit.SECONDS));
+            }
             assertTrue("the existing healthy pool must stay live during refresh",
                        allChannelsAreLive(oldChannels));
 
             client.releaseDelayedResolution.countDown();
-            for (Future<AbstractBlockingStub> future : futures) {
-                assertNotNull(future.get(5, TimeUnit.SECONDS));
-            }
-
-            ManagedChannel[] currentChannels = client.getChannels(target);
-            assertNotSame("the completed refresh must publish a new channel pool",
-                          oldChannels, currentChannels);
+            ManagedChannel[] currentChannels =
+                    awaitPoolReplacement(client, target, oldChannels);
             assertTrue("the previous pool must be retired after replacement is published",
                        allChannelsAreShutdown(oldChannels));
+            assertTrue("the replacement pool must be live", allChannelsAreLive(currentChannels));
             assertEquals("concurrent callers must share a single refresh resolution",
-                         resolutionsBeforeConcurrentCalls + 1,
-                         client.resolutionCount.get());
+                         resolutionsBeforeConcurrentCalls + 1, client.resolutionCount.get());
         } finally {
             client.releaseDelayedResolution.countDown();
             executor.shutdownNow();
@@ -413,67 +468,38 @@ public class AbstractGrpcClientTest {
     @Test
     public void testRefreshGracefullyRetiresActiveStreamChannels() throws Exception {
         String target = uniqueTarget("active-stream-refresh");
-        ActiveRetirementGrpcClient client = new ActiveRetirementGrpcClient();
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        client.activeCallsFinished = new CountDownLatch(1);
+        client.drainTimeoutNanos = TimeUnit.SECONDS.toNanos(5L);
         ManagedChannel[] oldChannels = client.getChannels(target);
         AbstractAsyncStub activeStreamStub = client.getAsyncStub(target);
         assertTrue("the simulated active stream must be on the old pool",
                    belongsToPool(activeStreamStub.getChannel(), oldChannels));
 
         client.resolvedTarget = "10.0.0.2";
-        ManagedChannel[] newChannels = client.getChannels(target);
-        assertNotSame("an address change must publish a replacement pool first",
-                      oldChannels, newChannels);
+        ManagedChannel[] newChannels = awaitPoolReplacement(client, target, oldChannels);
         List<FakeManagedChannel> retiredChannels = fakeChannels(oldChannels);
         assertTrue("the retired pool must receive graceful shutdown",
                    retiredChannels.stream().allMatch(FakeManagedChannel::isShutdown));
         assertFalse("active streams must not be force closed immediately",
                     retiredChannels.stream().anyMatch(FakeManagedChannel::isForceShutdown));
-        client.finishActiveCalls();
+        client.activeCallsFinished.countDown();
         awaitCondition("retired channels should terminate after active calls finish",
                        () -> retiredChannels.stream().allMatch(FakeManagedChannel::isTerminated));
         assertFalse("drained channels must not need forced shutdown",
                     retiredChannels.stream().anyMatch(FakeManagedChannel::isForceShutdown));
-        assertTrue("the replacement pool must remain live",
-                   allChannelsAreLive(newChannels));
+        assertTrue("the replacement pool must remain live", allChannelsAreLive(newChannels));
     }
 
+    /**
+     * Holds a stub pool build open, refreshes the pool underneath it, and asserts that both the
+     * interleaved build and a concurrent one return stubs bound to the published pool. Blocking
+     * and asynchronous acquisition share one implementation, so the asynchronous path stands in
+     * for both; it is the one that also publishes a stub cache worth asserting on.
+     */
     @Test
-    public void testBlockingStubBuildRetriesAfterChannelRefresh() throws Exception {
-        String target = uniqueTarget("concurrent-blocking-stub-refresh");
-        StubInterleavingGrpcClient client = new StubInterleavingGrpcClient();
-        ManagedChannel[] oldChannels = client.getChannels(target);
-        ExecutorService executor = Executors.newFixedThreadPool(2);
-
-        try {
-            Future<AbstractBlockingStub> staleStub =
-                    executor.submit(() -> client.getBlockingStub(target));
-            assertTrue("the old blocking stub pool build must be in flight",
-                       client.staleBlockingStubBuildStarted.await(5, TimeUnit.SECONDS));
-            client.resolvedTarget = "10.0.0.2";
-            Future<AbstractBlockingStub> freshStub =
-                    executor.submit(() -> client.getBlockingStub(target));
-            awaitCondition("refresh must retire the old channel pool",
-                           () -> allChannelsAreShutdown(oldChannels));
-            client.releaseStaleBlockingStubBuild.countDown();
-
-            AbstractBlockingStub staleResult = staleStub.get(5, TimeUnit.SECONDS);
-            AbstractBlockingStub freshResult = freshStub.get(5, TimeUnit.SECONDS);
-            ManagedChannel[] currentChannels = client.getChannels(target);
-            assertTrue("the stale build must retry against the current pool",
-                       belongsToPool(staleResult.getChannel(), currentChannels));
-            assertTrue("the concurrent build must use the current pool",
-                       belongsToPool(freshResult.getChannel(), currentChannels));
-            assertTrue("the current channel pool must remain live",
-                       allChannelsAreLive(currentChannels));
-        } finally {
-            client.releaseStaleBlockingStubBuild.countDown();
-            executor.shutdownNow();
-        }
-    }
-
-    @Test
-    public void testAsyncStubBuildRetriesAfterChannelRefresh() throws Exception {
-        String target = uniqueTarget("concurrent-async-stub-refresh");
+    public void testStubBuildRetriesAfterChannelRefresh() throws Exception {
+        String target = uniqueTarget("concurrent-stub-refresh");
         StubInterleavingGrpcClient client = new StubInterleavingGrpcClient();
         ManagedChannel[] oldChannels = client.getChannels(target);
         ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -481,60 +507,134 @@ public class AbstractGrpcClientTest {
         try {
             Future<AbstractAsyncStub> staleStub =
                     executor.submit(() -> client.getAsyncStub(target));
-            assertTrue("the old async stub pool build must be in flight",
-                       client.staleAsyncStubBuildStarted.await(5, TimeUnit.SECONDS));
+            assertTrue("the old stub pool build must be in flight",
+                       client.staleStubBuildStarted.await(5, TimeUnit.SECONDS));
             client.resolvedTarget = "10.0.0.2";
             Future<AbstractAsyncStub> freshStub =
                     executor.submit(() -> client.getAsyncStub(target));
             awaitCondition("refresh must retire the old channel pool",
                            () -> allChannelsAreShutdown(oldChannels));
-            client.releaseStaleAsyncStubBuild.countDown();
+            client.releaseStaleStubBuild.countDown();
 
-            AbstractAsyncStub staleResult = staleStub.get(5, TimeUnit.SECONDS);
-            AbstractAsyncStub freshResult = freshStub.get(5, TimeUnit.SECONDS);
             ManagedChannel[] currentChannels = client.getChannels(target);
-            assertTrue("the stale async build must retry against the current pool",
-                       belongsToPool(staleResult.getChannel(), currentChannels));
-            assertTrue("the concurrent async build must use the current pool",
-                       belongsToPool(freshResult.getChannel(), currentChannels));
+            assertTrue("the stale build must retry against the current pool",
+                       belongsToPool(staleStub.get(5, TimeUnit.SECONDS).getChannel(),
+                                     currentChannels));
+            assertTrue("the concurrent build must use the current pool",
+                       belongsToPool(freshStub.get(5, TimeUnit.SECONDS).getChannel(),
+                                     currentChannels));
+            assertTrue("the current channel pool must remain live",
+                       allChannelsAreLive(currentChannels));
             assertCachedChannelsCurrentAndLive(
-                    "the final async cache must only reference current live channels",
+                    "the final stub cache must only reference current live channels",
                     cachedAsyncStubChannels(client, target), currentChannels);
         } finally {
-            client.releaseStaleAsyncStubBuild.countDown();
+            client.releaseStaleStubBuild.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * QueryV2 used to take a channel straight from the pool and build its stub afterwards, which
+     * let a refresh retire that channel in between. It must now go through the guarded path.
+     */
+    @Test
+    public void testQueryV2StubFollowsPublishedPoolAcrossRefresh() throws Exception {
+        String target = uniqueTarget("query-v2-refresh");
+        QueryV2TestClient client = new QueryV2TestClient();
+        ManagedChannel[] oldChannels = client.getChannels(target);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        try {
+            /*
+             * Interleave a refresh with the stub build. Taking a channel from the pool and
+             * building the stub afterwards would bind it to a channel retired in between.
+             */
+            Future<QueryServiceGrpc.QueryServiceStub> stub =
+                    executor.submit(() -> client.getQueryServiceStub(target));
+            assertTrue("the QueryV2 stub build must be in flight",
+                       client.stubBuildStarted.await(5, TimeUnit.SECONDS));
+            client.resolvedTarget = "10.0.0.2";
+            // getChannels is what triggers a refresh, and the blocked build cannot call it.
+            awaitCondition("refresh must retire the old channel pool",
+                           () -> client.getChannels(target) != oldChannels &&
+                                 allChannelsAreShutdown(oldChannels));
+            client.releaseStubBuild.countDown();
+
+            ManagedChannel[] newChannels = client.getChannels(target);
+            Channel channel = stub.get(5, TimeUnit.SECONDS).getChannel();
+            assertTrue("QueryV2 must never return a stub bound to a retired channel",
+                       belongsToPool(channel, newChannels));
+            assertFalse("QueryV2 must never return a stub on a shut down channel",
+                        ((ManagedChannel) channel).isShutdown());
+
+            List<ManagedChannel> stubChannels = new ArrayList<>();
+            for (int i = 0; i < AbstractGrpcClient.concurrency; i++) {
+                stubChannels.add((ManagedChannel) client.getQueryServiceStub(target).getChannel());
+            }
+            assertCachedChannelsCurrentAndLive("QueryV2 stubs must stay on the published pool",
+                                               stubChannels, newChannels);
+            assertUsesEveryChannel("QueryV2 stubs must still spread across the pool",
+                                   stubChannels, newChannels);
+        } finally {
+            client.releaseStubBuild.countDown();
             executor.shutdownNow();
         }
     }
 
     @Test
     public void testResolveTargetSupportsDnsUriAndBracketedIpv6Targets() {
-        HostCapturingGrpcClient dnsClient = new HostCapturingGrpcClient();
-        assertEquals("10.0.0.1", dnsClient.resolveTarget("dns:///store.example.com:8500"));
-        assertEquals("store.example.com", dnsClient.capturedHost);
+        HostCapturingGrpcClient client = new HostCapturingGrpcClient();
+        assertEquals("10.0.0.1", client.resolveTarget("store.example.com:8500"));
+        assertEquals("store.example.com", client.capturedHost);
 
-        HostCapturingGrpcClient ipv6Client = new HostCapturingGrpcClient();
-        assertEquals("10.0.0.1", ipv6Client.resolveTarget("[2001:db8::1]:8500"));
-        assertEquals("2001:db8::1", ipv6Client.capturedHost);
+        assertEquals("10.0.0.1", client.resolveTarget("dns:///store.example.com:8500"));
+        assertEquals("store.example.com", client.capturedHost);
+
+        // The scheme-only spelling is a legal gRPC dns target too.
+        assertEquals("10.0.0.1", client.resolveTarget("dns:store.example.com:8500"));
+        assertEquals("store.example.com", client.capturedHost);
+
+        assertEquals("10.0.0.1", client.resolveTarget("dns://8.8.8.8/store.example.com:8500"));
+        assertEquals("store.example.com", client.capturedHost);
+
+        assertEquals("10.0.0.1", client.resolveTarget("[2001:db8::1]:8500"));
+        assertEquals("2001:db8::1", client.capturedHost);
     }
 
     @Test
     public void testResolveTargetSkipsUnsupportedGrpcSchemes() {
         HostCapturingGrpcClient client = new HostCapturingGrpcClient();
         assertEquals("", client.resolveTarget("unix:///var/run/store.sock"));
+        // The single-slash spelling is legal too, and must not resolve the literal host "unix".
+        assertEquals("", client.resolveTarget("unix:/var/run/store.sock"));
+        assertEquals("", client.resolveTarget("xds:///store.example.com"));
         assertEquals("unsupported schemes must not invoke DNS resolution",
-                     0, client.resolutionCount.get());
+                     0, client.hostResolutionCount.get());
     }
 
     private interface Condition {
 
-        boolean isTrue();
+        boolean isTrue() throws Exception;
     }
 
     private static class RecordingGrpcClient extends AbstractGrpcClient {
 
         private final AtomicInteger channelSeq = new AtomicInteger();
+        protected final AtomicInteger resolutionCount = new AtomicInteger();
+        protected final List<String> resolutionThreads =
+                Collections.synchronizedList(new ArrayList<>());
+        protected final CountDownLatch delayedResolutionStarted = new CountDownLatch(1);
+        protected final CountDownLatch releaseDelayedResolution = new CountDownLatch(1);
         protected volatile String resolvedTarget = "10.0.0.1";
         protected volatile long refreshIntervalNanos = 0L;
+        protected volatile boolean delayResolution;
+        /** Resolves through the real implementation instead of returning resolvedTarget. */
+        protected volatile boolean useRealResolution;
+        /** Null keeps the inherited drain deadline. */
+        protected volatile Long drainTimeoutNanos;
+        /** Null makes channels terminate as soon as they are shut down. */
+        protected volatile CountDownLatch activeCallsFinished;
         protected final List<ManagedChannel> blockingStubChannels =
                 Collections.synchronizedList(new ArrayList<>());
         protected final List<ManagedChannel> asyncStubChannels =
@@ -546,17 +646,32 @@ public class AbstractGrpcClientTest {
         }
 
         @Override
-        protected ManagedChannel createChannel(String target) {
-            return this.newFakeChannel(target + "#" + this.channelSeq.getAndIncrement());
+        protected long channelDrainTimeoutNanos() {
+            Long timeout = this.drainTimeoutNanos;
+            return timeout == null ? super.channelDrainTimeoutNanos() : timeout;
         }
 
-        protected FakeManagedChannel newFakeChannel(String authority) {
-            return new FakeManagedChannel(authority);
+        @Override
+        protected ManagedChannel createChannel(String target) {
+            return new FakeManagedChannel(target + "#" + this.channelSeq.getAndIncrement(),
+                                          this.activeCallsFinished);
         }
 
         @Override
         protected String resolveTarget(String target) {
-            return this.resolvedTarget;
+            this.resolutionCount.incrementAndGet();
+            this.resolutionThreads.add(Thread.currentThread().getName());
+            if (this.delayResolution) {
+                this.delayedResolutionStarted.countDown();
+                try {
+                    assertTrue("the delayed resolution must be released",
+                               this.releaseDelayedResolution.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            return this.useRealResolution ? super.resolveTarget(target) : this.resolvedTarget;
         }
 
         @Override
@@ -572,115 +687,35 @@ public class AbstractGrpcClientTest {
         }
     }
 
-    private static class CountingResolverGrpcClient extends RecordingGrpcClient {
+    private static class CreationControlGrpcClient extends RecordingGrpcClient {
 
-        protected final AtomicInteger resolutionCount = new AtomicInteger();
-
-        @Override
-        protected String resolveTarget(String target) {
-            this.resolutionCount.incrementAndGet();
-            return super.resolveTarget(target);
-        }
-    }
-
-    private static class DelayedResolverGrpcClient extends CountingResolverGrpcClient {
-
-        private final CountDownLatch delayedResolutionStarted = new CountDownLatch(1);
-        private final CountDownLatch releaseDelayedResolution = new CountDownLatch(1);
-        private volatile boolean delayChangedResolution;
+        private final AtomicInteger attempt = new AtomicInteger();
+        private final CountDownLatch creationStarted =
+                new CountDownLatch(AbstractGrpcClient.concurrency);
+        private final List<ManagedChannel> createdChannels =
+                Collections.synchronizedList(new ArrayList<>());
+        /** Negative never fails. */
+        private volatile int failedAttempt = -1;
+        /** Null creates channels without delay. */
+        private volatile CountDownLatch releaseCreation;
 
         @Override
-        protected String resolveTarget(String target) {
-            this.resolutionCount.incrementAndGet();
-            if (this.delayChangedResolution) {
-                this.delayedResolutionStarted.countDown();
+        protected ManagedChannel createChannel(String target) {
+            int current = this.attempt.getAndIncrement();
+            this.creationStarted.countDown();
+            if (current == this.failedAttempt) {
+                throw new IllegalStateException("injected channel creation failure");
+            }
+            CountDownLatch release = this.releaseCreation;
+            if (release != null) {
                 try {
-                    assertTrue("the delayed resolution must be released",
-                               this.releaseDelayedResolution.await(5, TimeUnit.SECONDS));
+                    release.await();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new AssertionError(e);
                 }
             }
-            return this.resolvedTarget;
-        }
-    }
-
-    private static class ActiveRetirementGrpcClient extends RecordingGrpcClient {
-
-        private final CountDownLatch activeCallsFinished = new CountDownLatch(1);
-
-        @Override
-        protected long channelDrainTimeoutNanos() {
-            return TimeUnit.SECONDS.toNanos(5L);
-        }
-
-        @Override
-        protected FakeManagedChannel newFakeChannel(String authority) {
-            return new FakeManagedChannel(authority, this.activeCallsFinished);
-        }
-
-        private void finishActiveCalls() {
-            this.activeCallsFinished.countDown();
-        }
-    }
-
-    private static class ImmediateRetirementGrpcClient extends RecordingGrpcClient {
-
-        private final CountDownLatch activeCallsFinished = new CountDownLatch(1);
-
-        @Override
-        protected long channelDrainTimeoutNanos() {
-            return 0L;
-        }
-
-        @Override
-        protected FakeManagedChannel newFakeChannel(String authority) {
-            return new FakeManagedChannel(authority, this.activeCallsFinished);
-        }
-    }
-
-    private static class FailingCreationGrpcClient extends RecordingGrpcClient {
-
-        private final int failedAttempt;
-        private final AtomicInteger attempt = new AtomicInteger();
-        private final List<ManagedChannel> createdChannels =
-                Collections.synchronizedList(new ArrayList<>());
-
-        private FailingCreationGrpcClient(int failedAttempt) {
-            this.failedAttempt = failedAttempt;
-        }
-
-        @Override
-        protected ManagedChannel createChannel(String target) {
-            int current = this.attempt.getAndIncrement();
-            if (current == this.failedAttempt) {
-                throw new IllegalStateException("injected channel creation failure");
-            }
-            ManagedChannel channel = this.newFakeChannel(target + "#" + current);
-            this.createdChannels.add(channel);
-            return channel;
-        }
-    }
-
-    private static class DelayedCreationGrpcClient extends RecordingGrpcClient {
-
-        private final CountDownLatch creationStarted =
-                new CountDownLatch(AbstractGrpcClient.concurrency);
-        private final CountDownLatch releaseCreation = new CountDownLatch(1);
-        private final List<ManagedChannel> createdChannels =
-                Collections.synchronizedList(new ArrayList<>());
-
-        @Override
-        protected ManagedChannel createChannel(String target) {
-            this.creationStarted.countDown();
-            try {
-                this.releaseCreation.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new AssertionError(e);
-            }
-            ManagedChannel channel = this.newFakeChannel(target);
+            ManagedChannel channel = new FakeManagedChannel(target + "#" + current);
             this.createdChannels.add(channel);
             return channel;
         }
@@ -688,35 +723,17 @@ public class AbstractGrpcClientTest {
 
     private static class StubInterleavingGrpcClient extends RecordingGrpcClient {
 
-        private final AtomicInteger blockingStubSeq = new AtomicInteger();
-        private final AtomicInteger asyncStubSeq = new AtomicInteger();
-        private final CountDownLatch staleBlockingStubBuildStarted = new CountDownLatch(1);
-        private final CountDownLatch releaseStaleBlockingStubBuild = new CountDownLatch(1);
-        private final CountDownLatch staleAsyncStubBuildStarted = new CountDownLatch(1);
-        private final CountDownLatch releaseStaleAsyncStubBuild = new CountDownLatch(1);
-
-        @Override
-        public AbstractBlockingStub getBlockingStub(ManagedChannel channel) {
-            if (this.blockingStubSeq.incrementAndGet() == 1) {
-                this.staleBlockingStubBuildStarted.countDown();
-                try {
-                    assertTrue("the stale blocking stub build must be released",
-                               this.releaseStaleBlockingStubBuild.await(5, TimeUnit.SECONDS));
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new AssertionError(e);
-                }
-            }
-            return super.getBlockingStub(channel);
-        }
+        private final AtomicInteger stubSeq = new AtomicInteger();
+        private final CountDownLatch staleStubBuildStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseStaleStubBuild = new CountDownLatch(1);
 
         @Override
         public AbstractAsyncStub getAsyncStub(ManagedChannel channel) {
-            if (this.asyncStubSeq.incrementAndGet() == 1) {
-                this.staleAsyncStubBuildStarted.countDown();
+            if (this.stubSeq.incrementAndGet() == 1) {
+                this.staleStubBuildStarted.countDown();
                 try {
-                    assertTrue("the stale async stub build must be released",
-                               this.releaseStaleAsyncStubBuild.await(5, TimeUnit.SECONDS));
+                    assertTrue("the stale stub build must be released",
+                               this.releaseStaleStubBuild.await(5, TimeUnit.SECONDS));
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new AssertionError(e);
@@ -726,31 +743,103 @@ public class AbstractGrpcClientTest {
         }
     }
 
-    private static class HostCapturingGrpcClient extends AbstractGrpcClient {
+    private static class QueryV2TestClient extends QueryV2Client {
 
-        private final AtomicInteger resolutionCount = new AtomicInteger();
-        private volatile String capturedHost;
+        private final AtomicInteger channelSeq = new AtomicInteger();
+        private final AtomicInteger stubSeq = new AtomicInteger();
+        private final CountDownLatch stubBuildStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseStubBuild = new CountDownLatch(1);
+        private volatile String resolvedTarget = "10.0.0.1";
+
+        @Override
+        protected long channelRefreshIntervalNanos() {
+            return 0L;
+        }
+
+        @Override
+        public AbstractAsyncStub<?> getAsyncStub(ManagedChannel channel) {
+            if (this.stubSeq.incrementAndGet() == 1) {
+                this.stubBuildStarted.countDown();
+                try {
+                    assertTrue("the QueryV2 stub build must be released",
+                               this.releaseStubBuild.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            return super.getAsyncStub(channel);
+        }
 
         @Override
         protected ManagedChannel createChannel(String target) {
-            return new FakeManagedChannel(target);
+            return new FakeManagedChannel(target + "#" + this.channelSeq.getAndIncrement());
         }
 
         @Override
-        public AbstractBlockingStub getBlockingStub(ManagedChannel channel) {
-            return new FakeBlockingStub(channel, CallOptions.DEFAULT);
+        protected String resolveTarget(String target) {
+            return this.resolvedTarget;
         }
+    }
 
-        @Override
-        public AbstractAsyncStub getAsyncStub(ManagedChannel channel) {
-            return new FakeAsyncStub(channel, CallOptions.DEFAULT);
+    /**
+     * Resolves through the inherited implementation, optionally reproducing the security check
+     * that InetAddress.getAllByName() performs on whichever thread resolution runs on.
+     */
+    private static class HostCapturingGrpcClient extends RecordingGrpcClient {
+
+        private final AtomicInteger hostResolutionCount = new AtomicInteger();
+        private volatile String capturedHost;
+        private volatile String resolvedAddress = "10.0.0.1";
+        private volatile boolean checkSocketPermission;
+
+        HostCapturingGrpcClient() {
+            this.useRealResolution = true;
         }
 
         @Override
         protected InetAddress[] resolveHost(String host) throws UnknownHostException {
-            this.resolutionCount.incrementAndGet();
+            SecurityManager security = System.getSecurityManager();
+            if (this.checkSocketPermission && security != null) {
+                security.checkConnect(host, -1);
+            }
+            this.hostResolutionCount.incrementAndGet();
             this.capturedHost = host;
-            return new InetAddress[]{InetAddress.getByName("10.0.0.1")};
+            return new InetAddress[]{InetAddress.getByName(this.resolvedAddress)};
+        }
+    }
+
+    /**
+     * Denies a deliberately narrow subset of what HugeSecurityManager denies on a Gremlin worker
+     * stack: the two checks this fix is about, opening sockets and creating threads. Everything
+     * else stays permitted so the test JVM keeps working, including restoring the previous
+     * manager. Keys on the thread name alone, where HugeSecurityManager also requires a Gremlin
+     * script engine frame on the stack. Relies on System.setSecurityManager, which is a no-op
+     * from JDK 18 and removed in JDK 24; this module builds and runs on Java 11.
+     */
+    private static class DenyingWorkerSecurityManager extends SecurityManager {
+
+        private static boolean isDeniedWorker() {
+            return Thread.currentThread().getName().startsWith("gremlin-server-exec");
+        }
+
+        @Override
+        public void checkConnect(String host, int port) {
+            if (isDeniedWorker()) {
+                throw new SecurityException("Not allowed to connect socket via Gremlin");
+            }
+        }
+
+        @Override
+        public void checkAccess(ThreadGroup threadGroup) {
+            if (isDeniedWorker()) {
+                throw new SecurityException("Not allowed to access thread group via Gremlin");
+            }
+        }
+
+        @Override
+        public void checkPermission(java.security.Permission permission) {
+            // Everything else stays permitted, including restoring the previous manager.
         }
     }
 
@@ -782,7 +871,6 @@ public class AbstractGrpcClientTest {
 
         private final String authority;
         private final CountDownLatch activeCallsFinished;
-        private final CountDownLatch awaitTerminationStarted = new CountDownLatch(1);
         private volatile boolean shutdown;
         private volatile boolean forceShutdown;
         private volatile boolean terminated;
@@ -842,27 +930,9 @@ public class AbstractGrpcClientTest {
             return this.terminated;
         }
 
-        boolean awaitTerminationStarted(long timeout, TimeUnit unit)
-                throws InterruptedException {
-            return this.awaitTerminationStarted.await(timeout, unit);
-        }
-
         @Override
-        public boolean awaitTermination(long timeout, TimeUnit unit)
-                throws InterruptedException {
-            this.awaitTerminationStarted.countDown();
-            if (this.terminated) {
-                return true;
-            }
-            if (this.activeCallsFinished == null) {
-                this.terminated = this.shutdown;
-                return this.terminated;
-            }
-            if (this.activeCallsFinished.await(timeout, unit)) {
-                this.terminated = true;
-                return true;
-            }
-            return false;
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return this.isTerminated();
         }
     }
 }

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.net.InetAddress;
@@ -608,7 +609,7 @@ public class AbstractGrpcClientTest {
 
         try {
             client.getChannels(target);
-            assertTrue("channel creation must propagate the injected failure", false);
+            fail("channel creation must propagate the injected failure");
         } catch (RuntimeException ignored) {
             // Expected.
         }
@@ -860,6 +861,45 @@ public class AbstractGrpcClientTest {
     }
 
     @Test
+    public void testInjectedQueryV2ChannelBypassesRefreshRetirement() throws Exception {
+        String target = uniqueTarget("query-v2-injected-channel");
+        FakeManagedChannel injected = new FakeManagedChannel(target);
+        InjectedChannelQueryV2Client client = new InjectedChannelQueryV2Client();
+        QueryV2Client.setTestChannel(injected);
+
+        try {
+            QueryServiceGrpc.QueryServiceStub stub = client.getQueryServiceStub(target);
+            assertSame("the QueryV2 stub must use the injected channel", injected,
+                       stub.getChannel());
+
+            /*
+             * Without the injected-channel resolution guard, the delayed resolution lands after
+             * the first pool is published, rebuilds that pool with the same injected channel,
+             * and retires the channel that the replacement still references.
+             */
+            client.releaseResolution.countDown();
+            awaitCondition("the injected-channel refresh must settle",
+                           () -> refreshIsIdle(client, target));
+            assertFalse("refresh must not retire an injected channel", injected.isShutdown());
+            assertSame("the cached stub must retain the live injected channel", injected,
+                       client.getQueryServiceStub(target).getChannel());
+        } finally {
+            client.releaseResolution.countDown();
+            QueryV2Client.setTestChannel(null);
+        }
+    }
+
+    @Test
+    public void testQueryV2WithoutInjectedChannelUsesDnsResolution() {
+        QueryV2Client.setTestChannel(null);
+        ResolvingQueryV2Client client = new ResolvingQueryV2Client();
+
+        assertEquals("10.0.0.1,10.0.0.2",
+                     client.resolve("store.example.com:8500"));
+        assertEquals("store.example.com", client.capturedHost);
+    }
+
+    @Test
     public void testResolveTargetSupportsDnsUriAndBracketedIpv6Targets() {
         HostCapturingGrpcClient client = new HostCapturingGrpcClient();
         assertEquals("10.0.0.1", client.resolveTarget("store.example.com:8500"));
@@ -877,6 +917,15 @@ public class AbstractGrpcClientTest {
 
         assertEquals("10.0.0.1", client.resolveTarget("[2001:db8::1]:8500"));
         assertEquals("2001:db8::1", client.capturedHost);
+    }
+
+    @Test
+    public void testResolveTargetSortsAndDeduplicatesAddressSet() {
+        HostCapturingGrpcClient client = new HostCapturingGrpcClient();
+        client.resolvedAddresses = new String[]{"10.0.0.2", "10.0.0.1", "10.0.0.2"};
+
+        assertEquals("10.0.0.1,10.0.0.2",
+                     client.resolveTarget("store.example.com:8500"));
     }
 
     @Test
@@ -1019,8 +1068,6 @@ public class AbstractGrpcClientTest {
         private final AtomicInteger attempt = new AtomicInteger();
         private final CountDownLatch creationStarted =
                 new CountDownLatch(AbstractGrpcClient.concurrency);
-        private final List<ManagedChannel> createdChannels =
-                Collections.synchronizedList(new ArrayList<>());
         /** Negative never fails. */
         private volatile int failedAttempt = -1;
         /** Null creates channels without delay. */
@@ -1109,6 +1156,40 @@ public class AbstractGrpcClientTest {
         }
     }
 
+    private static class InjectedChannelQueryV2Client extends QueryV2Client {
+
+        private final CountDownLatch releaseResolution = new CountDownLatch(1);
+
+        @Override
+        protected InetAddress[] resolveHost(String host) throws UnknownHostException {
+            try {
+                assertTrue("the injected-channel resolution must be released",
+                           this.releaseResolution.await(5, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(e);
+            }
+            return new InetAddress[]{InetAddress.getByName("10.0.0.1")};
+        }
+    }
+
+    private static class ResolvingQueryV2Client extends QueryV2Client {
+
+        private volatile String capturedHost;
+
+        private String resolve(String target) {
+            return super.resolveTarget(target);
+        }
+
+        @Override
+        protected InetAddress[] resolveHost(String host) throws UnknownHostException {
+            this.capturedHost = host;
+            return new InetAddress[]{InetAddress.getByName("10.0.0.2"),
+                                     InetAddress.getByName("10.0.0.1"),
+                                     InetAddress.getByName("10.0.0.2")};
+        }
+    }
+
     /**
      * Resolves through the inherited implementation, optionally reproducing the security check
      * that InetAddress.getAllByName() performs on whichever thread resolution runs on.
@@ -1118,6 +1199,7 @@ public class AbstractGrpcClientTest {
         private final AtomicInteger hostResolutionCount = new AtomicInteger();
         private volatile String capturedHost;
         private volatile String resolvedAddress = "10.0.0.1";
+        private volatile String[] resolvedAddresses;
         private volatile boolean checkSocketPermission;
 
         HostCapturingGrpcClient() {
@@ -1132,7 +1214,15 @@ public class AbstractGrpcClientTest {
             }
             this.hostResolutionCount.incrementAndGet();
             this.capturedHost = host;
-            return new InetAddress[]{InetAddress.getByName(this.resolvedAddress)};
+            String[] addresses = this.resolvedAddresses;
+            if (addresses == null) {
+                return new InetAddress[]{InetAddress.getByName(this.resolvedAddress)};
+            }
+            InetAddress[] resolved = new InetAddress[addresses.length];
+            for (int i = 0; i < addresses.length; i++) {
+                resolved[i] = InetAddress.getByName(addresses[i]);
+            }
+            return resolved;
         }
     }
 
@@ -1141,8 +1231,8 @@ public class AbstractGrpcClientTest {
      * stack: the two checks this fix is about, opening sockets and creating threads. Everything
      * else stays permitted so the test JVM keeps working, including restoring the previous
      * manager. Keys on the thread name alone, where HugeSecurityManager also requires a Gremlin
-     * script engine frame on the stack. Relies on System.setSecurityManager, which is a no-op
-     * from JDK 18 and removed in JDK 24; this module builds and runs on Java 11.
+     * script engine frame on the stack. Relies on System.setSecurityManager, whose dynamic use is
+     * restricted from JDK 18 and permanently disabled from JDK 24; this test runs on Java 11.
      */
     private static class DenyingWorkerSecurityManager extends SecurityManager {
 

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
@@ -18,22 +18,29 @@
 package org.apache.hugegraph.store.client.grpc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
+import org.apache.hugegraph.store.term.HgPair;
 import org.junit.Test;
 
 import io.grpc.CallOptions;
@@ -45,7 +52,7 @@ import io.grpc.stub.AbstractAsyncStub;
 import io.grpc.stub.AbstractBlockingStub;
 
 /**
- * Verifies that Store address changes replace channels and their cached stubs safely.
+ * Verifies that Store address changes replace channels and cached stubs safely.
  */
 public class AbstractGrpcClientTest {
 
@@ -60,6 +67,57 @@ public class AbstractGrpcClientTest {
         return Arrays.stream(channels).anyMatch(current -> current == channel);
     }
 
+    private static boolean allChannelsAreShutdown(ManagedChannel[] channels) {
+        return Arrays.stream(channels).allMatch(ManagedChannel::isShutdown);
+    }
+
+    private static boolean allChannelsAreLive(ManagedChannel[] channels) {
+        return Arrays.stream(channels).noneMatch(ManagedChannel::isShutdown);
+    }
+
+    private static List<FakeManagedChannel> fakeChannels(ManagedChannel[] channels) {
+        return Arrays.stream(channels)
+                     .map(channel -> (FakeManagedChannel) channel)
+                     .collect(Collectors.toList());
+    }
+
+    private static void assertUsesEveryChannel(String message,
+                                               List<ManagedChannel> stubChannels,
+                                               ManagedChannel[] channels) {
+        assertEquals(message, channels.length, new HashSet<>(stubChannels).size());
+    }
+
+    private static void assertCachedChannelsCurrentAndLive(String message,
+                                                           List<ManagedChannel> cached,
+                                                           ManagedChannel[] current) {
+        assertEquals(message, current.length, cached.size());
+        assertTrue(message, cached.stream().allMatch(channel ->
+                   belongsToPool(channel, current) && !channel.isShutdown()));
+    }
+
+    private static void awaitCondition(String message, Condition condition) throws Exception {
+        for (int i = 0; i < 500; i++) {
+            if (condition.isTrue()) {
+                return;
+            }
+            Thread.sleep(10L);
+        }
+        assertTrue(message, condition.isTrue());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<ManagedChannel> cachedAsyncStubChannels(AbstractGrpcClient client,
+                                                                String target)
+            throws Exception {
+        Field field = AbstractGrpcClient.class.getDeclaredField("asyncStubs");
+        field.setAccessible(true);
+        Map<String, HgPair<ManagedChannel, AbstractAsyncStub>[]> stubs =
+                (Map<String, HgPair<ManagedChannel, AbstractAsyncStub>[]>) field.get(client);
+        HgPair<ManagedChannel, AbstractAsyncStub>[] pairs = stubs.get(target);
+        assertNotNull("the async stub cache must exist", pairs);
+        return Arrays.stream(pairs).map(HgPair::getKey).collect(Collectors.toList());
+    }
+
     @Test
     public void testAddressChangeReplacesChannelAndStubPools() {
         String target = uniqueTarget("address-change");
@@ -72,8 +130,11 @@ public class AbstractGrpcClientTest {
         ManagedChannel[] newChannels = client.getChannels(target);
         assertNotSame("an address change must replace the channel pool",
                       oldChannels, newChannels);
-        assertTrue("every stale channel must be shut down",
-                   Arrays.stream(oldChannels).allMatch(ManagedChannel::isShutdown));
+        assertTrue("every stale channel must be gracefully shut down",
+                   allChannelsAreShutdown(oldChannels));
+        assertFalse("refresh must not force close stale channels immediately",
+                    fakeChannels(oldChannels).stream()
+                                             .anyMatch(FakeManagedChannel::isForceShutdown));
 
         client.blockingStubChannels.clear();
         client.asyncStubChannels.clear();
@@ -85,12 +146,16 @@ public class AbstractGrpcClientTest {
                    client.blockingStubChannels.stream()
                                               .allMatch(channel ->
                                                         belongsToPool(channel, newChannels)));
+        assertUsesEveryChannel("blocking stubs must be spread across the pool",
+                               client.blockingStubChannels, newChannels);
         assertEquals("the async stub pool must be rebuilt",
                      newChannels.length, client.asyncStubChannels.size());
         assertTrue("replacement async stubs must use the new channel pool",
                    client.asyncStubChannels.stream()
                                            .allMatch(channel ->
                                                      belongsToPool(channel, newChannels)));
+        assertUsesEveryChannel("async stubs must be spread across the pool",
+                               client.asyncStubChannels, newChannels);
     }
 
     @Test
@@ -104,46 +169,112 @@ public class AbstractGrpcClientTest {
         ManagedChannel[] resolvedChannels = client.getChannels(target);
         assertNotSame("a pool with unknown addresses must be replaced",
                       unknownChannels, resolvedChannels);
-        assertTrue("every channel from the unknown pool must be shut down",
-                   Arrays.stream(unknownChannels).allMatch(ManagedChannel::isShutdown));
+        assertTrue("every channel from the unknown pool must be gracefully shut down",
+                   allChannelsAreShutdown(unknownChannels));
+        assertFalse("unknown channels must not be force closed immediately",
+                    fakeChannels(unknownChannels).stream()
+                                                 .anyMatch(FakeManagedChannel::isForceShutdown));
         assertTrue("the resolved channel pool must remain live",
-                   Arrays.stream(resolvedChannels).noneMatch(ManagedChannel::isShutdown));
+                   allChannelsAreLive(resolvedChannels));
     }
 
     @Test
-    public void testOlderResolutionCannotReplaceNewerChannels() throws Exception {
-        String target = uniqueTarget("concurrent-address-change");
-        OutOfOrderResolverGrpcClient client = new OutOfOrderResolverGrpcClient();
+    public void testStubAcquisitionReusesResolutionWithinRefreshInterval() {
+        String target = uniqueTarget("throttled-refresh");
+        CountingResolverGrpcClient client = new CountingResolverGrpcClient();
+        client.refreshIntervalNanos = TimeUnit.HOURS.toNanos(1L);
+
+        assertNotNull(client.getBlockingStub(target));
+        assertNotNull(client.getAsyncStub(target));
+        for (int i = 0; i < 10; i++) {
+            assertNotNull(client.getBlockingStub(target));
+            assertNotNull(client.getAsyncStub(target));
+        }
+
+        assertEquals("stub acquisition must not resolve again inside the refresh interval",
+                     1, client.resolutionCount.get());
+    }
+
+    @Test
+    public void testConcurrentStubAcquisitionRetainsHealthyPoolDuringDelayedRefresh()
+            throws Exception {
+        String target = uniqueTarget("delayed-refresh");
+        DelayedResolverGrpcClient client = new DelayedResolverGrpcClient();
+        client.refreshIntervalNanos = 0L;
         ManagedChannel[] oldChannels = client.getChannels(target);
-        ExecutorService executor = Executors.newFixedThreadPool(2);
+        assertNotNull(client.getBlockingStub(target));
+        int resolutionsBeforeConcurrentCalls = client.resolutionCount.get();
 
+        client.resolvedTarget = "10.0.0.2";
+        client.delayChangedResolution = true;
+        client.refreshIntervalNanos = TimeUnit.HOURS.toNanos(1L);
+
+        ExecutorService executor = Executors.newFixedThreadPool(6);
+        List<Future<AbstractBlockingStub>> futures = new ArrayList<>();
         try {
-            Future<ManagedChannel[]> staleResolution =
-                    executor.submit(() -> client.getChannels(target));
-            assertTrue("the stale resolution must be in flight",
-                       client.staleResolutionStarted.await(5, TimeUnit.SECONDS));
-            Future<ManagedChannel[]> freshResolution =
-                    executor.submit(() -> client.getChannels(target));
-            ManagedChannel[] freshChannels = freshResolution.get(5, TimeUnit.SECONDS);
+            for (int i = 0; i < 6; i++) {
+                futures.add(executor.submit(() -> client.getBlockingStub(target)));
+            }
+            assertTrue("one refresh should be waiting in the delayed resolver",
+                       client.delayedResolutionStarted.await(5, TimeUnit.SECONDS));
+            awaitCondition("callers that miss the refresh lock must keep using the cache",
+                           () -> futures.stream().anyMatch(Future::isDone));
+            assertTrue("the existing healthy pool must stay live during refresh",
+                       allChannelsAreLive(oldChannels));
 
-            assertNotSame("the newer address must replace the old channel pool",
-                          oldChannels, freshChannels);
-            client.releaseStaleResolution.countDown();
-            assertSame("the late stale result must retain the newer channel pool",
-                       freshChannels, staleResolution.get(5, TimeUnit.SECONDS));
-            assertTrue("the replaced channel pool must be shut down",
-                       Arrays.stream(oldChannels).allMatch(ManagedChannel::isShutdown));
-            assertTrue("the newer channel pool must remain live",
-                       Arrays.stream(freshChannels).noneMatch(ManagedChannel::isShutdown));
+            client.releaseDelayedResolution.countDown();
+            for (Future<AbstractBlockingStub> future : futures) {
+                assertNotNull(future.get(5, TimeUnit.SECONDS));
+            }
+
+            ManagedChannel[] currentChannels = client.getChannels(target);
+            assertNotSame("the completed refresh must publish a new channel pool",
+                          oldChannels, currentChannels);
+            assertTrue("the previous pool must be retired after replacement is published",
+                       allChannelsAreShutdown(oldChannels));
+            assertEquals("concurrent callers must share a single refresh resolution",
+                         resolutionsBeforeConcurrentCalls + 1,
+                         client.resolutionCount.get());
         } finally {
-            client.releaseStaleResolution.countDown();
+            client.releaseDelayedResolution.countDown();
             executor.shutdownNow();
         }
     }
 
     @Test
-    public void testStubBuildRetriesAfterChannelRefresh() throws Exception {
-        String target = uniqueTarget("concurrent-stub-refresh");
+    public void testRefreshGracefullyRetiresActiveStreamChannels() throws Exception {
+        String target = uniqueTarget("active-stream-refresh");
+        ActiveRetirementGrpcClient client = new ActiveRetirementGrpcClient();
+        ManagedChannel[] oldChannels = client.getChannels(target);
+        AbstractAsyncStub activeStreamStub = client.getAsyncStub(target);
+        assertTrue("the simulated active stream must be on the old pool",
+                   belongsToPool(activeStreamStub.getChannel(), oldChannels));
+
+        client.resolvedTarget = "10.0.0.2";
+        ManagedChannel[] newChannels = client.getChannels(target);
+        assertNotSame("an address change must publish a replacement pool first",
+                      oldChannels, newChannels);
+        List<FakeManagedChannel> retiredChannels = fakeChannels(oldChannels);
+        assertTrue("the retired pool must receive graceful shutdown",
+                   retiredChannels.stream().allMatch(FakeManagedChannel::isShutdown));
+        assertFalse("active streams must not be force closed immediately",
+                    retiredChannels.stream().anyMatch(FakeManagedChannel::isForceShutdown));
+        assertTrue("retirement should wait for in-flight calls to drain",
+                   retiredChannels.get(0)
+                                  .awaitTerminationStarted(5, TimeUnit.SECONDS));
+
+        client.finishActiveCalls();
+        awaitCondition("retired channels should terminate after active calls finish",
+                       () -> retiredChannels.stream().allMatch(FakeManagedChannel::isTerminated));
+        assertFalse("drained channels must not need forced shutdown",
+                    retiredChannels.stream().anyMatch(FakeManagedChannel::isForceShutdown));
+        assertTrue("the replacement pool must remain live",
+                   allChannelsAreLive(newChannels));
+    }
+
+    @Test
+    public void testBlockingStubBuildRetriesAfterChannelRefresh() throws Exception {
+        String target = uniqueTarget("concurrent-blocking-stub-refresh");
         StubInterleavingGrpcClient client = new StubInterleavingGrpcClient();
         ManagedChannel[] oldChannels = client.getChannels(target);
         ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -151,19 +282,14 @@ public class AbstractGrpcClientTest {
         try {
             Future<AbstractBlockingStub> staleStub =
                     executor.submit(() -> client.getBlockingStub(target));
-            assertTrue("the old stub pool build must be in flight",
-                       client.staleStubBuildStarted.await(5, TimeUnit.SECONDS));
+            assertTrue("the old blocking stub pool build must be in flight",
+                       client.staleBlockingStubBuildStarted.await(5, TimeUnit.SECONDS));
             client.resolvedTarget = "10.0.0.2";
             Future<AbstractBlockingStub> freshStub =
                     executor.submit(() -> client.getBlockingStub(target));
-            for (int i = 0; i < 500 &&
-                            Arrays.stream(oldChannels).anyMatch(channel -> !channel.isShutdown());
-                 i++) {
-                Thread.sleep(10L);
-            }
-            assertTrue("refresh must shut down the old channel pool",
-                       Arrays.stream(oldChannels).allMatch(ManagedChannel::isShutdown));
-            client.releaseStaleStubBuild.countDown();
+            awaitCondition("refresh must retire the old channel pool",
+                           () -> allChannelsAreShutdown(oldChannels));
+            client.releaseStaleBlockingStubBuild.countDown();
 
             AbstractBlockingStub staleResult = staleStub.get(5, TimeUnit.SECONDS);
             AbstractBlockingStub freshResult = freshStub.get(5, TimeUnit.SECONDS);
@@ -173,25 +299,94 @@ public class AbstractGrpcClientTest {
             assertTrue("the concurrent build must use the current pool",
                        belongsToPool(freshResult.getChannel(), currentChannels));
             assertTrue("the current channel pool must remain live",
-                       Arrays.stream(currentChannels).noneMatch(ManagedChannel::isShutdown));
+                       allChannelsAreLive(currentChannels));
         } finally {
-            client.releaseStaleStubBuild.countDown();
+            client.releaseStaleBlockingStubBuild.countDown();
             executor.shutdownNow();
         }
+    }
+
+    @Test
+    public void testAsyncStubBuildRetriesAfterChannelRefresh() throws Exception {
+        String target = uniqueTarget("concurrent-async-stub-refresh");
+        StubInterleavingGrpcClient client = new StubInterleavingGrpcClient();
+        ManagedChannel[] oldChannels = client.getChannels(target);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<AbstractAsyncStub> staleStub =
+                    executor.submit(() -> client.getAsyncStub(target));
+            assertTrue("the old async stub pool build must be in flight",
+                       client.staleAsyncStubBuildStarted.await(5, TimeUnit.SECONDS));
+            client.resolvedTarget = "10.0.0.2";
+            Future<AbstractAsyncStub> freshStub =
+                    executor.submit(() -> client.getAsyncStub(target));
+            awaitCondition("refresh must retire the old channel pool",
+                           () -> allChannelsAreShutdown(oldChannels));
+            client.releaseStaleAsyncStubBuild.countDown();
+
+            AbstractAsyncStub staleResult = staleStub.get(5, TimeUnit.SECONDS);
+            AbstractAsyncStub freshResult = freshStub.get(5, TimeUnit.SECONDS);
+            ManagedChannel[] currentChannels = client.getChannels(target);
+            assertTrue("the stale async build must retry against the current pool",
+                       belongsToPool(staleResult.getChannel(), currentChannels));
+            assertTrue("the concurrent async build must use the current pool",
+                       belongsToPool(freshResult.getChannel(), currentChannels));
+            assertCachedChannelsCurrentAndLive(
+                    "the final async cache must only reference current live channels",
+                    cachedAsyncStubChannels(client, target), currentChannels);
+        } finally {
+            client.releaseStaleAsyncStubBuild.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testResolveTargetSupportsDnsUriAndBracketedIpv6Targets() {
+        HostCapturingGrpcClient dnsClient = new HostCapturingGrpcClient();
+        assertEquals("10.0.0.1", dnsClient.resolveTarget("dns:///store.example.com:8500"));
+        assertEquals("store.example.com", dnsClient.capturedHost);
+
+        HostCapturingGrpcClient ipv6Client = new HostCapturingGrpcClient();
+        assertEquals("10.0.0.1", ipv6Client.resolveTarget("[2001:db8::1]:8500"));
+        assertEquals("2001:db8::1", ipv6Client.capturedHost);
+    }
+
+    @Test
+    public void testResolveTargetSkipsUnsupportedGrpcSchemes() {
+        HostCapturingGrpcClient client = new HostCapturingGrpcClient();
+        assertEquals("", client.resolveTarget("unix:///var/run/store.sock"));
+        assertEquals("unsupported schemes must not invoke DNS resolution",
+                     0, client.resolutionCount.get());
+    }
+
+    private interface Condition {
+
+        boolean isTrue();
     }
 
     private static class RecordingGrpcClient extends AbstractGrpcClient {
 
         private final AtomicInteger channelSeq = new AtomicInteger();
         protected volatile String resolvedTarget = "10.0.0.1";
-        private final List<ManagedChannel> blockingStubChannels =
+        protected volatile long refreshIntervalNanos = 0L;
+        protected final List<ManagedChannel> blockingStubChannels =
                 Collections.synchronizedList(new ArrayList<>());
-        private final List<ManagedChannel> asyncStubChannels =
+        protected final List<ManagedChannel> asyncStubChannels =
                 Collections.synchronizedList(new ArrayList<>());
 
         @Override
+        protected long channelRefreshIntervalNanos() {
+            return this.refreshIntervalNanos;
+        }
+
+        @Override
         protected ManagedChannel createChannel(String target) {
-            return new FakeManagedChannel(target + "#" + this.channelSeq.getAndIncrement());
+            return this.newFakeChannel(target + "#" + this.channelSeq.getAndIncrement());
+        }
+
+        protected FakeManagedChannel newFakeChannel(String authority) {
+            return new FakeManagedChannel(authority);
         }
 
         @Override
@@ -212,52 +407,124 @@ public class AbstractGrpcClientTest {
         }
     }
 
-    private static class OutOfOrderResolverGrpcClient extends RecordingGrpcClient {
+    private static class CountingResolverGrpcClient extends RecordingGrpcClient {
 
-        private final AtomicInteger resolutionSeq = new AtomicInteger();
-        private final CountDownLatch staleResolutionStarted = new CountDownLatch(1);
-        private final CountDownLatch releaseStaleResolution = new CountDownLatch(1);
+        protected final AtomicInteger resolutionCount = new AtomicInteger();
 
         @Override
         protected String resolveTarget(String target) {
-            int sequence = this.resolutionSeq.incrementAndGet();
-            if (sequence == 1) {
-                return "10.0.0.1";
-            }
-            if (sequence == 2) {
-                this.staleResolutionStarted.countDown();
+            this.resolutionCount.incrementAndGet();
+            return super.resolveTarget(target);
+        }
+    }
+
+    private static class DelayedResolverGrpcClient extends CountingResolverGrpcClient {
+
+        private final CountDownLatch delayedResolutionStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseDelayedResolution = new CountDownLatch(1);
+        private volatile boolean delayChangedResolution;
+
+        @Override
+        protected String resolveTarget(String target) {
+            this.resolutionCount.incrementAndGet();
+            if (this.delayChangedResolution) {
+                this.delayedResolutionStarted.countDown();
                 try {
-                    assertTrue("the stale resolution must be released",
-                               this.releaseStaleResolution.await(5, TimeUnit.SECONDS));
+                    assertTrue("the delayed resolution must be released",
+                               this.releaseDelayedResolution.await(5, TimeUnit.SECONDS));
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new AssertionError(e);
                 }
-                return "10.0.0.1";
             }
-            return "10.0.0.2";
+            return this.resolvedTarget;
+        }
+    }
+
+    private static class ActiveRetirementGrpcClient extends RecordingGrpcClient {
+
+        private final CountDownLatch activeCallsFinished = new CountDownLatch(1);
+
+        @Override
+        protected long channelDrainTimeoutNanos() {
+            return TimeUnit.SECONDS.toNanos(5L);
+        }
+
+        @Override
+        protected FakeManagedChannel newFakeChannel(String authority) {
+            return new FakeManagedChannel(authority, this.activeCallsFinished);
+        }
+
+        private void finishActiveCalls() {
+            this.activeCallsFinished.countDown();
         }
     }
 
     private static class StubInterleavingGrpcClient extends RecordingGrpcClient {
 
         private final AtomicInteger blockingStubSeq = new AtomicInteger();
-        private final CountDownLatch staleStubBuildStarted = new CountDownLatch(1);
-        private final CountDownLatch releaseStaleStubBuild = new CountDownLatch(1);
+        private final AtomicInteger asyncStubSeq = new AtomicInteger();
+        private final CountDownLatch staleBlockingStubBuildStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseStaleBlockingStubBuild = new CountDownLatch(1);
+        private final CountDownLatch staleAsyncStubBuildStarted = new CountDownLatch(1);
+        private final CountDownLatch releaseStaleAsyncStubBuild = new CountDownLatch(1);
 
         @Override
         public AbstractBlockingStub getBlockingStub(ManagedChannel channel) {
             if (this.blockingStubSeq.incrementAndGet() == 1) {
-                this.staleStubBuildStarted.countDown();
+                this.staleBlockingStubBuildStarted.countDown();
                 try {
-                    assertTrue("the stale stub build must be released",
-                               this.releaseStaleStubBuild.await(5, TimeUnit.SECONDS));
+                    assertTrue("the stale blocking stub build must be released",
+                               this.releaseStaleBlockingStubBuild.await(5, TimeUnit.SECONDS));
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new AssertionError(e);
                 }
             }
             return super.getBlockingStub(channel);
+        }
+
+        @Override
+        public AbstractAsyncStub getAsyncStub(ManagedChannel channel) {
+            if (this.asyncStubSeq.incrementAndGet() == 1) {
+                this.staleAsyncStubBuildStarted.countDown();
+                try {
+                    assertTrue("the stale async stub build must be released",
+                               this.releaseStaleAsyncStubBuild.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                }
+            }
+            return super.getAsyncStub(channel);
+        }
+    }
+
+    private static class HostCapturingGrpcClient extends AbstractGrpcClient {
+
+        private final AtomicInteger resolutionCount = new AtomicInteger();
+        private volatile String capturedHost;
+
+        @Override
+        protected ManagedChannel createChannel(String target) {
+            return new FakeManagedChannel(target);
+        }
+
+        @Override
+        public AbstractBlockingStub getBlockingStub(ManagedChannel channel) {
+            return new FakeBlockingStub(channel, CallOptions.DEFAULT);
+        }
+
+        @Override
+        public AbstractAsyncStub getAsyncStub(ManagedChannel channel) {
+            return new FakeAsyncStub(channel, CallOptions.DEFAULT);
+        }
+
+        @Override
+        protected InetAddress[] resolveHost(String host) throws UnknownHostException {
+            this.resolutionCount.incrementAndGet();
+            this.capturedHost = host;
+            return new InetAddress[]{InetAddress.getByName("10.0.0.1")};
         }
     }
 
@@ -288,10 +555,19 @@ public class AbstractGrpcClientTest {
     private static class FakeManagedChannel extends ManagedChannel {
 
         private final String authority;
+        private final CountDownLatch activeCallsFinished;
+        private final CountDownLatch awaitTerminationStarted = new CountDownLatch(1);
         private volatile boolean shutdown;
+        private volatile boolean forceShutdown;
+        private volatile boolean terminated;
 
         FakeManagedChannel(String authority) {
+            this(authority, null);
+        }
+
+        FakeManagedChannel(String authority, CountDownLatch activeCallsFinished) {
             this.authority = authority;
+            this.activeCallsFinished = activeCallsFinished;
         }
 
         @Override
@@ -308,12 +584,18 @@ public class AbstractGrpcClientTest {
         @Override
         public ManagedChannel shutdown() {
             this.shutdown = true;
+            if (this.activeCallsFinished == null) {
+                this.terminated = true;
+            }
             return this;
         }
 
         @Override
         public ManagedChannel shutdownNow() {
-            return this.shutdown();
+            this.shutdown = true;
+            this.forceShutdown = true;
+            this.terminated = true;
+            return this;
         }
 
         @Override
@@ -321,14 +603,36 @@ public class AbstractGrpcClientTest {
             return this.shutdown;
         }
 
-        @Override
-        public boolean isTerminated() {
-            return this.shutdown;
+        boolean isForceShutdown() {
+            return this.forceShutdown;
         }
 
         @Override
-        public boolean awaitTermination(long timeout, TimeUnit unit) {
-            return this.shutdown;
+        public boolean isTerminated() {
+            return this.terminated;
+        }
+
+        boolean awaitTerminationStarted(long timeout, TimeUnit unit)
+                throws InterruptedException {
+            return this.awaitTerminationStarted.await(timeout, unit);
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit)
+                throws InterruptedException {
+            this.awaitTerminationStarted.countDown();
+            if (this.terminated) {
+                return true;
+            }
+            if (this.activeCallsFinished == null) {
+                this.terminated = this.shutdown;
+                return this.terminated;
+            }
+            if (this.activeCallsFinished.await(timeout, unit)) {
+                this.terminated = true;
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
+++ b/hugegraph-store/hg-store-test/src/main/java/org/apache/hugegraph/store/client/grpc/AbstractGrpcClientTest.java
@@ -36,8 +36,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.apache.hugegraph.store.term.HgPair;
@@ -118,6 +121,25 @@ public class AbstractGrpcClientTest {
         return Arrays.stream(pairs).map(HgPair::getKey).collect(Collectors.toList());
     }
 
+    @SuppressWarnings("unchecked")
+    private static HgPair<ManagedChannel, AbstractBlockingStub>[] cachedBlockingStubs(
+            AbstractGrpcClient client, String target) throws Exception {
+        Field field = AbstractGrpcClient.class.getDeclaredField("blockingStubs");
+        field.setAccessible(true);
+        Map<String, HgPair<ManagedChannel, AbstractBlockingStub>[]> stubs =
+                (Map<String, HgPair<ManagedChannel, AbstractBlockingStub>[]>) field.get(client);
+        HgPair<ManagedChannel, AbstractBlockingStub>[] pairs = stubs.get(target);
+        assertNotNull("the blocking stub cache must exist", pairs);
+        return pairs;
+    }
+
+    private static ThreadPoolExecutor channelCreationExecutor(AbstractGrpcClient client)
+            throws Exception {
+        Field field = AbstractGrpcClient.class.getDeclaredField("executor");
+        field.setAccessible(true);
+        return (ThreadPoolExecutor) field.get(client);
+    }
+
     @Test
     public void testAddressChangeReplacesChannelAndStubPools() {
         String target = uniqueTarget("address-change");
@@ -176,6 +198,153 @@ public class AbstractGrpcClientTest {
                                                  .anyMatch(FakeManagedChannel::isForceShutdown));
         assertTrue("the resolved channel pool must remain live",
                    allChannelsAreLive(resolvedChannels));
+    }
+
+    @Test
+    public void testRetirementDoesNotBlockWhenCreationExecutorIsSaturated()
+            throws Exception {
+        String target = uniqueTarget("saturated-retirement");
+        ActiveRetirementGrpcClient client = new ActiveRetirementGrpcClient();
+        ManagedChannel[] oldChannels = client.getChannels(target);
+        ThreadPoolExecutor channelExecutor = channelCreationExecutor(client);
+        CountDownLatch workersStarted = new CountDownLatch(AbstractGrpcClient.concurrency);
+        CountDownLatch releaseWorkers = new CountDownLatch(1);
+        ExecutorService caller = Executors.newSingleThreadExecutor();
+
+        try {
+            for (int i = 0; i < AbstractGrpcClient.concurrency; i++) {
+                channelExecutor.execute(() -> {
+                    workersStarted.countDown();
+                    try {
+                        releaseWorkers.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+            }
+            assertTrue("the shared creation executor must be fully occupied",
+                       workersStarted.await(5, TimeUnit.SECONDS));
+
+            client.resolvedTarget = "10.0.0.2";
+            Future<ManagedChannel[]> refreshed =
+                    caller.submit(() -> client.getChannels(target));
+            ManagedChannel[] newChannels = refreshed.get(1, TimeUnit.SECONDS);
+
+            assertNotSame("refresh must publish the replacement pool",
+                          oldChannels, newChannels);
+            assertTrue("the retired pool must be shut down before refresh returns",
+                       allChannelsAreShutdown(oldChannels));
+            assertFalse("the scheduled cleanup must preserve the drain window",
+                        fakeChannels(oldChannels).stream()
+                                                 .anyMatch(FakeManagedChannel::isForceShutdown));
+        } finally {
+            releaseWorkers.countDown();
+            client.finishActiveCalls();
+            caller.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testPartialChannelsAreRetiredAfterMixedCreationFailure()
+            throws Exception {
+        String target = uniqueTarget("partial-creation-failure");
+        FailingCreationGrpcClient client = new FailingCreationGrpcClient(5);
+
+        try {
+            client.getChannels(target);
+            assertTrue("channel creation must propagate the injected failure", false);
+        } catch (RuntimeException ignored) {
+            // Expected.
+        }
+
+        assertEquals("all creation tasks must converge before failure is returned",
+                     AbstractGrpcClient.concurrency - 1, client.createdChannels.size());
+        assertTrue("every partial channel must be force terminated before failure returns",
+                   client.createdChannels.stream().allMatch(channel ->
+                           channel.isTerminated() &&
+                           ((FakeManagedChannel) channel).isForceShutdown()));
+    }
+
+    @Test
+    public void testInterruptedCreationWaitsAndRetiresPartialChannels()
+            throws Exception {
+        String target = uniqueTarget("interrupted-creation");
+        DelayedCreationGrpcClient client = new DelayedCreationGrpcClient();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean interrupted = new AtomicBoolean();
+        Thread caller = new Thread(() -> {
+            try {
+                client.getChannels(target);
+            } catch (Throwable e) {
+                failure.set(e);
+                interrupted.set(Thread.currentThread().isInterrupted());
+            }
+        });
+
+        caller.start();
+        assertTrue("all channel creation tasks must start",
+                   client.creationStarted.await(5, TimeUnit.SECONDS));
+        caller.interrupt();
+        try {
+            Thread.sleep(100L);
+            assertTrue("an interrupted caller must wait for creation tasks to converge",
+                       caller.isAlive());
+        } finally {
+            client.releaseCreation.countDown();
+        }
+        caller.join(TimeUnit.SECONDS.toMillis(5L));
+
+        assertFalse("the interrupted creation call must finish", caller.isAlive());
+        assertTrue("interruption must be reported as a runtime failure",
+                   failure.get() instanceof RuntimeException);
+        assertTrue("the caller interrupt status must be restored", interrupted.get());
+        assertEquals("every creation task must finish before interruption is reported",
+                     AbstractGrpcClient.concurrency, client.createdChannels.size());
+        assertTrue("all partial channels must be force terminated before interruption returns",
+                   client.createdChannels.stream().allMatch(channel ->
+                           channel.isTerminated() &&
+                           ((FakeManagedChannel) channel).isForceShutdown()));
+    }
+
+    @Test
+    public void testDrainDeadlineForceTerminatesRetiredChannels() throws Exception {
+        String target = uniqueTarget("drain-deadline");
+        ImmediateRetirementGrpcClient client = new ImmediateRetirementGrpcClient();
+        ManagedChannel[] oldChannels = client.getChannels(target);
+
+        client.resolvedTarget = "10.0.0.2";
+        ManagedChannel[] newChannels = client.getChannels(target);
+
+        assertNotSame("refresh must publish a replacement pool", oldChannels, newChannels);
+        awaitCondition("expired drain deadline must force terminate the retired pool",
+                       () -> fakeChannels(oldChannels).stream().allMatch(channel ->
+                               channel.isTerminated() && channel.isForceShutdown()));
+        assertTrue("the replacement pool must remain live", allChannelsAreLive(newChannels));
+    }
+
+    @Test
+    public void testStubCacheRequiresIndexIdentityMapping() throws Exception {
+        String target = uniqueTarget("index-mapping");
+        RecordingGrpcClient client = new RecordingGrpcClient();
+        ManagedChannel[] targetChannels = client.getChannels(target);
+        assertNotNull(client.getBlockingStub(target));
+        HgPair<ManagedChannel, AbstractBlockingStub>[] pairs =
+                cachedBlockingStubs(client, target);
+        HgPair<ManagedChannel, AbstractBlockingStub> first = pairs[0];
+        pairs[0] = pairs[1];
+        pairs[1] = first;
+        client.blockingStubChannels.clear();
+
+        assertNotNull(client.getBlockingStub(target));
+
+        assertEquals("a permuted cache must be rebuilt instead of reused",
+                     AbstractGrpcClient.concurrency, client.blockingStubChannels.size());
+        HgPair<ManagedChannel, AbstractBlockingStub>[] rebuilt =
+                cachedBlockingStubs(client, target);
+        for (int i = 0; i < targetChannels.length; i++) {
+            assertTrue("each cached stub must map to the channel at the same index",
+                       rebuilt[i].getKey() == targetChannels[i]);
+        }
     }
 
     @Test
@@ -259,10 +428,6 @@ public class AbstractGrpcClientTest {
                    retiredChannels.stream().allMatch(FakeManagedChannel::isShutdown));
         assertFalse("active streams must not be force closed immediately",
                     retiredChannels.stream().anyMatch(FakeManagedChannel::isForceShutdown));
-        assertTrue("retirement should wait for in-flight calls to drain",
-                   retiredChannels.get(0)
-                                  .awaitTerminationStarted(5, TimeUnit.SECONDS));
-
         client.finishActiveCalls();
         awaitCondition("retired channels should terminate after active calls finish",
                        () -> retiredChannels.stream().allMatch(FakeManagedChannel::isTerminated));
@@ -460,6 +625,67 @@ public class AbstractGrpcClientTest {
         }
     }
 
+    private static class ImmediateRetirementGrpcClient extends RecordingGrpcClient {
+
+        private final CountDownLatch activeCallsFinished = new CountDownLatch(1);
+
+        @Override
+        protected long channelDrainTimeoutNanos() {
+            return 0L;
+        }
+
+        @Override
+        protected FakeManagedChannel newFakeChannel(String authority) {
+            return new FakeManagedChannel(authority, this.activeCallsFinished);
+        }
+    }
+
+    private static class FailingCreationGrpcClient extends RecordingGrpcClient {
+
+        private final int failedAttempt;
+        private final AtomicInteger attempt = new AtomicInteger();
+        private final List<ManagedChannel> createdChannels =
+                Collections.synchronizedList(new ArrayList<>());
+
+        private FailingCreationGrpcClient(int failedAttempt) {
+            this.failedAttempt = failedAttempt;
+        }
+
+        @Override
+        protected ManagedChannel createChannel(String target) {
+            int current = this.attempt.getAndIncrement();
+            if (current == this.failedAttempt) {
+                throw new IllegalStateException("injected channel creation failure");
+            }
+            ManagedChannel channel = this.newFakeChannel(target + "#" + current);
+            this.createdChannels.add(channel);
+            return channel;
+        }
+    }
+
+    private static class DelayedCreationGrpcClient extends RecordingGrpcClient {
+
+        private final CountDownLatch creationStarted =
+                new CountDownLatch(AbstractGrpcClient.concurrency);
+        private final CountDownLatch releaseCreation = new CountDownLatch(1);
+        private final List<ManagedChannel> createdChannels =
+                Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        protected ManagedChannel createChannel(String target) {
+            this.creationStarted.countDown();
+            try {
+                this.releaseCreation.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(e);
+            }
+            ManagedChannel channel = this.newFakeChannel(target);
+            this.createdChannels.add(channel);
+            return channel;
+        }
+    }
+
     private static class StubInterleavingGrpcClient extends RecordingGrpcClient {
 
         private final AtomicInteger blockingStubSeq = new AtomicInteger();
@@ -609,6 +835,10 @@ public class AbstractGrpcClientTest {
 
         @Override
         public boolean isTerminated() {
+            if (this.shutdown && this.activeCallsFinished != null &&
+                this.activeCallsFinished.getCount() == 0L) {
+                this.terminated = true;
+            }
             return this.terminated;
         }
 

--- a/hugegraph-store/pom.xml
+++ b/hugegraph-store/pom.xml
@@ -96,6 +96,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.4</version>


### PR DESCRIPTION
## Purpose of the PR

> Kept in sync with https://github.com/apache/hugegraph/pull/3130

HStore caches gRPC channels and blocking/asynchronous stubs by Store target.
When a stable target resolves to a different address, those pools can retain the
failed transport indefinitely even though the replacement Store is reachable.

This is the channel-lifecycle half of #3124. Complete recovery behind a stable
DNS name still requires the finite positive DNS TTL from #3126; this patch does
not bypass an indefinitely stale JVM DNS cache.

## Main Changes

- Fingerprint each target's sorted, deduplicated resolved address set before
  selecting a channel.
- Throttle refresh checks with a per-target single-flight TTL and explicit
  first-run state, using overflow-safe monotonic deadline comparisons.
- Run DNS resolution and replacement coordination on prestarted maintenance
  threads, with channel construction on the existing common executor, so
  Gremlin request threads keep using the last healthy pool; preserve that pool
  across resolution, submission, creation, and cleanup failures.
- Publish replacement channel pools before retiring old pools; retire old
  channels with `shutdown()` first and use bounded delayed `shutdownNow()` on a
  separate retirement scheduler only if they do not drain.
- Rebuild blocking and asynchronous stub pools when their channels no longer
  belong to the current pool, and spread cached stubs across the channel pool.
- Route QueryV2 through the same guarded asynchronous-stub path rather than
  handing it a raw channel during refresh; keep directly injected test channels
  outside the DNS refresh lifecycle.
- Parse raw `host:port`, `dns:///host:port`, and bracketed IPv6 targets for
  fingerprinting; unsupported resolver schemes are left to gRPC and skipped by
  the DNS fingerprint refresh path.
- Add focused regressions for negative and wrapped `nanoTime()`, executor and
  resolution failures, SecurityManager thread boundaries, retirement
  starvation, active-call draining, guarded QueryV2 publication, injected
  channel lifecycle, normal QueryV2 DNS delegation, and duplicate DNS answers.

## Verifying these changes

- [x] Need tests and can be verified as follows:
  - `JAVA_HOME=$(/usr/libexec/java_home -v 11) mvn test -pl hugegraph-store/hg-store-test -am -Dtest=AbstractGrpcClientTest -Dsurefire.failIfNoSpecifiedTests=false`: all configured Store executions ran 27 tests with 0 failures, errors, or skips on Java 11.
  - `JAVA_HOME=$(/usr/libexec/java_home -v 11) mvn test -pl hugegraph-store/hg-store-test -am -P store-client-test -Dsurefire.failIfNoSpecifiedTests=false`: the Store client execution ran 27 tests with 0 failures, errors, or skips on Java 11; aggregate JaCoCo records the guarded `QueryV2Client` call at line 47 with `mi=0`, `ci=5`, and both lifecycle-guard branches at line 58 with `mb=0`, `cb=2`.
  - `JAVA_HOME=$(/usr/libexec/java_home -v 11) mvn editorconfig:format`: passed across all 38 modules with 0 files changed.
  - `JAVA_HOME=$(/usr/libexec/java_home -v 11) mvn clean compile -Dmaven.javadoc.skip=true`: passed across all 38 reactor modules on Java 11.
  - `git diff --check b026a90a0c526dabe2daac744554be331cf32335`: passed with no output.

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [ ] Modify configurations
- [ ] The public API
- [ ] Other affects
- [x] Nope

## Documentation Status

- [ ] `Doc - TODO`
- [ ] `Doc - Done`
- [x] `Doc - No Need`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 支持普通地址、DNS 地址及 IPv6 目标解析，并自动去重、排序。
  - 后台自动检测地址变化并更新连接池，减少服务切换期间的连接中断。
  - 连接刷新过程中保留健康连接，支持失败重试与并发请求安全切换。
  - 活跃请求可优雅完成；超时连接将被强制终止，提升资源回收可靠性。
- **稳定性改进**
  - 优化查询客户端的连接获取与缓存机制，提升高并发和网络波动场景下的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->