### PR TITLE
feat(docker): add attachable Hubble Compose add-on for the 3-node cluster

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -171,8 +171,10 @@ jobs:
             fi
 
             # The add-on alone must define Hubble and nothing else, join the
-            # shared external network, and need no credentials.
+            # shared external network with its default name, and need no
+            # credentials or overrides.
             env -u HUGEGRAPH_ADMIN_PASSWORD -u HUGEGRAPH_AUTH_TOKEN_SECRET \
+                -u HUGEGRAPH_NETWORK -u HUGEGRAPH_VERSION \
               docker compose -f "$addon" config --format json > "$rendered"
             jq -e '
                 (.services | keys) == ["hubble"] and
@@ -186,15 +188,24 @@ jobs:
 
             # The combined render carries the PD-registration and auth
             # settings on every server replica and keeps Hubble on loopback.
+            # Rendered with non-default HUGEGRAPH_NETWORK/HUGEGRAPH_VERSION so
+            # CI fails if any file stops honoring the overrides (the add-on
+            # render above covers the defaults).
             HUGEGRAPH_ADMIN_PASSWORD=ci-test-password \
             HUGEGRAPH_AUTH_TOKEN_SECRET=ci-test-secret \
+            HUGEGRAPH_NETWORK=ci-test-net \
+            HUGEGRAPH_VERSION=ci-test-tag \
               docker compose -f "$cluster" -f "$addon" \
                 config --format json > "$rendered"
             jq -e '
                 .name == "hugegraph-3x3" and
                 (.services | keys | length) == 10 and
                 .networks."hg-net".external == true and
-                .networks."hg-net".name == "hugegraph-net" and
+                .networks."hg-net".name == "ci-test-net" and
+                .services.pd0.image == "hugegraph/pd:ci-test-tag" and
+                .services.store0.image == "hugegraph/store:ci-test-tag" and
+                .services.server0.image == "hugegraph/server:ci-test-tag" and
+                .services.hubble.image == "hugegraph/hubble:ci-test-tag" and
                 .services.server0.environment.HG_SERVER_USE_PD == "true" and
                 .services.server0.environment.HG_SERVER_CLUSTER == "hg" and
                 .services.server0.environment.HG_SERVER_REST_URL ==

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -138,6 +138,96 @@ jobs:
           check_compose docker/docker-compose.yml always always
           check_compose docker/docker-compose.dev.yml build missing
 
+          check_cluster_compose() {
+            local cluster="docker/docker-compose-3pd-3store-3server.yml"
+            local addon="docker/docker-compose-hubble.yml"
+            local rendered
+            rendered="$(mktemp)"
+
+            # Both cluster credentials are required and may not be empty.
+            if HUGEGRAPH_AUTH_TOKEN_SECRET=ci-test-secret \
+                 env -u HUGEGRAPH_ADMIN_PASSWORD \
+                 docker compose -f "$cluster" config -q >/dev/null 2>&1; then
+              echo "$cluster accepted an unset admin password" >&2
+              return 1
+            fi
+            if HUGEGRAPH_ADMIN_PASSWORD= \
+                 HUGEGRAPH_AUTH_TOKEN_SECRET=ci-test-secret \
+                 docker compose -f "$cluster" config -q >/dev/null 2>&1; then
+              echo "$cluster accepted an empty admin password" >&2
+              return 1
+            fi
+            if HUGEGRAPH_ADMIN_PASSWORD=ci-test-password \
+                 env -u HUGEGRAPH_AUTH_TOKEN_SECRET \
+                 docker compose -f "$cluster" config -q >/dev/null 2>&1; then
+              echo "$cluster accepted an unset token secret" >&2
+              return 1
+            fi
+            if HUGEGRAPH_ADMIN_PASSWORD=ci-test-password \
+                 HUGEGRAPH_AUTH_TOKEN_SECRET= \
+                 docker compose -f "$cluster" config -q >/dev/null 2>&1; then
+              echo "$cluster accepted an empty token secret" >&2
+              return 1
+            fi
+
+            # The add-on alone must define Hubble and nothing else, join the
+            # shared external network, and need no credentials.
+            env -u HUGEGRAPH_ADMIN_PASSWORD -u HUGEGRAPH_AUTH_TOKEN_SECRET \
+              docker compose -f "$addon" config --format json > "$rendered"
+            jq -e '
+                (.services | keys) == ["hubble"] and
+                .networks."hg-net".external == true and
+                .networks."hg-net".name == "hugegraph-net" and
+                (.services.hubble | has("depends_on") | not) and
+                any(.services.hubble.volumes[];
+                    .target == "/hubble/conf/hugegraph-hubble.properties" and
+                    (.source | endswith("hugegraph-hubble-3x3.properties")))
+              ' "$rendered" >/dev/null
+
+            # The combined render carries the PD-registration and auth
+            # settings on every server replica and keeps Hubble on loopback.
+            HUGEGRAPH_ADMIN_PASSWORD=ci-test-password \
+            HUGEGRAPH_AUTH_TOKEN_SECRET=ci-test-secret \
+              docker compose -f "$cluster" -f "$addon" \
+                config --format json > "$rendered"
+            jq -e '
+                .name == "hugegraph-3x3" and
+                (.services | keys | length) == 10 and
+                .networks."hg-net".external == true and
+                .networks."hg-net".name == "hugegraph-net" and
+                .services.server0.environment.HG_SERVER_USE_PD == "true" and
+                .services.server0.environment.HG_SERVER_CLUSTER == "hg" and
+                .services.server0.environment.HG_SERVER_REST_URL ==
+                  "http://server0:8080" and
+                .services.server1.environment.HG_SERVER_REST_URL ==
+                  "http://server1:8080" and
+                .services.server1.environment.HG_SERVER_AUTH_TOKEN_SECRET ==
+                  "ci-test-secret" and
+                .services.server2.environment.HG_SERVER_REST_URL ==
+                  "http://server2:8080" and
+                .services.server2.environment.HG_SERVER_AUTH_TOKEN_SECRET ==
+                  "ci-test-secret" and
+                .services.server0.environment.HG_SERVER_INIT_STORE_ENABLED ==
+                  "false" and
+                .services.server0.environment.PASSWORD ==
+                  "ci-test-password" and
+                .services.server0.environment.HG_SERVER_AUTH_TOKEN_SECRET ==
+                  "ci-test-secret" and
+                (.services.hubble | has("depends_on") | not) and
+                .services.hubble.pull_policy == "missing" and
+                (.services.hubble.healthcheck.test[1] |
+                  contains("http://127.0.0.1:8088/about") and
+                  contains("\"status\":200") and
+                  contains("\"name\":\"hugegraph-hubble\"")) and
+                any(.services.hubble.ports[];
+                    .target == 8088 and .published == "8088" and
+                    .host_ip == "127.0.0.1")
+              ' "$rendered" >/dev/null
+            rm -f "$rendered"
+          }
+
+          check_cluster_compose
+
       - name: Run check_port unit tests
         if: ${{ env.BACKEND == 'rocksdb' }}
         run: |

--- a/.serena/memories/implementation_patterns_and_guidelines.md
+++ b/.serena/memories/implementation_patterns_and_guidelines.md
@@ -40,7 +40,8 @@
 
 ## Docker
 - Single-node: `docker/docker-compose.yml` (bridge network, pd+store+server)
-- Cluster: `docker/docker-compose-3pd-3store-3server.yml`
+- Cluster: `docker/docker-compose-3pd-3store-3server.yml` (external `hugegraph-net` network + `docker/.env` credentials)
+- Hubble add-on for the cluster: `docker/docker-compose-hubble.yml`
 - Container logs: stdout-based
 
 ## CI Pipelines

--- a/.serena/memories/key_file_locations.md
+++ b/.serena/memories/key_file_locations.md
@@ -17,7 +17,8 @@
 
 ## Docker
 - `docker/docker-compose.yml` — Single-node (bridge network, pd+store+server)
-- `docker/docker-compose-3pd-3store-3server.yml` — 3-node cluster
+- `docker/docker-compose-3pd-3store-3server.yml` — 3-node cluster (external `hugegraph-net` network, credentials required)
+- `docker/docker-compose-hubble.yml` — Hubble add-on for the 3-node cluster
 - `docker/docker-compose.dev.yml` — Dev mode
 
 ## PD Module

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -47,7 +47,11 @@ bin/enable-auth.sh                            # Enable auth
 ## Docker
 ```bash
 cd docker && docker compose up -d                                          # Single-node (bridge network)
-cd docker && docker compose -f docker-compose-3pd-3store-3server.yml up -d # Cluster
+# Cluster: needs one-time setup first (hugegraph-net network + docker/.env
+# credentials) — see docker/README.md "3-Node Cluster Quickstart"
+cd docker && docker compose -f docker-compose-3pd-3store-3server.yml up -d
+# Hubble add-on for a running cluster
+cd docker && docker compose -p hugegraph-hubble -f docker-compose-hubble.yml up -d
 ```
 
 ## Distributed Build (BETA)

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ For advanced Docker configurations, see:
 * [Docker README](./docker/README.md)
 * [Server Docker README](hugegraph-server/hugegraph-dist/docker/README.md)
 
-> **Docker Desktop (Mac/Windows)**: The 3-node distributed cluster (`docker/docker-compose-3pd-3store-3server.yml`) uses Docker bridge networking and works on all platforms including Docker Desktop. Allocate at least 12 GB memory to Docker Desktop.
+> **Docker Desktop (Mac/Windows)**: The 3-node distributed cluster (`docker/docker-compose-3pd-3store-3server.yml`) joins a pre-created external Docker network shared with the Hubble add-on (see the [Docker README](./docker/README.md) quickstart) and works on all platforms including Docker Desktop. Allocate at least 12 GB memory to Docker Desktop.
 
 > **Note**: Docker images are convenience releases, not **official ASF distribution artifacts**. See [ASF Release Distribution Policy](https://infra.apache.org/release-distribution.html#dockerhub) for details.
 >

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,22 +1,27 @@
 # HugeGraph Docker Deployment
 
-This directory contains Docker Compose files for running HugeGraph:
+This directory contains Docker Compose files and their configuration for
+running HugeGraph:
 
 | File | Description |
 |------|-------------|
 | `docker-compose.yml` | PD, Store, Server, and Hubble using pre-built images |
 | `docker-compose.dev.yml` | PD, Store, and Server built from source, plus Hubble |
 | `docker-compose-3pd-3store-3server.yml` | 3-node distributed cluster (PD + Store + Server) |
+| `docker-compose-hubble.yml` | Hubble add-on for the 3-node cluster (attachable to a running cluster) |
+| `hugegraph-hubble.properties` | Hubble configuration mounted by the single-node files |
+| `hugegraph-hubble-3x3.properties` | Hubble configuration mounted by the add-on; edit when attaching to a cluster with different hostnames |
 
 ## Prerequisites
 
 - **Docker Engine** 20.10+ (or Docker Desktop 4.x+)
 - **Docker Compose** v2 (included in Docker Desktop)
 - **OpenSSL CLI** (used to generate the initial administrator password)
-- **Memory**: Allocate at least **12 GB** to Docker Desktop (Settings → Resources → Memory). The 3-node cluster runs 9 JVM processes (3 PD + 3 Store + 3 Server) which are memory-intensive. Insufficient memory causes OOM kills that appear as silent Raft failures.
+- **Memory**: Allocate at least **12 GB** to Docker Desktop (Settings → Resources → Memory). The 3-node cluster runs 9 JVM processes (3 PD + 3 Store + 3 Server) which are memory-intensive — plus a tenth container when the Hubble add-on is attached. Insufficient memory causes OOM kills that appear as silent Raft failures.
 
 > [!IMPORTANT]
 > The 12 GB minimum is for Docker Desktop. On Linux with native Docker, ensure the host has at least 12 GB of free memory.
+
 ---
 
 ## Single-Node Setup
@@ -168,13 +173,86 @@ To validate local images without Compose replacing them with remote `latest`:
 
 ## 3-Node Cluster Quickstart
 
+The cluster and the Hubble add-on share one named Docker network so Hubble
+can attach to a running cluster without touching it. Treat that network as a
+trust boundary: PD and Store expose unauthenticated control APIs on it (only
+the Server layer authenticates), and any container on the host can join it
+by declaring the well-known name. One-time setup: write the required
+credentials to a mode-600 `docker/.env` and create the network.
+The cluster file requires both credentials — the admin password enables
+authentication, and every Server replica must share one token secret so a
+token issued by any server validates on all of them. The `:?` guards fire
+on every Compose subcommand, including `down`.
+
+```bash
+(
+  set -eu
+  cd docker
+  command -v openssl >/dev/null 2>&1 || { echo "openssl not found" >&2; exit 1; }
+  [ -e .env ] || install -m 600 /dev/null .env
+  chmod 600 .env
+  # Keep appends on their own lines even if the file was hand-edited.
+  [ ! -s .env ] || [ -z "$(tail -c1 .env)" ] || printf '\n' >> .env
+  pat='^[[:space:]]*(export[[:space:]]+)?'
+  if ! grep -Eq "${pat}HUGEGRAPH_ADMIN_PASSWORD=" .env; then
+    admin_password="$(openssl rand -base64 12)"
+    printf "HUGEGRAPH_ADMIN_PASSWORD='%s'\n" "${admin_password}" >> .env
+    unset admin_password
+  fi
+  if ! grep -Eq "${pat}HUGEGRAPH_AUTH_TOKEN_SECRET=" .env; then
+    token_secret="$(openssl rand -hex 32)"
+    printf "HUGEGRAPH_AUTH_TOKEN_SECRET='%s'\n" "${token_secret}" >> .env
+    unset token_secret
+  fi
+  # The shared cluster network. To override the name, export
+  # HUGEGRAPH_NETWORK in this shell before running the block — a value
+  # in docker/.env is read by Compose, not by this script.
+  net="${HUGEGRAPH_NETWORK:-hugegraph-net}"
+  docker network inspect "${net}" >/dev/null 2>&1 ||
+    docker network create "${net}"
+  env -u HUGEGRAPH_ADMIN_PASSWORD -u HUGEGRAPH_AUTH_TOKEN_SECRET \
+    docker compose -f docker-compose-3pd-3store-3server.yml config --quiet
+)
+```
+
+Then start the cluster:
+
 ```bash
 cd docker
-HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
+docker compose -f docker-compose-3pd-3store-3server.yml up -d
 
-# To stop and remove all data volumes (clean restart)
+# To stop and remove all data volumes (clean restart).
+# The external hugegraph-net network is intentionally left in place.
+# If the Hubble add-on is running, see "Hubble for the 3-Node Cluster"
+# for the teardown that matches how it was started.
 docker compose -f docker-compose-3pd-3store-3server.yml down -v
 ```
+
+Pin a release by setting `HUGEGRAPH_VERSION` in `docker/.env` — the
+cluster, the Hubble add-on, and the single-node quickstart file all read
+it from there, so those versions cannot drift apart
+(`docker-compose.dev.yml` builds PD/Store/Server from source and defaults
+Hubble to `hugegraph/hubble:latest`; set `HUBBLE_IMAGE` to pin it).
+Unpinned, the images default to `latest`; note the authenticated PD/Hubble
+integration requires a release newer than `1.7.x`. Because the cluster
+files use `pull_policy: missing`, an already-pulled `latest` is never
+refreshed by `up -d` — pull explicitly or pin to pick up new releases.
+
+> [!NOTE]
+> Upgrading an existing 3-node deployment:
+> - Create `docker/.env` (block above) before running any Compose command
+>   against an older stack, `down` included.
+> - The cluster now joins the pre-created `hugegraph-net` network instead of
+>   a per-project bridge, so the first `up -d` recreates all nine containers.
+>   Named data volumes are unchanged and survive the move; the orphaned
+>   `hugegraph-3x3_hg-net` bridge can be removed with
+>   `docker network rm hugegraph-3x3_hg-net`.
+> - Authentication is now enabled: previously unauthenticated clients of the
+>   graph APIs on ports 8080–8082 will start receiving 401 responses and
+>   must supply the `admin` credential from `docker/.env` (`/versions` and
+>   `/openapi.json` stay open, so they cannot serve as an auth smoke test).
+>   On a cluster whose volumes predate authentication, verify you can sign
+>   in before decommissioning any existing access path.
 
 **Startup ordering** is enforced via `depends_on` with `condition: service_healthy`:
 
@@ -201,6 +279,110 @@ curl http://localhost:8620/v1/stores
 
 # List partitions
 curl http://localhost:8620/v1/partitions
+```
+
+---
+
+## Hubble for the 3-Node Cluster
+
+`docker-compose-hubble.yml` defines only the Hubble service. It joins the
+cluster's external network (`hugegraph-net` by default, override with
+`HUGEGRAPH_NETWORK`) and has no `depends_on` on cluster services, so
+starting, stopping, or upgrading Hubble never recreates or restarts PD,
+Store, or Server containers. Hubble reads the cluster topology from
+`hugegraph-hubble-3x3.properties`; adjust that file when attaching to a
+cluster with different hostnames.
+
+Sign in at `http://localhost:8088` as `admin` with the
+`HUGEGRAPH_ADMIN_PASSWORD` from `docker/.env`. Hubble binds to host
+loopback by default (`HUBBLE_PUBLISH_HOST`, same caveats as the
+single-node setup).
+
+The two flows below create Hubble in different Compose projects, so manage
+Hubble with the same flags you started it with: the attach flow always uses
+`-p hugegraph-hubble -f docker-compose-hubble.yml`, the combined flow always
+uses both `-f` flags. The explicit `-p` keeps the attach project independent
+of the directory name and of other Compose projects.
+
+Run one Hubble per host: the single-node stack and both add-on flows all
+publish `127.0.0.1:8088` and name their container `hg-hubble`. The two
+add-on flows are therefore mutually exclusive — starting one while the
+other's Hubble exists fails with a container-name conflict, so `down` the
+flow you are leaving before switching.
+
+### Attach to a running cluster
+
+With the 3-node cluster already up:
+
+```bash
+cd docker
+docker compose -p hugegraph-hubble -f docker-compose-hubble.yml up -d
+```
+
+Lifecycle commands in this flow operate on Hubble alone and leave the
+cluster and the external network in place:
+
+```bash
+cd docker
+docker compose -p hugegraph-hubble -f docker-compose-hubble.yml ps
+docker compose -p hugegraph-hubble -f docker-compose-hubble.yml down
+```
+
+To remove everything in this flow, take down Hubble first, then the cluster:
+
+```bash
+cd docker
+docker compose -p hugegraph-hubble -f docker-compose-hubble.yml down
+docker compose -f docker-compose-3pd-3store-3server.yml down -v
+```
+
+### Fresh cluster plus Hubble in one command
+
+After the one-time network and `docker/.env` setup from the quickstart:
+
+```bash
+cd docker
+docker compose -f docker-compose-3pd-3store-3server.yml \
+               -f docker-compose-hubble.yml up -d
+```
+
+Hubble has no startup dependency on the cluster, so it reports healthy while
+PD, Store, and Server are still forming the cluster; wait until every service
+shows healthy before signing in:
+
+```bash
+cd docker
+docker compose -f docker-compose-3pd-3store-3server.yml \
+               -f docker-compose-hubble.yml ps
+```
+
+In this flow Hubble belongs to the cluster project — use the same pair of
+`-f` flags for `ps`, `stop`, and `down`. The attach-flow `ps`/`stop`/`down`
+commands manage a different, empty project and do nothing here, and the
+cluster-only quickstart commands treat this Hubble as an orphan container
+(`--remove-orphans` would delete it) — always pass both `-f` flags.
+
+### Local Hubble image for development
+
+Build the Hubble image from `hugegraph-toolchain` source, then replace only
+the Hubble container. In the attach flow:
+
+```bash
+cd docker
+HUBBLE_IMAGE=local/hugegraph-hubble:dev \
+HUBBLE_PULL_POLICY=never \
+docker compose -p hugegraph-hubble -f docker-compose-hubble.yml up -d
+```
+
+If the stack was started with the combined command, replace only the
+`hubble` service under that project instead:
+
+```bash
+cd docker
+HUBBLE_IMAGE=local/hugegraph-hubble:dev \
+HUBBLE_PULL_POLICY=never \
+docker compose -f docker-compose-3pd-3store-3server.yml \
+               -f docker-compose-hubble.yml up -d --no-deps hubble
 ```
 
 ---
@@ -256,7 +438,7 @@ Configuration is injected via environment variables. The old `docker/configs/app
 |----------|----------|---------|-----------------------------|-------------|
 | `HG_SERVER_BACKEND` | Yes | — | `backend` in `hugegraph.properties` | Storage backend (e.g. `hstore`) |
 | `HG_SERVER_PD_PEERS` | Yes | — | `pd.peers` | PD cluster addresses (e.g. `pd0:8686,pd1:8686,pd2:8686`) |
-| `HG_SERVER_CLUSTER` | No | — | `cluster` in `rest-server.properties` | PD discovery application name; single-node Compose uses `hg` to match Hubble |
+| `HG_SERVER_CLUSTER` | No | — | `cluster` in `rest-server.properties` | PD discovery application name; both the single-node and 3-node Compose files use `hg` to match the Hubble configuration |
 | `HG_SERVER_USE_PD` | No | — | `usePD` in `rest-server.properties` | Enables Server PD registration and discovery |
 | `HG_SERVER_REST_URL` | No | — | `restserver.url` | Address registered with PD and used by clients |
 | `HG_SERVER_MIN_FREE_MEMORY` | No | — | `restserver.min_free_memory` | Minimum free-memory guard in MB; local Compose uses `0` |
@@ -287,17 +469,22 @@ Configuration is injected via environment variables. The old `docker/configs/app
 > PD startup path uses the explicit `auth.admin_pa` value when it first creates
 > the administrator. Changing it later does not rotate an existing password.
 
-The single-node Compose files also accept these deployment-level overrides:
+The Compose files also accept these deployment-level overrides; the
+"Used by" column names the files that read each variable (single = the
+single-node files, cluster = `docker-compose-3pd-3store-3server.yml`,
+add-on = `docker-compose-hubble.yml`):
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `HUGEGRAPH_SERVER_IMAGE` | `hugegraph/server:<version>` | Complete Server image reference |
-| `HUGEGRAPH_SERVER_PULL_POLICY` | `always` (`build` for dev) | Server pull policy |
-| `HUBBLE_IMAGE` | `hugegraph/hubble:<version>` | Complete Hubble image reference |
-| `HUBBLE_PULL_POLICY` | `always` (`missing` for dev) | Hubble pull policy |
-| `HUBBLE_PUBLISH_HOST` | `127.0.0.1` | Hubble host bind address; remote access requires an HTTPS reverse proxy |
-| `HUGEGRAPH_ADMIN_PASSWORD` | required (`docker/.env`) | Initial admin password; no public default is provided |
-| `HUGEGRAPH_AUTH_TOKEN_SECRET` | generated | JWT signing secret; explicit values must be at least 32 bytes |
+| Variable | Used by | Default | Description |
+|----------|---------|---------|-------------|
+| `HUGEGRAPH_VERSION` | single (quickstart), cluster, add-on | `latest` | Shared image tag for PD, Store, Server, and Hubble; pin it in `docker/.env` so these files resolve the same release. The dev file builds from source and defaults Hubble to `latest`; set `HUBBLE_IMAGE` to pin it |
+| `HUGEGRAPH_SERVER_IMAGE` | single | `hugegraph/server:<version>` | Complete Server image reference |
+| `HUGEGRAPH_SERVER_PULL_POLICY` | single | `always` (`build` for dev) | Server pull policy |
+| `HUBBLE_IMAGE` | single, add-on | `hugegraph/hubble:<version>` | Complete Hubble image reference |
+| `HUBBLE_PULL_POLICY` | single, add-on | `always` (`missing` for dev and the add-on) | Hubble pull policy |
+| `HUBBLE_PUBLISH_HOST` | single, add-on | `127.0.0.1` | Hubble host bind address; remote access requires an HTTPS reverse proxy |
+| `HUGEGRAPH_NETWORK` | cluster, add-on | `hugegraph-net` | Pre-created external Docker network shared by the 3-node cluster and the Hubble add-on; the single-node files use their own project bridge instead |
+| `HUGEGRAPH_ADMIN_PASSWORD` | single, cluster | required (`docker/.env`) | Initial admin password; no public default is provided |
+| `HUGEGRAPH_AUTH_TOKEN_SECRET` | single, cluster | generated (single); **required** (cluster) | JWT signing secret; explicit values must be at least 32 bytes. The cluster file requires it so all Server replicas validate each other's tokens |
 
 When authentication is enabled and no token secret is supplied, the Server
 entrypoint generates a random secret and writes it to both authentication
@@ -362,7 +549,16 @@ configuration file.
 
 ## Port Reference
 
-The table below reflects the published host ports in `docker-compose-3pd-3store-3server.yml`.
+The table below reflects the published host ports of the 3-node cluster
+(`docker-compose-3pd-3store-3server.yml`) and its Hubble add-on
+(`docker-compose-hubble.yml`).
+
+> [!IMPORTANT]
+> Cluster ports bind all host interfaces and bypass host firewalls under
+> Docker's port publishing; the PD and Store APIs among them are
+> unauthenticated. Do not run this file on an untrusted network. Hubble is
+> the exception and binds loopback only by default.
+
 The single-node Compose file publishes `8620`, `8520`, `8080`, and Hubble
 `8088`; Hubble defaults to host loopback.
 
@@ -387,6 +583,7 @@ The single-node Compose file publishes `8620`, `8520`, `8080`, and Hubble
 | server0 | 8080 | 8080 | HTTP | Graph API |
 | server1 | 8080 | 8081 | HTTP | Graph API |
 | server2 | 8080 | 8082 | HTTP | Graph API |
+| hubble | 8088 | 8088 | HTTP | Hubble UI; loopback-only by default (`HUBBLE_PUBLISH_HOST`) |
 
 ---
 
@@ -402,6 +599,19 @@ The single-node Compose file publishes `8620`, `8520`, `8080`, and Hubble
 ---
 
 ## Troubleshooting
+
+### `network hugegraph-net declared as external, but could not be found`
+
+**Symptom**: 3-node cluster or Hubble add-on commands that create
+containers (`up`, `run`, `create`) fail immediately with this error, with
+the resolved network name in the message. `config` and `ps` do not check
+the network, so they can succeed while `up` fails.
+
+**Cause**: The shared cluster network does not exist yet. It is declared
+`external`, so Compose never creates it on its own.
+
+**Fix**: `docker network create hugegraph-net` (or the name you set via
+`HUGEGRAPH_NETWORK`), then re-run the command.
 
 ### Containers Exiting or Restarting (OOM Kills)
 
@@ -445,6 +655,6 @@ docker stats --no-stream
 
 **Symptom**: Stores cannot connect to PD, or Server cannot connect to Store.
 
-**Cause**: Services are using `127.0.0.1` instead of container hostnames, or the `hg-net` bridge network is misconfigured.
+**Cause**: Services are using `127.0.0.1` instead of container hostnames, or containers are attached to different Docker networks (the cluster and the Hubble add-on must share the pre-created `hugegraph-net`).
 
 **Fix**: Ensure all `HG_*` env vars use container hostnames (`pd0`, `store0`, etc.), not `127.0.0.1` or `localhost`.

--- a/docker/docker-compose-3pd-3store-3server.yml
+++ b/docker/docker-compose-3pd-3store-3server.yml
@@ -17,9 +17,14 @@
 
 name: hugegraph-3x3
 
+# The cluster network is shared with the Hubble add-on
+# (docker-compose-hubble.yml), so it is external and must exist first:
+#   docker network create hugegraph-net
+# Set HUGEGRAPH_NETWORK to use a differently named network.
 networks:
   hg-net:
-    driver: bridge
+    external: true
+    name: ${HUGEGRAPH_NETWORK:-hugegraph-net}
 
 volumes:
   hg-pd0-data:
@@ -31,6 +36,8 @@ volumes:
 
 # ── Shared service defaults ──────────────────────────────────────────
 x-pd-common: &pd-common
+  # Pin a release via HUGEGRAPH_VERSION in docker/.env; unset, the image
+  # tags default to latest. All Compose files here read the same variable.
   image: hugegraph/pd:${HUGEGRAPH_VERSION:-latest}
   pull_policy: missing
   restart: unless-stopped
@@ -58,6 +65,24 @@ x-store-common: &store-common
     retries: 40
     start_period: 120s
 
+# Shared Server environment; each server node adds its own
+# HG_SERVER_REST_URL on top of this map.
+x-server-env: &server-env
+  STORE_REST: store0:8520
+  HG_SERVER_BACKEND: hstore
+  HG_SERVER_PD_PEERS: pd0:8686,pd1:8686,pd2:8686
+  # Register every Server replica with PD under one application name so
+  # PD-aware clients such as Hubble discover the cluster as one logical
+  # Server; `hg` matches the Hubble configuration.
+  HG_SERVER_CLUSTER: hg
+  HG_SERVER_USE_PD: "true"
+  HG_SERVER_MIN_FREE_MEMORY: "0"
+  HG_SERVER_INIT_STORE_ENABLED: "false"
+  # All replicas must share one token secret so a token issued by any
+  # server validates on every other server.
+  HG_SERVER_AUTH_TOKEN_SECRET: ${HUGEGRAPH_AUTH_TOKEN_SECRET:?Set a shared auth token secret}
+  PASSWORD: ${HUGEGRAPH_ADMIN_PASSWORD:?Set a non-default admin password}
+
 x-server-common: &server-common
   image: hugegraph/server:${HUGEGRAPH_VERSION:-latest}
   pull_policy: missing
@@ -67,12 +92,10 @@ x-server-common: &server-common
     store0: { condition: service_healthy }
     store1: { condition: service_healthy }
     store2: { condition: service_healthy }
-  environment:
-    STORE_REST: store0:8520
-    HG_SERVER_BACKEND: hstore
-    HG_SERVER_PD_PEERS: pd0:8686,pd1:8686,pd2:8686
   healthcheck:
-    test: ["CMD-SHELL", "curl -fsS http://localhost:8080/versions >/dev/null || exit 1"]
+    # With HG_SERVER_REST_URL set, the REST server binds that URL's
+    # hostname rather than localhost, so probe the bound address.
+    test: ["CMD-SHELL", "curl -fsS $${HG_SERVER_REST_URL}/versions >/dev/null || exit 1"]
     interval: 10s
     timeout: 5s
     retries: 30
@@ -86,7 +109,6 @@ services:
     <<: *pd-common
     container_name: hg-pd0
     hostname: pd0
-    networks: [ hg-net ]
     environment:
       HG_PD_GRPC_HOST: pd0
       HG_PD_GRPC_PORT: "8686"
@@ -104,7 +126,6 @@ services:
     <<: *pd-common
     container_name: hg-pd1
     hostname: pd1
-    networks: [ hg-net ]
     environment:
       HG_PD_GRPC_HOST: pd1
       HG_PD_GRPC_PORT: "8686"
@@ -122,7 +143,6 @@ services:
     <<: *pd-common
     container_name: hg-pd2
     hostname: pd2
-    networks: [ hg-net ]
     environment:
       HG_PD_GRPC_HOST: pd2
       HG_PD_GRPC_PORT: "8686"
@@ -187,16 +207,25 @@ services:
     <<: *server-common
     container_name: hg-server0
     hostname: server0
+    environment:
+      <<: *server-env
+      HG_SERVER_REST_URL: http://server0:8080
     ports: ["8080:8080"]
 
   server1:
     <<: *server-common
     container_name: hg-server1
     hostname: server1
+    environment:
+      <<: *server-env
+      HG_SERVER_REST_URL: http://server1:8080
     ports: ["8081:8080"]
 
   server2:
     <<: *server-common
     container_name: hg-server2
     hostname: server2
+    environment:
+      <<: *server-env
+      HG_SERVER_REST_URL: http://server2:8080
     ports: ["8082:8080"]

--- a/docker/docker-compose-hubble.yml
+++ b/docker/docker-compose-hubble.yml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Hubble add-on for the distributed cluster defined in
+# docker-compose-3pd-3store-3server.yml. Requires the pre-created cluster
+# network (docker network create hugegraph-net). See "Hubble for the
+# 3-Node Cluster" in docker/README.md for the attach and combined flows.
+
+networks:
+  hg-net:
+    external: true
+    name: ${HUGEGRAPH_NETWORK:-hugegraph-net}
+
+services:
+  hubble:
+    # Pin a release via HUGEGRAPH_VERSION in docker/.env; unset, the image
+    # tag defaults to latest.
+    image: ${HUBBLE_IMAGE:-hugegraph/hubble:${HUGEGRAPH_VERSION:-latest}}
+    pull_policy: ${HUBBLE_PULL_POLICY:-missing}
+    container_name: hg-hubble
+    hostname: hubble
+    restart: unless-stopped
+    networks: [hg-net]
+    ports:
+      - "${HUBBLE_PUBLISH_HOST:-127.0.0.1}:8088:8088"
+    volumes:
+      - ./hugegraph-hubble-3x3.properties:/hubble/conf/hugegraph-hubble.properties:ro
+    healthcheck:
+      test: ["CMD-SHELL", "body=$$(curl -fsS http://127.0.0.1:8088/about) && printf '%s' \"$$body\" | grep -q '\"status\":200' && printf '%s' \"$$body\" | grep -q '\"name\":\"hugegraph-hubble\"'"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s

--- a/docker/hugegraph-hubble-3x3.properties
+++ b/docker/hugegraph-hubble-3x3.properties
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+server.host=0.0.0.0
+server.port=8088
+
+cluster=hg
+idc=docker
+
+pd.enabled=true
+# Bootstrap target; the live topology comes from PD discovery. If this
+# replica is down when Hubble starts, point it at another server.
+server.direct_url=http://server0:8080
+pd.peers=pd0:8686,pd1:8686,pd2:8686
+# PD REST endpoint for the operations view (single address).
+pd.server=pd0:8620
+
+operations.store.allowed_targets=[http://store0:8520,http://store1:8520,http://store2:8520]
+
+# Dashboard is not part of this Compose stack.
+dashboard.address=

--- a/hugegraph-pd/README.md
+++ b/hugegraph-pd/README.md
@@ -155,9 +155,9 @@ raft:
 
 For detailed configuration options and production tuning, see [Configuration Guide](docs/configuration.md).
 
-#### Docker Bridge Network Example
+#### Docker Network Example
 
-When running PD in Docker with bridge networking (e.g., `docker/docker-compose-3pd-3store-3server.yml`), configuration is injected via environment variables instead of editing `application.yml` directly. Container hostnames are used instead of IP addresses:
+When running PD in Docker on a shared network (e.g., `docker/docker-compose-3pd-3store-3server.yml`, which joins the pre-created external `hugegraph-net` network), configuration is injected via environment variables instead of editing `application.yml` directly. Container hostnames are used instead of IP addresses:
 
 **pd0** container:
 ```bash

--- a/hugegraph-pd/docs/configuration.md
+++ b/hugegraph-pd/docs/configuration.md
@@ -119,9 +119,9 @@ raft:
   peers-list: 192.168.1.10:8610,192.168.1.11:8610,192.168.1.12:8610
 ```
 
-### Docker Bridge Network Deployment
+### Docker Network Deployment
 
-When deploying PD in Docker with bridge networking (e.g., `docker/docker-compose-3pd-3store-3server.yml`), container hostnames are used instead of IP addresses. Configuration is injected via `HG_PD_*` environment variables:
+When deploying PD in Docker on a shared network (e.g., `docker/docker-compose-3pd-3store-3server.yml`, which joins the pre-created external `hugegraph-net` network), container hostnames are used instead of IP addresses. Configuration is injected via `HG_PD_*` environment variables:
 
 ```yaml
 # pd0 — set via HG_PD_RAFT_ADDRESS and HG_PD_RAFT_PEERS_LIST env vars

--- a/hugegraph-server/README.md
+++ b/hugegraph-server/README.md
@@ -45,7 +45,10 @@ For a full distributed deployment, use the compose file in the `docker/` directo
 
 ```bash
 cd docker
-HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
+# One-time setup first: the shared hugegraph-net network and the required
+# credentials in docker/.env — see the 3-Node Cluster Quickstart in the
+# guide linked below.
+docker compose -f docker-compose-3pd-3store-3server.yml up -d
 ```
 
 See [docker/README.md](../docker/README.md) for the full setup guide.

--- a/hugegraph-server/hugegraph-dist/docker/README.md
+++ b/hugegraph-server/hugegraph-dist/docker/README.md
@@ -125,7 +125,10 @@ For a full distributed HugeGraph cluster with PD, Store, and Server, use the
 
 ```bash
 cd docker
-HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
+# One-time setup first: the shared hugegraph-net network and the required
+# credentials in docker/.env — see the 3-Node Cluster Quickstart in the
+# guide linked below.
+docker compose -f docker-compose-3pd-3store-3server.yml up -d
 ```
 
 See [docker/README.md](../../../docker/README.md) for the full setup guide,

--- a/hugegraph-store/AGENTS.md
+++ b/hugegraph-store/AGENTS.md
@@ -129,7 +129,7 @@ bin/restart-hugegraph-store.sh
 2. HugeGraph Store cluster (3+ nodes)
 3. Proper configuration pointing Store nodes to PD cluster
 
-See Docker Compose examples in the repository root `../docker/` directory. Single-node quickstart (pre-built images): `../docker/docker-compose.yml`. Single-node dev build (from source): `../docker/docker-compose.dev.yml`. 3-node cluster: `../docker/docker-compose-3pd-3store-3server.yml`. See `../docker/README.md` for the full setup guide.
+See Docker Compose examples in the repository root `../docker/` directory. Single-node quickstart (pre-built images): `../docker/docker-compose.yml`. Single-node dev build (from source): `../docker/docker-compose.dev.yml`. 3-node cluster: `../docker/docker-compose-3pd-3store-3server.yml`. Hubble add-on for the cluster: `../docker/docker-compose-hubble.yml`. See `../docker/README.md` for the full setup guide.
 
 ## Configuration Files
 

--- a/hugegraph-store/docs/deployment-guide.md
+++ b/hugegraph-store/docs/deployment-guide.md
@@ -678,10 +678,13 @@ For a production-like 3-node distributed deployment, use the compose file at `do
 
 ```bash
 cd docker
-HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
+# One-time setup first: the shared hugegraph-net network and the required
+# credentials in docker/.env — see the 3-Node Cluster Quickstart in
+# docker/README.md.
+docker compose -f docker-compose-3pd-3store-3server.yml up -d
 ```
 
-The compose file uses a Docker bridge network (`hg-net`) with container hostnames for service discovery. Configuration is injected via environment variables using the `HG_*` prefix:
+The compose file joins a pre-created external Docker network (`hugegraph-net`, override via `HUGEGRAPH_NETWORK`) shared with the Hubble add-on, with container hostnames for service discovery. Configuration is injected via environment variables using the `HG_*` prefix:
 
 **PD environment variables** (per node):
 
@@ -709,13 +712,20 @@ environment:
   HG_STORE_DATA_PATH: /hugegraph-store/storage         # maps to app.data-path
 ```
 
-**Server environment variables**:
+**Server environment variables** (per node; `HG_SERVER_REST_URL` names the node itself):
 
 ```yaml
 environment:
   HG_SERVER_BACKEND: hstore                            # maps to backend
   HG_SERVER_PD_PEERS: pd0:8686,pd1:8686,pd2:8686      # maps to pd.peers
   STORE_REST: store0:8520                              # used by wait-partition.sh
+  HG_SERVER_CLUSTER: hg                                # PD discovery application name
+  HG_SERVER_USE_PD: "true"                             # register with PD
+  HG_SERVER_REST_URL: http://server0:8080              # address registered with PD
+  HG_SERVER_MIN_FREE_MEMORY: "0"                       # disable free-memory guard locally
+  HG_SERVER_INIT_STORE_ENABLED: "false"                # PD/HStore deployments skip init-store
+  HG_SERVER_AUTH_TOKEN_SECRET: ${HUGEGRAPH_AUTH_TOKEN_SECRET:?Set a shared auth token secret}  # same value on all replicas, from docker/.env
+  PASSWORD: ${HUGEGRAPH_ADMIN_PASSWORD:?}              # required; initial admin password, from docker/.env
 ```
 
 **Startup ordering** is enforced via `depends_on` with `condition: service_healthy`:
@@ -728,8 +738,9 @@ environment:
 **Deploy**:
 
 ```bash
-# Start cluster (run from the docker/ directory)
-HUGEGRAPH_VERSION=1.7.0 docker compose -f docker-compose-3pd-3store-3server.yml up -d
+# Start cluster (run from the docker/ directory, after the one-time setup
+# in docker/README.md)
+docker compose -f docker-compose-3pd-3store-3server.yml up -d
 
 # Check status
 docker ps


### PR DESCRIPTION
> Kept in sync with https://github.com/apache/hugegraph/pull/3149

- close #3147

## What this PR does

Adds an attachable Hubble deployment for the distributed Compose topology:

- **`docker/docker-compose-hubble.yml`** (new) — defines only the Hubble
  service. It joins the pre-created cluster network and has no `depends_on`
  on cluster services, so attaching, upgrading, or removing Hubble never
  recreates PD, Store, or Server containers.
- **`docker/docker-compose-3pd-3store-3server.yml`** — adds the Server
  PD-registration and auth settings Hubble needs (cluster name, PD mode,
  per-replica REST URL, required admin password and shared token secret),
  mirroring what #3143 did for the single-node file.
- **`docker/hugegraph-hubble-3x3.properties`** (new) — Hubble topology
  config for the 3-node cluster.
- **`docker/README.md`** — documents the three flows: attach to a running
  cluster, fresh cluster + Hubble in one command, and a local Hubble image
  override for development.
- **`.github/workflows/server-ci.yml`** — extends the existing compose
  contract checks to the cluster file and the add-on.
- Doc call-site updates (root/server/pd/store docs) — the old documented
  commands no longer work with the required-credential guards.

## Design rationale (why it is shaped this way)

- **Add-on file over duplication:** the add-on defines only Hubble and
  merges with the canonical cluster file via `-f` flags, so the topology
  is never maintained in two places. This is the pattern Elastic documents
  for attaching Kibana to a running Elasticsearch over a shared Docker
  network with versions matched through one variable, and the attach model
  TiDB Operator provides via its standalone `TidbDashboard` resource.
- **Pre-created external network:** Compose validates `external:` networks
  before creating project networks and refuses to adopt unlabeled ones, so
  both files declare the shared network as external with a well-known name
  (`hugegraph-net`, override via `HUGEGRAPH_NETWORK`) and setup includes a
  one-time `docker network create`. Verified empirically; the generated
  per-project network name cannot support the one-command fresh flow.
- **Explicit `-p hugegraph-hubble` for the attach flow:** without it the
  attach project takes the directory name, colliding with other projects
  and making documented lifecycle commands cross project boundaries.
- **`latest` as the current default:** the authenticated PD/Hubble
  integration is not in `1.7.x`, so pinning to an existing release would
  ship a broken combination. Once the next release publishes, the default
  should move to that tag; deployments pin today via `HUGEGRAPH_VERSION`
  in `docker/.env`. (Unpinned `latest` with no compatibility story is the
  documented failure mode of Dgraph's Ratel — hence the single shared
  version variable.)

## Breaking change owned by this PR

Existing 3-node deployments: the first `up -d` after this change recreates
all nine containers (network move; named volumes survive), and the graph
APIs begin requiring authentication (401 for previously anonymous
clients). The README carries an upgrade note covering `.env` creation,
the orphaned old network, and verifying sign-in before decommissioning
existing access paths.

## Validation evidence

- Fresh combined up: 10/10 containers healthy; Hubble login through PD
  (HTTP 200, role SUPERADMIN); Operations view shows 1 logical Server +
  3 PD + 3 Store, all UP.
- Attach flow: cluster brought up alone, container IDs recorded; one
  add-on command attached Hubble; all cluster container IDs unchanged.
- Single-node regression: `docker/docker-compose.yml` path unaffected and
  healthy.
- CI checks replicated locally (positive and negative cases).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持通过共享外部 Docker 网络部署三节点集群。
  * 新增 Hubble 三节点集群附加组件及独立启动配置。
  * 支持统一配置集群发现、认证凭据、服务地址和镜像版本。
  * 新增 Hubble 健康检查、端口映射及可覆盖配置。

* **文档**
  * 更新集群部署、初始化、升级、生命周期管理和故障排查说明。
  * 补充网络创建、凭据配置、Token 初始化及 Docker 资源要求。

* **测试**
  * 新增集群 Compose 配置校验，覆盖认证、网络、服务数量及健康检查。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->