### PR TITLE
fix(build): limit supported JDK to Java 17

### DIFF
--- a/.serena/memories/ecosystem_and_related_projects.md
+++ b/.serena/memories/ecosystem_and_related_projects.md
@@ -20,4 +20,4 @@ Sources → hugegraph-loader → hugegraph-server → Hubble / Computer / AI
 - Queries: Gremlin (TinkerPop 3.7.6), OpenCypher, REST API + Swagger UI
 - Storage: RocksDB (default), HStore (distributed)
 
-## Version: Server 1.7.0, TinkerPop 3.7.6, Java 17+
+## Version: Server 1.7.0, TinkerPop 3.7.6, Java 17

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -14,7 +14,7 @@ Apache HugeGraph is a fast-speed, highly-scalable graph database supporting 10+ 
 - Integration with Flink/Spark/HDFS
 
 ## Technology Stack
-- **Language**: Java 17+ (required)
+- **Language**: Java 17 (required; currently supported release)
 - **Build**: Maven 3.6.3+
 - **Graph Framework**: Apache TinkerPop 3.7.6
 - **RPC**: gRPC + Protocol Buffers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@ README.md covers human-facing deployment/ecosystem context; only consult it on d
 ## Stack & Modules
 
 Apache HugeGraph — Apache TinkerPop 3 compliant graph database.
-Java 17+, Maven 3.6.3+. Version managed via `${revision}` (currently `1.7.0`).
+Java 17 (currently supported release), Maven 3.6.3+. Version managed via
+`${revision}` (currently `1.7.0`).
 
 ```
 Client (Gremlin / Cypher / REST)

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,8 +3,12 @@ Building HugeGraph
 
 Required:
 
-* Java 17+
+* Java 17 (currently the only supported Java release)
 * Maven 3.6.3+
+
+The launch scripts enforce Java 17 as the minimum runtime. This check does not
+qualify later Java releases; build HugeGraph with Java 17 unless another
+release is explicitly listed as supported.
 
 To build without executing tests: `mvn clean package -Dmaven.test.skip=true`
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,12 @@ curl -X POST http://localhost:8080/gremlin \
 
 ### Prerequisites
 
-- **Java 17+** (required)
+- **Java 17** (required and currently the only supported Java release)
 - **Maven 3.6.3+** (for building from source)
+
+The launch scripts reject Java versions older than 17. That minimum-version
+check does not qualify later Java releases; use Java 17 unless another release
+is explicitly listed as supported.
 
 ### Option 1: Docker (Fastest)
 
@@ -327,7 +331,7 @@ For detailed architecture and development guidance, see [AGENTS.md](AGENTS.md).
    - Review the [Architecture Diagram](#architecture) above
 
 2. **Set Up Your Environment**
-   - Install Java 17+ and Maven 3.6.3+
+   - Install Java 17 and Maven 3.6.3+
    - Follow [BUILDING.md](BUILDING.md) for build instructions
    - Configure your IDE to use `.editorconfig` for code style and `style/checkstyle.xml` for Checkstyle rules
 

--- a/hugegraph-commons/AGENTS.md
+++ b/hugegraph-commons/AGENTS.md
@@ -71,7 +71,7 @@ This is a Maven multi-module project with 2 main modules:
 
 ### Prerequisites
 ```bash
-# Verify Java version (17+ required)
+# Verify Java version (Java 17 required)
 java -version
 
 # Verify Maven version (3.6.3+ required)

--- a/hugegraph-commons/AGENTS.md
+++ b/hugegraph-commons/AGENTS.md
@@ -7,7 +7,7 @@ This file provides guidance to an AI coding tool when working with code in this 
 hugegraph-commons is a shared utility module for Apache HugeGraph and its peripheral components. It provides core infrastructure components (locks, config, events, iterators, REST client, RPC framework) to simplify development across the HugeGraph ecosystem.
 
 **Technology Stack**:
-- Java 17+ (compiler release: 17)
+- Java 17 (currently supported release; compiler release: 17)
 - Apache Maven 3.6.3+
 - Apache Commons Configuration2 for config management
 - OkHttp 4.10.0 for REST client (hugegraph-common)

--- a/hugegraph-pd/AGENTS.md
+++ b/hugegraph-pd/AGENTS.md
@@ -11,7 +11,7 @@ HugeGraph PD (Placement Driver) is a meta server for distributed HugeGraph deplo
 - Metadata coordination using Raft consensus
 
 **Technology Stack**:
-- Java 17+ (required)
+- Java 17 (currently supported release; required)
 - Apache Maven 3.6.3+
 - gRPC + Protocol Buffers for RPC communication
 - JRaft (Ant Design's Raft implementation) for consensus

--- a/hugegraph-pd/README.md
+++ b/hugegraph-pd/README.md
@@ -36,7 +36,7 @@ For detailed architecture and design, see [Architecture Documentation](docs/arch
 
 ### Prerequisites
 
-- **Java**: 17 or higher
+- **Java**: 17 (currently the only supported release)
 - **Maven**: 3.6.3 or higher
 - **Disk Space**: At least 1GB for PD data directory
 

--- a/hugegraph-pd/docs/architecture.md
+++ b/hugegraph-pd/docs/architecture.md
@@ -54,7 +54,7 @@ HugeGraph PD (Placement Driver) is the control plane for HugeGraph distributed d
 - **Storage**: RocksDB for persistent metadata
 - **Communication**: gRPC with Protocol Buffers
 - **Framework**: Spring Boot for REST APIs and dependency injection
-- **Language**: Java 17+
+- **Language**: Java 17 (currently supported release)
 
 ## Module Architecture
 

--- a/hugegraph-pd/docs/development.md
+++ b/hugegraph-pd/docs/development.md
@@ -18,10 +18,10 @@ This document provides comprehensive guidance for developing, testing, and contr
 
 Ensure you have the following tools installed:
 
-| Tool | Minimum Version | Recommended | Purpose |
+| Tool | Version Requirement | Recommended | Purpose |
 |------|----------------|-------------|---------|
-| **JDK** | 17 | 17 LTS | Java runtime and compilation |
-| **Maven** | 3.6.3 | 3.8+ | Build tool and dependency management |
+| **JDK** | 17 (only supported release) | 17 LTS | Java runtime and compilation |
+| **Maven** | 3.6.3+ | 3.8+ | Build tool and dependency management |
 | **Git** | 2.0+ | Latest | Version control |
 | **IDE** | N/A | IntelliJ IDEA | Development environment |
 
@@ -30,7 +30,7 @@ Ensure you have the following tools installed:
 ```bash
 # Check Java version
 java -version
-# Expected: openjdk version "17.0.x" or later
+# Expected: openjdk version "17.0.x"
 
 # Check Maven version
 mvn -version

--- a/hugegraph-pd/hg-pd-dist/src/assembly/static/bin/start-hugegraph-pd.sh
+++ b/hugegraph-pd/hg-pd-dist/src/assembly/static/bin/start-hugegraph-pd.sh
@@ -114,7 +114,7 @@ case "$GC_OPTION" in
                       -XX:InitiatingHeapOccupancyPercent=50 -XX:G1RSetUpdatingPauseTimePercent=5"
         ;;
     zgc|ZGC)
-        echo "Using ZGC as the default garbage collector (Only support Java 17+)"
+        echo "Using ZGC as the default garbage collector (requires Java 17 or later)"
         JAVA_OPTIONS="${JAVA_OPTIONS} -XX:+UseZGC -XX:+UnlockExperimentalVMOptions \
                                       -XX:ConcGCThreads=2 -XX:ParallelGCThreads=6 \
                                       -XX:ZCollectionInterval=120 -XX:ZAllocationSpikeTolerance=5 \

--- a/hugegraph-server/AGENTS.md
+++ b/hugegraph-server/AGENTS.md
@@ -10,7 +10,8 @@ HugeGraph Server is the graph engine layer of Apache HugeGraph, consisting of:
 - **Backend Interface**: Abstraction layer for pluggable storage backends
 - **Storage Backend Implementations**: RocksDB (default), HStore (distributed), HBase (deprecated; planned for removal in 2.0), and Memory (test-only)
 
-Technology: Java 17+, Maven 3.6.3+, Apache TinkerPop 3.7.6, Jersey 3.0 (REST), gRPC (distributed communication)
+Technology: Java 17 (currently supported release), Maven 3.6.3+,
+Apache TinkerPop 3.7.6, Jersey 3.0 (REST), gRPC (distributed communication)
 
 ## Build Commands
 

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/bin/hugegraph-server.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/bin/hugegraph-server.sh
@@ -144,7 +144,7 @@ case "$GC_OPTION" in
                                       -XX:G1RSetUpdatingPauseTimePercent=5"
         ;;
     zgc|ZGC)
-        echo "Using ZGC as the default garbage collector (Only support Java 17+)"
+        echo "Using ZGC as the default garbage collector (requires Java 17 or later)"
         JAVA_OPTIONS="${JAVA_OPTIONS} -XX:+UseZGC -XX:+UnlockExperimentalVMOptions \
                                       -XX:ConcGCThreads=2 -XX:ParallelGCThreads=6 \
                                       -XX:ZCollectionInterval=120 -XX:ZAllocationSpikeTolerance=5 \

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/test-java17-upgrade-contracts.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/test-java17-upgrade-contracts.sh
@@ -54,6 +54,51 @@ if value is None or (value.text or "").strip() != "false":
 PY
 }
 
+assert_supported_java_contract() {
+    local pom="$1"
+
+    python3 - "$pom" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+pom = sys.argv[1]
+namespace = {"m": "http://maven.apache.org/POM/4.0.0"}
+root = ET.parse(pom).getroot()
+properties = root.find("m:properties", namespace)
+if properties is None:
+    raise SystemExit("{}: Maven properties are missing".format(pom))
+
+release = properties.find("m:maven.compiler.release", namespace)
+if release is None or (release.text or "").strip() != "17":
+    raise SystemExit("{}: compiler release must remain 17".format(pom))
+
+supported_range = properties.find("m:java.supported.version.range", namespace)
+if supported_range is None or (supported_range.text or "").strip() != "[17,18)":
+    raise SystemExit("{}: supported JDK range must be [17,18)".format(pom))
+
+expected_reference = "${java.supported.version.range}"
+actual_references = []
+for plugin in root.findall("m:build/m:plugins/m:plugin", namespace):
+    artifact_id = plugin.find("m:artifactId", namespace)
+    if artifact_id is None or artifact_id.text != "maven-enforcer-plugin":
+        continue
+    for rule in plugin.findall(
+        "m:executions/m:execution/m:configuration/m:rules/m:requireJavaVersion",
+        namespace,
+    ):
+        version = rule.find("m:version", namespace)
+        if version is not None:
+            actual_references.append((version.text or "").strip())
+
+if actual_references != [expected_reference]:
+    raise SystemExit(
+        "{}: requireJavaVersion must consume {} exactly once; found {}".format(
+            pom, expected_reference, actual_references
+        )
+    )
+PY
+}
+
 assert_surefire_execution_scope() {
     local pom="$1"
     shift
@@ -104,6 +149,7 @@ if missing:
 PY
 }
 
+assert_supported_java_contract "${SOURCE_ROOT}/pom.xml"
 assert_default_test_is_tolerant "${SOURCE_ROOT}/pom.xml"
 assert_surefire_execution_scope \
     "${SOURCE_ROOT}/hugegraph-server/hugegraph-test/pom.xml" \

--- a/hugegraph-store/AGENTS.md
+++ b/hugegraph-store/AGENTS.md
@@ -7,7 +7,7 @@ This file provides guidance to an AI coding tool when working with code in this 
 HugeGraph Store is a distributed storage backend for Apache HugeGraph, using RocksDB as the underlying storage engine with Raft consensus protocol for distributed coordination. It is designed for production-scale deployments requiring high availability and horizontal scalability.
 
 **Technology Stack**:
-- Java 17+
+- Java 17 (currently supported release)
 - RocksDB: Embedded key-value storage engine
 - Raft (JRaft): Distributed consensus protocol
 - gRPC: Inter-node communication

--- a/hugegraph-store/README.md
+++ b/hugegraph-store/README.md
@@ -23,7 +23,7 @@ HugeGraph Store is a distributed storage backend for HugeGraph that provides hig
 - **Storage Engine**: RocksDB 7.7.3 (optimized for graph workloads)
 - **Consensus Protocol**: Apache JRaft (Ant Financial's Raft implementation)
 - **RPC Framework**: gRPC + Protocol Buffers
-- **Deployment**: Java 17+, Docker/Kubernetes support
+- **Deployment**: Java 17 (currently supported release), Docker/Kubernetes support
 
 ### When to Use HugeGraph Store
 

--- a/hugegraph-store/README.md
+++ b/hugegraph-store/README.md
@@ -87,7 +87,7 @@ For detailed architecture, Raft consensus mechanisms, and partition management, 
 
 ### Prerequisites
 
-- **Java**: 17 or higher
+- **Java**: 17 (currently the only supported release)
 - **Maven**: 3.6.3 or higher
 - **HugeGraph PD Cluster**: Store requires a running PD cluster for metadata coordination (see [PD README](../hugegraph-pd/README.md))
 - **Disk Space**: At least 10GB per Store node for data and Raft logs

--- a/hugegraph-store/docs/deployment-guide.md
+++ b/hugegraph-store/docs/deployment-guide.md
@@ -384,7 +384,7 @@ graph.name=hugegraph
 **On all nodes**:
 
 ```bash
-# Check Java version (17+ required)
+# Check Java version (Java 17 is the only currently supported release)
 java -version
 
 # Check Maven (for building from source)

--- a/hugegraph-store/docs/development-guide.md
+++ b/hugegraph-store/docs/development-guide.md
@@ -18,7 +18,7 @@ Comprehensive guide for developing, testing, and contributing to HugeGraph Store
 ### Prerequisites
 
 **Required**:
-- Java: 17 or higher (OpenJDK or Oracle JDK)
+- Java: 17 (currently the only supported release; OpenJDK or Oracle JDK)
 - Maven: 3.6.3 or higher
 - Git: Latest version
 - IDE: IntelliJ IDEA (recommended) or Eclipse

--- a/hugegraph-store/hg-store-dist/src/assembly/static/bin/start-hugegraph-store.sh
+++ b/hugegraph-store/hg-store-dist/src/assembly/static/bin/start-hugegraph-store.sh
@@ -167,7 +167,7 @@ case "$GC_OPTION" in
                       -XX:InitiatingHeapOccupancyPercent=50 -XX:G1RSetUpdatingPauseTimePercent=5"
         ;;
     zgc|ZGC)
-        echo "Using ZGC as the default garbage collector (Only support Java 17+)"
+        echo "Using ZGC as the default garbage collector (requires Java 17 or later)"
         JAVA_OPTIONS="${JAVA_OPTIONS} -XX:+UseZGC -XX:+UnlockExperimentalVMOptions \
                                       -XX:ConcGCThreads=2 -XX:ParallelGCThreads=6 \
                                       -XX:ZCollectionInterval=120 -XX:ZAllocationSpikeTolerance=5 \

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,9 @@
         <lombok.version>1.18.30</lombok.version>
         <release.name>hugegraph</release.name>
         <maven.compiler.release>17</maven.compiler.release>
+        <!-- Java 17 is the only qualified build/runtime release. Expand this
+             range only after CI qualifies another JDK release. -->
+        <java.supported.version.range>[17,18)</java.supported.version.range>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
         <!-- -Dtest also reaches upstream modules selected by -am. Named leaf
@@ -303,7 +306,7 @@
                                 <!-- TODO: uncomment for checking dependency conflicts -->
                                 <!-- <DependencyConvergence/> -->
                                 <requireJavaVersion>
-                                    <version>[17,)</version>
+                                    <version>${java.supported.version.range}</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[3.6.3,)</version>


### PR DESCRIPTION
## Purpose of the PR

- Related to #189.
- Follow-up to #183.

PR #183 established Java 17 as HugeGraph's build and runtime baseline, but the root Maven Enforcer range remained `[17,)`. That range accepted later JDK releases even though HugeGraph still depends on non-public JDK APIs such as `jdk.internal.reflect` and `sun.nio.ch`, and those releases have not been qualified.

This PR makes Java 17 the only currently supported JDK release. It keeps `release=17` and distinguishes that support policy from the launch scripts' `>=17` minimum-version check: a later JDK may pass the launcher gate, but it is not considered supported until CI qualifies it.

Detailed Phase 2 status and evidence are maintained in the [upgrade plan](https://hugegraph.feishu.cn/docx/Ewj6dAcowoGCRpxPhlVcIqoZnLf) and [implementation record](https://hugegraph.feishu.cn/wiki/Uxsyw0DH5iyPklkCAxecAKNHnsc).

## Main Changes

- Define `java.supported.version.range=[17,18)` and make Maven Enforcer consume that property.
- Extend the existing Java 17 upgrade contract script to prevent the compiler release, supported range, and Enforcer wiring from drifting apart.
- Align README, BUILDING, module guidance, and runtime messages with the support boundary.
- Keep launcher behavior unchanged: Java versions older than 17 are rejected, while support for later releases remains unclaimed.
- Do not change dependencies, sandbox behavior, public APIs, default Server startup checks, or HStore Compose smoke coverage.

## Verifying these changes

- [x] Need tests and can be verified as follows:
  - `test-java17-upgrade-contracts.sh`: passed.
  - Shell syntax checks for the contract and Server/PD/Store launchers: passed.
  - `xmllint --noout pom.xml`: passed.
  - Java 17: `mvn -N -ntp validate -DskipTests -Drat.skip=true`: passed.
  - Temurin 21: the same Maven validation was rejected by `RequireJavaVersion` with allowed range `[17,18)`.
  - EditorConfig check for all 20 changed files: passed.
  - `git diff --check`: passed.

No full, Docker, or HStore runtime suite was run locally; those remain CI responsibilities.

## Does this PR potentially affect the following parts?

- [ ] Dependencies ([add/update license](https://hugegraph.apache.org/docs/contribution-guidelines/contribute/#321-check-licenses) info & [regenerate_known_dependencies.sh](../install-dist/scripts/dependency/regenerate_known_dependencies.sh))
- [x] Modify configurations
- [ ] The public API
- [x] Other affects: supported JDK policy and contributor/runtime documentation
- [ ] Nope

## Documentation Status

- [ ] `Doc - TODO`
- [x] `Doc - Done`
- [ ] `Doc - No Need`