### PR TITLE
fix(helm): harden distributed startup and metadata configuration

### DIFF
--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -238,8 +238,12 @@ jobs:
           # --reuse-values discards them, so the fixture must become values.yaml.
           cp -R helm/hugegraph /tmp/legacy
           cp helm/hugegraph/testdata/values-pre-hardening.yaml /tmp/legacy/values.yaml
-          helm template legacy /tmp/legacy > /dev/null
-          helm template legacy /tmp/legacy --is-upgrade > /dev/null
+          helm template legacy /tmp/legacy > /tmp/legacy-render.yaml
+          helm template legacy /tmp/legacy --is-upgrade > /tmp/legacy-upgrade.yaml
+          # Missing new persistence/cluster keys must retain the behavior that
+          # old releases had before those values existed.
+          test "$(grep -cF 'volumeClaimTemplates:' /tmp/legacy-render.yaml)" -eq 2
+          grep -qF 'value: "hg-test"' /tmp/legacy-render.yaml
 
       - name: helm package
         run: helm package helm/hugegraph -d /tmp/chart

--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -48,10 +48,18 @@ jobs:
           helm lint helm/hugegraph
           helm lint helm/hugegraph -f helm/hugegraph/values-single.yaml
           helm lint helm/hugegraph -f helm/hugegraph/values-cluster.yaml
+          helm lint helm/hugegraph -f helm/hugegraph/values-1.5.yaml
+          helm lint helm/hugegraph -f helm/hugegraph/values-1.7.yaml
+          helm lint helm/hugegraph -f helm/hugegraph/values-master-target.yaml
 
       - name: helm template
         run: |
-          for preset in "" "-f helm/hugegraph/values-single.yaml" "-f helm/hugegraph/values-cluster.yaml"; do
+          for preset in "" \
+            "-f helm/hugegraph/values-single.yaml" \
+            "-f helm/hugegraph/values-cluster.yaml" \
+            "-f helm/hugegraph/values-1.5.yaml" \
+            "-f helm/hugegraph/values-1.7.yaml" \
+            "-f helm/hugegraph/values-master-target.yaml"; do
             # shellcheck disable=SC2086 # $preset intentionally splits into flags
             helm template ci helm/hugegraph $preset > /dev/null
           done
@@ -62,12 +70,11 @@ jobs:
           grep -qF 'kind: Secret' /tmp/helm-default.yaml
           grep -qF 'helm.sh/resource-policy: keep' /tmp/helm-default.yaml
           grep -qF 'name: PASSWORD' /tmp/helm-default.yaml
-          grep -qF 'image: "hugegraph/pd:helm-dev"' /tmp/helm-default.yaml
-          grep -qF 'image: "hugegraph/store:helm-dev"' /tmp/helm-default.yaml
-          grep -qF 'image: "hugegraph/server:helm-dev"' /tmp/helm-default.yaml
-          grep -qF 'image: "hugegraph/hubble:latest"' /tmp/helm-default.yaml
+          grep -qF 'image: "hugegraph/pd:1.7.0"' /tmp/helm-default.yaml
+          grep -qF 'image: "hugegraph/store:1.7.0"' /tmp/helm-default.yaml
+          grep -qF 'image: "hugegraph/server:1.7.0"' /tmp/helm-default.yaml
+          grep -qF 'image: "hugegraph/hubble:1.7.0"' /tmp/helm-default.yaml
           grep -qF 'imagePullPolicy: IfNotPresent' /tmp/helm-default.yaml
-          grep -qF 'imagePullPolicy: Always' /tmp/helm-default.yaml
           # An explicitly supplied admin Secret takes precedence over auto-creation.
           helm template ci helm/hugegraph \
             --set server.auth.admin.autoGenerate=true \
@@ -195,7 +202,12 @@ jobs:
           set -o pipefail
           curl -sSLo /tmp/kc.tar.gz https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
           tar -xzf /tmp/kc.tar.gz -C /tmp
-          for preset in "" "-f helm/hugegraph/values-single.yaml" "-f helm/hugegraph/values-cluster.yaml"; do
+          for preset in "" \
+            "-f helm/hugegraph/values-single.yaml" \
+            "-f helm/hugegraph/values-cluster.yaml" \
+            "-f helm/hugegraph/values-1.5.yaml" \
+            "-f helm/hugegraph/values-1.7.yaml" \
+            "-f helm/hugegraph/values-master-target.yaml"; do
             # shellcheck disable=SC2086 # $preset intentionally splits into flags
             helm template ci helm/hugegraph $preset | /tmp/kubeconform -strict -summary -kubernetes-version 1.23.0
           done

--- a/helm/hugegraph/README.md
+++ b/helm/hugegraph/README.md
@@ -41,10 +41,10 @@ from Docker Hub, so no local build or image-loading step is needed:
 
 | Component | Default image | Pull policy |
 |---|---|---|
-| PD | `hugegraph/pd:helm-dev` | `IfNotPresent` |
-| Store | `hugegraph/store:helm-dev` | `IfNotPresent` |
-| Server | `hugegraph/server:helm-dev` | `IfNotPresent` |
-| Hubble | `hugegraph/hubble:latest` | `Always` |
+| PD | `hugegraph/pd:1.7.0` | `IfNotPresent` |
+| Store | `hugegraph/store:1.7.0` | `IfNotPresent` |
+| Server | `hugegraph/server:1.7.0` | `IfNotPresent` |
+| Hubble | `hugegraph/hubble:1.7.0` | `IfNotPresent` |
 
 If your cluster uses a private registry, override the image repository, tag,
 and pull policy in a values file before installing.
@@ -123,6 +123,7 @@ Open <http://127.0.0.1:8088> and sign in as `admin`. The Server API is at
 | Resources | `pd.resources`, `store.resources`, `server.resources`, `hubble.resources` | Explicit requests and limits |
 | Storage | `pd.storage.*`, `store.storage.*`, `hubble.persistence.*` | `10Gi`, `50Gi`, `1Gi` PVC |
 | Authentication | `server.auth.enabled`, `server.auth.admin.*`, `server.auth.token.*` | `true`, chart-managed admin + JWT |
+| Server metadata | `server.cluster` | Stable PD metadata namespace (`hg-test` by default) |
 | Hubble | `hubble.enabled`, `hubble.mode`, `hubble.port` | `true`, `pd`, `8088` |
 
 `values-cluster.yaml` is a starting point, not a capacity guarantee. Recalculate
@@ -217,12 +218,10 @@ A fresh install seeds PD with a partition shard count of 3 when
 default of 1. The seed applies at first bootstrap only; see Partition
 Sharding below.
 
-This first chart is version `0.1.1`. On this development branch, PD, Store,
-and Server default to Docker Hub images tagged `helm-dev` with
-`pullPolicy: IfNotPresent`. Hubble still tracks
-`hugegraph/hubble:latest` with `Always` (source is in `hugegraph-toolchain`).
-Before stable publication, pin all component tags and `appVersion` to the next
-HugeGraph release.
+This first chart is version `0.1.1` and defaults to the reproducible HugeGraph
+`1.7.0` image set. Use `values-1.5.yaml` or `values-1.7.yaml` for release
+compatibility checks. `values-master-target.yaml` is explicitly a moving
+`helm-dev` candidate and must not be advertised as a released `1.8`.
 
 Verify the release:
 
@@ -234,6 +233,9 @@ helm test hugegraph --namespace hugegraph
 
 | File | Purpose |
 |---|---|
+| `values-1.5.yaml` | HugeGraph 1.5.0 component tags |
+| `values-1.7.yaml` | HugeGraph 1.7.0 component tags |
+| `values-master-target.yaml` | `helm-dev` PD/Store/Server candidate |
 | `values.yaml` | Default 3+3+3+1 topology with preferred anti-affinity, authentication, automatic admin Secret, and Hubble in `pd` mode |
 | `values-single.yaml` | Single-node 1+1+1+1 development preset with the same authentication and Hubble defaults |
 | `values-cluster.yaml` | Production 3+3+3+1 starting point with JVM/resources, PD/Store PDBs, required anti-affinity, authentication, and Hubble persistence |
@@ -247,10 +249,10 @@ node topology, and storage class before production use.
 The following section is only for users who do not already have a Kubernetes
 cluster. If you already have one, follow Quick Start and skip this section.
 
-The normal chart defaults pull PD, Store, and Server from Docker Hub. To test
+The normal chart defaults pull PD, Store, Server, and Hubble from Docker Hub. To test
 local PD, Store, and Server builds instead, build those three images, load them
 into the cluster, and override their tags and pull policies during install.
-Hubble still pulls `hugegraph/hubble:latest`. Current Hubble images need
+Hubble uses the pinned `hugegraph/hubble:1.7.0` image. Current Hubble images need
 `server.auth`. The Quick Start generates the admin Secret when no existing
 Secret is supplied and reuses an existing Secret first.
 
@@ -674,8 +676,8 @@ trusted network.
 | `hubble.mode` | `pd` discovers the cluster through PD and enables the operations view; `direct` talks to the Server client Service only | `pd` |
 | `hubble.allowWithoutServerAuth` | Renders Hubble without `server.auth`, for future images whose login does not require cluster authentication | `false` |
 | `hubble.image.repository` | Hubble image repository | `hugegraph/hubble` |
-| `hubble.image.tag` | Hubble image tag. Tracks the development image until the next release is pinned | `latest` |
-| `hubble.image.pullPolicy` | Hubble image pull policy | `Always` |
+| `hubble.image.tag` | Hubble image tag | `1.7.0` |
+| `hubble.image.pullPolicy` | Hubble image pull policy | `IfNotPresent` |
 | `hubble.port` | Hubble HTTP port, container port, and Service port | `8088` |
 | `hubble.persistence.enabled` | Persist UI connection metadata in a PVC | `false` |
 | `hubble.persistence.size` | PVC size | `1Gi` |

--- a/helm/hugegraph/templates/hubble-deployment.yaml
+++ b/helm/hugegraph/templates/hubble-deployment.yaml
@@ -19,6 +19,7 @@
 {{- include "hugegraph.validateValues" . }}
 {{- $customPort := ne (int .Values.hubble.port) 8088 }}
 {{- $mode := .Values.hubble.mode | default "pd" }}
+{{- $anonymousMode := and (not .Values.server.auth.enabled) .Values.hubble.allowWithoutServerAuth }}
 {{- if not (has $mode (list "pd" "direct")) }}
 {{- fail "hubble.mode must be one of: pd, direct" }}
 {{- end }}
@@ -110,6 +111,9 @@ spec:
               fi
               TMP=$(mktemp)
               FOUND_PD_ENABLED=false
+              {{- if $anonymousMode }}
+              FOUND_SERVER_AUTH=false
+              {{- end }}
               {{- if $pdMode }}
               FOUND_PD_PEERS=false
               FOUND_PD_SERVER=false
@@ -128,6 +132,12 @@ spec:
                     printf 'pd.enabled={{ $pdMode }}\n' >>"${TMP}"
                     FOUND_PD_ENABLED=true
                     ;;
+                  {{- if $anonymousMode }}
+                  server.auth.enabled=*)
+                    printf 'server.auth.enabled=false\n' >>"${TMP}"
+                    FOUND_SERVER_AUTH=true
+                    ;;
+                  {{- end }}
                   {{- if $pdMode }}
                   pd.peers=*)
                     printf 'pd.peers=%s\n' "${HG_HUBBLE_PD_PEERS}" >>"${TMP}"
@@ -170,6 +180,11 @@ spec:
               if [[ "${FOUND_PD_ENABLED}" == false ]]; then
                 printf 'pd.enabled={{ $pdMode }}\n' >>"${TMP}"
               fi
+              {{- if $anonymousMode }}
+              if [[ "${FOUND_SERVER_AUTH}" == false ]]; then
+                printf 'server.auth.enabled=false\n' >>"${TMP}"
+              fi
+              {{- end }}
               {{- if $pdMode }}
               if [[ "${FOUND_PD_PEERS}" == false ]]; then
                 printf 'pd.peers=%s\n' "${HG_HUBBLE_PD_PEERS}" >>"${TMP}"

--- a/helm/hugegraph/templates/hubble-service.yaml
+++ b/helm/hugegraph/templates/hubble-service.yaml
@@ -30,6 +30,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ get $svc "type" | default "ClusterIP" }}
+  {{- with (get $svc "clusterIP") }}
+  clusterIP: {{ . | quote }}
+  {{- end }}
   selector:
     {{- include "hugegraph.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: hubble

--- a/helm/hugegraph/templates/pd-service-client.yaml
+++ b/helm/hugegraph/templates/pd-service-client.yaml
@@ -29,6 +29,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ get $svc "type" | default "ClusterIP" }}
+  {{- with (get $svc "clusterIP") }}
+  clusterIP: {{ . | quote }}
+  {{- end }}
   selector:
     {{- include "hugegraph.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: pd

--- a/helm/hugegraph/templates/pd-statefulset.yaml
+++ b/helm/hugegraph/templates/pd-statefulset.yaml
@@ -75,6 +75,11 @@ spec:
       {{- else }}
       {{- with include "hugegraph.antiAffinity" (dict "mode" .Values.pd.antiAffinity "component" "pd" "labels" (include "hugegraph.selectorLabels" . | fromYaml)) }}{{ . | trim | nindent 6 }}{{- end }}
       {{- end }}
+      {{- if not .Values.pd.storage.enabled }}
+      volumes:
+        - name: pd-data
+          emptyDir: {}
+      {{- end }}
       containers:
         - name: pd
           image: "{{ .Values.pd.image.repository }}:{{ .Values.pd.image.tag | default $.Chart.AppVersion }}"
@@ -145,6 +150,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+  {{- if .Values.pd.storage.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: pd-data
@@ -156,3 +162,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.pd.storage.size }}
+  {{- end }}

--- a/helm/hugegraph/templates/pd-statefulset.yaml
+++ b/helm/hugegraph/templates/pd-statefulset.yaml
@@ -75,7 +75,7 @@ spec:
       {{- else }}
       {{- with include "hugegraph.antiAffinity" (dict "mode" .Values.pd.antiAffinity "component" "pd" "labels" (include "hugegraph.selectorLabels" . | fromYaml)) }}{{ . | trim | nindent 6 }}{{- end }}
       {{- end }}
-      {{- if not .Values.pd.storage.enabled }}
+      {{- if and (hasKey .Values.pd.storage "enabled") (not .Values.pd.storage.enabled) }}
       volumes:
         - name: pd-data
           emptyDir: {}
@@ -150,7 +150,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-  {{- if .Values.pd.storage.enabled }}
+  {{- if or (not (hasKey .Values.pd.storage "enabled")) .Values.pd.storage.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: pd-data

--- a/helm/hugegraph/templates/server-deployment.yaml
+++ b/helm/hugegraph/templates/server-deployment.yaml
@@ -281,7 +281,7 @@ spec:
             - name: HG_SERVER_PD_PEERS
               value: {{ include "hugegraph.pd.grpcPeersList" . | quote }}
             - name: HG_SERVER_CLUSTER
-              value: {{ .Values.server.cluster | quote }}
+              value: {{ .Values.server.cluster | default "hg-test" | quote }}
             - name: HG_SERVER_PD_REST_ENDPOINT
               value: {{ include "hugegraph.pd.restPeersList" . | quote }}
             - name: STORE_REST

--- a/helm/hugegraph/templates/server-deployment.yaml
+++ b/helm/hugegraph/templates/server-deployment.yaml
@@ -135,6 +135,7 @@ spec:
               {{- if $pdMeta }}
               FOUND_USE_PD=false
               FOUND_PD_PEERS=false
+              FOUND_CLUSTER=false
               FOUND_URLS_TO_PD=false
               FOUND_DEPLOY_IN_K8S=false
               {{- end }}
@@ -160,6 +161,10 @@ spec:
                   pd.peers=*)
                     printf 'pd.peers=%s\n' "${HG_SERVER_PD_PEERS}" >>"${TMP}"
                     FOUND_PD_PEERS=true
+                    ;;
+                  cluster=*)
+                    printf 'cluster=%s\n' "${HG_SERVER_CLUSTER}" >>"${TMP}"
+                    FOUND_CLUSTER=true
                     ;;
                   server.urls_to_pd=*)
                     printf 'server.urls_to_pd=%s\n' "${HG_SERVER_URLS_TO_PD}" >>"${TMP}"
@@ -209,6 +214,9 @@ spec:
               if [[ "${FOUND_PD_PEERS}" == false ]]; then
                 printf 'pd.peers=%s\n' "${HG_SERVER_PD_PEERS}" >>"${TMP}"
               fi
+              if [[ "${FOUND_CLUSTER}" == false ]]; then
+                printf 'cluster=%s\n' "${HG_SERVER_CLUSTER}" >>"${TMP}"
+              fi
               # PD hands this URL to discovery clients such as Hubble.
               # HG_SERVER_URLS_TO_PD uses server.advertiseUrl when set,
               # otherwise the in-cluster Server Service URL. The k8s
@@ -247,7 +255,22 @@ spec:
               {{- end }}
               chmod 600 "${TMP}"
               mv "${TMP}" "${CONF}"
-              exec ./docker-entrypoint.sh
+              ./docker-entrypoint.sh &
+              ENTRYPOINT_PID=$!
+              forward_term() {
+                kill -TERM "${ENTRYPOINT_PID}" 2>/dev/null || true
+              }
+              trap forward_term TERM INT
+              set +e
+              wait "${ENTRYPOINT_PID}"
+              ENTRYPOINT_STATUS=$?
+              set -e
+              if [[ "${ENTRYPOINT_STATUS}" -ne 0 ]]; then
+                echo "docker-entrypoint.sh failed with status ${ENTRYPOINT_STATUS}" >&2
+                echo "Last 200 lines of ./logs/hugegraph-server.log:" >&2
+                tail -n 200 ./logs/hugegraph-server.log >&2 || true
+              fi
+              exit "${ENTRYPOINT_STATUS}"
           {{- end }}
           ports:
             - name: http
@@ -257,6 +280,8 @@ spec:
               value: {{ .Values.server.backend | quote }}
             - name: HG_SERVER_PD_PEERS
               value: {{ include "hugegraph.pd.grpcPeersList" . | quote }}
+            - name: HG_SERVER_CLUSTER
+              value: {{ .Values.server.cluster | quote }}
             - name: HG_SERVER_PD_REST_ENDPOINT
               value: {{ include "hugegraph.pd.restPeersList" . | quote }}
             - name: STORE_REST

--- a/helm/hugegraph/templates/server-service.yaml
+++ b/helm/hugegraph/templates/server-service.yaml
@@ -29,6 +29,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ get $svc "type" | default "ClusterIP" }}
+  {{- with (get $svc "clusterIP") }}
+  clusterIP: {{ . | quote }}
+  {{- end }}
   selector:
     {{- include "hugegraph.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/helm/hugegraph/templates/store-statefulset.yaml
+++ b/helm/hugegraph/templates/store-statefulset.yaml
@@ -122,7 +122,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if not .Values.store.storage.enabled }}
+      {{- if and (hasKey .Values.store.storage "enabled") (not .Values.store.storage.enabled) }}
       volumes:
         - name: store-data
           emptyDir: {}
@@ -193,7 +193,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-  {{- if .Values.store.storage.enabled }}
+  {{- if or (not (hasKey .Values.store.storage "enabled")) .Values.store.storage.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: store-data

--- a/helm/hugegraph/templates/store-statefulset.yaml
+++ b/helm/hugegraph/templates/store-statefulset.yaml
@@ -91,29 +91,42 @@ spec:
               HEALTH_PEERS=$(echo "{{ include "hugegraph.pd.restPeersList" . }}" | tr ',' ' ')
               TIMEOUT={{ .Values.store.waitTimeoutSeconds | default 900 }}
               DEADLINE=$(( $(date +%s) + TIMEOUT ))
-              echo "Waiting for PD quorum (${REQUIRED}) among: ${HEALTH_PEERS}"
+              echo "Waiting for PD leader and quorum (${REQUIRED}) among: ${HEALTH_PEERS}"
               until [ "$(
                 ok=0
                 for peer in ${HEALTH_PEERS}; do
-                  if curl -fsS "http://${peer}/v1/health" >/dev/null 2>&1; then
+                  # PD protects /v1/members with its internal service Basic auth.
+                  # The current PD contract validates the service name; Store uses
+                  # the same "store" identity as its gRPC client.
+                  MEMBERS=$(curl -fsS -u store: "http://${peer}/v1/members" 2>/dev/null || true)
+                  SERVICE_COUNT=$(printf '%s' "${MEMBERS}" | sed -n 's/.*"numOfService"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p')
+                  NORMAL_COUNT=$(printf '%s' "${MEMBERS}" | sed -n 's/.*"numOfNormalService"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p')
+                  if printf '%s' "${MEMBERS}" | grep -Eq '"pdLeader"[[:space:]]*:[[:space:]]*\{' \
+                    && [ "${SERVICE_COUNT:-0}" -ge "${REQUIRED}" ] \
+                    && [ "${NORMAL_COUNT:-0}" -ge "${REQUIRED}" ]; then
                     ok=$((ok+1))
                   fi
                 done
                 echo "$ok"
               )" -ge "${REQUIRED}" ]; do
                 if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
-                  echo "Timed out after ${TIMEOUT}s waiting for PD quorum (${REQUIRED}) among: ${HEALTH_PEERS}" >&2
+                  echo "Timed out after ${TIMEOUT}s waiting for PD leader and quorum (${REQUIRED}) among: ${HEALTH_PEERS}" >&2
                   echo "Check PD Pods: kubectl get pods -l app.kubernetes.io/component=pd" >&2
                   exit 1
                 fi
-                echo "Waiting for PD quorum..."
+                echo "Waiting for PD leader and quorum..."
                 sleep 5
               done
-              echo "PD quorum reached."
+              echo "PD leader and quorum reached."
           {{- with .Values.store.waitResources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if not .Values.store.storage.enabled }}
+      volumes:
+        - name: store-data
+          emptyDir: {}
+      {{- end }}
       containers:
         - name: store
           image: "{{ .Values.store.image.repository }}:{{ .Values.store.image.tag | default $.Chart.AppVersion }}"
@@ -180,6 +193,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+  {{- if .Values.store.storage.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: store-data
@@ -191,3 +205,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.store.storage.size }}
+  {{- end }}

--- a/helm/hugegraph/values-1.5.yaml
+++ b/helm/hugegraph/values-1.5.yaml
@@ -15,22 +15,17 @@
 # limitations under the License.
 #
 
-apiVersion: v2
-name: hugegraph
-description: Helm chart for Apache HugeGraph HStore cluster (PD + Store + Server)
-type: application
-version: 0.1.1
-appVersion: "1.7.0"
-kubeVersion: ">=1.22.0-0"
-keywords:
-  - hugegraph
-  - graph
-  - hstore
-  - raft
-home: https://hugegraph.apache.org/
-sources:
-  - https://github.com/apache/hugegraph
-maintainers:
-  - name: HugeGraph Community
-    url: https://hugegraph.apache.org/
-    email: dev@hugegraph.apache.org
+# Apache HugeGraph 1.5.0 compatibility preset.
+# Use only with the corresponding 1.5.0 PD/Store/Server/Hubble images.
+pd:
+  image:
+    tag: 1.5.0
+store:
+  image:
+    tag: 1.5.0
+server:
+  image:
+    tag: 1.5.0
+hubble:
+  image:
+    tag: 1.5.0

--- a/helm/hugegraph/values-1.7.yaml
+++ b/helm/hugegraph/values-1.7.yaml
@@ -15,22 +15,17 @@
 # limitations under the License.
 #
 
-apiVersion: v2
-name: hugegraph
-description: Helm chart for Apache HugeGraph HStore cluster (PD + Store + Server)
-type: application
-version: 0.1.1
-appVersion: "1.7.0"
-kubeVersion: ">=1.22.0-0"
-keywords:
-  - hugegraph
-  - graph
-  - hstore
-  - raft
-home: https://hugegraph.apache.org/
-sources:
-  - https://github.com/apache/hugegraph
-maintainers:
-  - name: HugeGraph Community
-    url: https://hugegraph.apache.org/
-    email: dev@hugegraph.apache.org
+# Apache HugeGraph 1.7.0 compatibility preset.
+# Use only with the corresponding 1.7.0 PD/Store/Server/Hubble images.
+pd:
+  image:
+    tag: 1.7.0
+store:
+  image:
+    tag: 1.7.0
+server:
+  image:
+    tag: 1.7.0
+hubble:
+  image:
+    tag: 1.7.0

--- a/helm/hugegraph/values-cluster.yaml
+++ b/helm/hugegraph/values-cluster.yaml
@@ -23,7 +23,7 @@ pd:
   replicas: 3
   image:
     repository: hugegraph/pd
-    tag: helm-dev
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   javaOpts: >-
     -Xms256m -Xmx512m
@@ -49,7 +49,7 @@ store:
   replicas: 3
   image:
     repository: hugegraph/store
-    tag: helm-dev
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   javaOpts: >-
     -Xms512m -Xmx1024m
@@ -82,7 +82,7 @@ server:
   replicas: 3
   image:
     repository: hugegraph/server
-    tag: helm-dev
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   javaOpts: >-
     -Xms512m -Xmx1024m

--- a/helm/hugegraph/values-master-target.yaml
+++ b/helm/hugegraph/values-master-target.yaml
@@ -15,22 +15,18 @@
 # limitations under the License.
 #
 
-apiVersion: v2
-name: hugegraph
-description: Helm chart for Apache HugeGraph HStore cluster (PD + Store + Server)
-type: application
-version: 0.1.1
-appVersion: "1.7.0"
-kubeVersion: ">=1.22.0-0"
-keywords:
-  - hugegraph
-  - graph
-  - hstore
-  - raft
-home: https://hugegraph.apache.org/
-sources:
-  - https://github.com/apache/hugegraph
-maintainers:
-  - name: HugeGraph Community
-    url: https://hugegraph.apache.org/
-    email: dev@hugegraph.apache.org
+# Candidate matrix preset for the helm-dev branch.
+# helm-dev is a moving candidate and must not be advertised as a released 1.8.
+pd:
+  image:
+    tag: helm-dev
+store:
+  image:
+    tag: helm-dev
+server:
+  image:
+    tag: helm-dev
+hubble:
+  image:
+    # There is no published Hubble helm-dev tag; use the explicit tested base.
+    tag: 1.7.0

--- a/helm/hugegraph/values-single.yaml
+++ b/helm/hugegraph/values-single.yaml
@@ -24,34 +24,40 @@ pd:
   replicas: 1
   image:
     repository: hugegraph/pd
-    tag: helm-dev
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   antiAffinity: disabled
   pdb:
     enabled: false
+  service:
+    clusterIP: None
   storage:
+    enabled: false
     size: 5Gi
 
 store:
   replicas: 1
   image:
     repository: hugegraph/store
-    tag: helm-dev
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   antiAffinity: disabled
   pdb:
     enabled: false
   storage:
+    enabled: false
     size: 10Gi
 
 server:
   replicas: 1
   image:
     repository: hugegraph/server
-    tag: helm-dev
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   hpa:
     enabled: false
+  service:
+    clusterIP: None
   auth:
     enabled: true
     admin:
@@ -62,3 +68,5 @@ server:
 hubble:
   enabled: true
   mode: pd
+  service:
+    clusterIP: None

--- a/helm/hugegraph/values.schema.json
+++ b/helm/hugegraph/values.schema.json
@@ -120,7 +120,6 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "enabled",
         "size",
         "storageClassName"
       ],
@@ -510,7 +509,6 @@
         "image",
         "port",
         "backend",
-        "cluster",
         "resources",
         "waitImage",
         "initStoreEnabled",

--- a/helm/hugegraph/values.schema.json
+++ b/helm/hugegraph/values.schema.json
@@ -120,10 +120,14 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "enabled",
         "size",
         "storageClassName"
       ],
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
         "size": {
           "type": "string",
           "minLength": 1
@@ -354,6 +358,9 @@
                 "LoadBalancer"
               ]
             },
+            "clusterIP": {
+              "type": "string"
+            },
             "annotations": {
               "type": "object"
             },
@@ -503,6 +510,7 @@
         "image",
         "port",
         "backend",
+        "cluster",
         "resources",
         "waitImage",
         "initStoreEnabled",
@@ -530,6 +538,11 @@
         "backend": {
           "type": "string",
           "const": "hstore"
+        },
+        "cluster": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable PD metadata namespace shared by all Server replicas"
         },
         "resources": {
           "$ref": "#/definitions/resources"
@@ -869,6 +882,9 @@
             "NodePort",
             "LoadBalancer"
           ]
+        },
+        "clusterIP": {
+          "type": "string"
         },
         "annotations": {
           "type": "object"

--- a/helm/hugegraph/values.yaml
+++ b/helm/hugegraph/values.yaml
@@ -27,7 +27,7 @@ pd:
   replicas: 3
   image:
     repository: hugegraph/pd
-    tag: helm-dev
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   # Empty preserves the image entrypoint's automatic JVM sizing. The chart
   # renders its partition settings below as -D system properties ahead of
@@ -61,6 +61,7 @@ pd:
     raft: 8610
   dataPath: /hugegraph-pd/pd_data
   storage:
+    enabled: true
     size: 10Gi
     storageClassName: ""
   resources: {}
@@ -126,7 +127,7 @@ store:
   replicas: 3
   image:
     repository: hugegraph/store
-    tag: helm-dev
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   # Empty preserves the image entrypoint's automatic JVM sizing.
   javaOpts: ""
@@ -136,6 +137,7 @@ store:
     rest: 8520
   dataPath: /hugegraph-store/storage
   storage:
+    enabled: true
     size: 50Gi
     storageClassName: ""
   resources: {}
@@ -195,12 +197,16 @@ server:
   replicas: 3
   image:
     repository: hugegraph/server
-    tag: helm-dev
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   # Empty preserves the image entrypoint's automatic JVM sizing.
   javaOpts: ""
   port: 8080
   backend: hstore
+  # PD metadata namespace used by every Server replica. Keep this stable
+  # across upgrades and image changes or existing graph configs will appear
+  # to disappear even though their Store data is still present.
+  cluster: hg-test
   resources: {}
   # Server is stateless and may scale past the node count via HPA, so the
   # default only prefers spreading. Use "required" when replicas are always
@@ -321,17 +327,15 @@ hubble:
   enabled: true
   # pd: discover the cluster through PD (enables the cluster operations view).
   # direct: talk to the Server client Service only, without PD discovery.
-  # Current Hubble images require server.auth to be enabled: the UI login
-  # authenticates against the cluster, so rendering fails otherwise unless
-  # allowWithoutServerAuth explicitly overrides for images that support it.
+  # Released Hubble 1.7 images require server.auth. Set this override only for
+  # a Hubble image with anonymous-session support; the chart then writes
+  # server.auth.enabled=false into Hubble's runtime configuration.
   mode: pd
   allowWithoutServerAuth: false
   image:
     repository: hugegraph/hubble
-    # The draft tracks latest until the next HugeGraph release tag is available.
-    # Pin the release tag and switch to IfNotPresent before stable publication.
-    tag: latest
-    pullPolicy: Always
+    tag: 1.7.0
+    pullPolicy: IfNotPresent
   port: 8088
   # Hubble keeps UI connection metadata, including any graph credentials
   # entered in the UI, in an embedded per-instance H2 database, so the

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
@@ -218,6 +218,18 @@ public final class GraphManager {
         this.rpcServer = new RpcServer(conf);
         this.rpcClient = new RpcClientProvider(conf);
         this.pdPeers = conf.get(ServerOptions.PD_PEERS);
+        this.PDExist = conf.get(ServerOptions.USE_PD);
+
+        /*
+         * Connect the process-wide MetaManager with the configured cluster
+         * before any local HStore graph is opened. StandardHugeGraph has a
+         * legacy fallback connection for callers outside GraphManager; if it
+         * wins this race, every graph config and listener uses its hard-coded
+         * metadata namespace instead of ServerOptions.CLUSTER.
+         */
+        if (this.PDExist) {
+            this.initMetaManager(conf);
+        }
 
         this.roleStateMachine = null;
         this.globalNodeRoleInfo = new GlobalMasterInfo();
@@ -248,8 +260,7 @@ public final class GraphManager {
             this.localGraphs = ImmutableSet.of();
         }
 
-        PDExist = conf.get(ServerOptions.USE_PD);
-        if (PDExist) {
+        if (this.PDExist) {
             try {
                 loadMetaFromPD();
             } catch (Exception e) {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
@@ -265,7 +265,8 @@ public class StandardHugeGraph implements HugeGraph {
 
         if (isHstore()) {
             // TODO: parameterize the remaining configurations
-            MetaManager.instance().connect("hg", MetaManager.MetaDriverType.PD,
+            MetaManager.instance().connect(config.get(CoreOptions.CLUSTER),
+                                           MetaManager.MetaDriverType.PD,
                                            "ca", "ca", "ca",
                                            config.get(CoreOptions.PD_PEERS));
         }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/config/CoreOptions.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/config/CoreOptions.java
@@ -652,6 +652,12 @@ public class CoreOptions extends OptionHolder {
             disallowEmpty(),
             "127.0.0.1:8686"
     );
+    public static final ConfigOption<String> CLUSTER = new ConfigOption<>(
+            "cluster",
+            "The PD metadata namespace shared by HStore graphs.",
+            disallowEmpty(),
+            "hg"
+    );
     public static final ConfigOption<String> MEMORY_MODE = new ConfigOption<>(
             "memory.mode",
             "The memory mode used for query in HugeGraph.",

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/meta/MetaManager.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/meta/MetaManager.java
@@ -162,27 +162,33 @@ public class MetaManager {
                                      String clientKeyFile, Object... args) {
         E.checkArgument(cluster != null && !cluster.isEmpty(),
                         "The cluster can't be null or empty");
-        if (this.metaDriver == null) {
-            this.cluster = cluster;
+        if (this.metaDriver != null) {
+            // MetaManager is process-wide. Opening each HStore graph calls
+            // connect() again with a legacy default cluster. Rebuilding the
+            // managers here would silently switch their key namespace and
+            // discard the graph listeners registered by GraphManager.
+            return;
+        }
 
-            switch (type) {
-                case ETCD:
-                    this.metaDriver = trustFile == null || trustFile.isEmpty() ?
-                                      new EtcdMetaDriver(args) :
-                                      new EtcdMetaDriver(trustFile,
-                                                         clientCertFile,
-                                                         clientKeyFile, args);
-                    break;
-                case PD:
-                    assert args.length > 0;
-                    // FIXME: assume pd.peers is urls separated by commas in a string
-                    //        like `127.0.0.1:8686,127.0.0.1:8687,127.0.0.1:8688`
-                    this.metaDriver = new PdMetaDriver((String) args[0]);
-                    break;
-                default:
-                    throw new AssertionError(String.format(
-                            "Invalid meta driver type: %s", type));
-            }
+        this.cluster = cluster;
+
+        switch (type) {
+            case ETCD:
+                this.metaDriver = trustFile == null || trustFile.isEmpty() ?
+                                  new EtcdMetaDriver(args) :
+                                  new EtcdMetaDriver(trustFile,
+                                                     clientCertFile,
+                                                     clientKeyFile, args);
+                break;
+            case PD:
+                assert args.length > 0;
+                // FIXME: assume pd.peers is urls separated by commas in a string
+                //        like `127.0.0.1:8686,127.0.0.1:8687,127.0.0.1:8688`
+                this.metaDriver = new PdMetaDriver((String) args[0]);
+                break;
+            default:
+                throw new AssertionError(String.format(
+                        "Invalid meta driver type: %s", type));
         }
         this.initManagers(this.cluster);
     }

--- a/hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh
+++ b/hugegraph-server/hugegraph-dist/docker/docker-entrypoint.sh
@@ -124,6 +124,8 @@ fi
     set_prop "pd.peers" "${HG_SERVER_PD_PEERS}" "${REST_SERVER_CONF}"
 [[ -n "${HG_SERVER_CLUSTER:-}" ]] && \
     set_prop "cluster" "${HG_SERVER_CLUSTER}" "${REST_SERVER_CONF}"
+[[ -n "${HG_SERVER_CLUSTER:-}" ]] && \
+    set_prop "cluster" "${HG_SERVER_CLUSTER}" "${GRAPH_CONF}"
 [[ -n "${HG_SERVER_REST_URL:-}" ]] && set_prop "restserver.url" \
     "${HG_SERVER_REST_URL}" "${REST_SERVER_CONF}"
 [[ -n "${HG_SERVER_MIN_FREE_MEMORY:-}" ]] && set_prop "restserver.min_free_memory" \

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/meta/MetaManagerConnectionTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/meta/MetaManagerConnectionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.meta;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hugegraph.meta.managers.GraphMetaManager;
+import org.apache.hugegraph.testutil.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class MetaManagerConnectionTest {
+
+    @Test
+    public void testReconnectKeepsOriginalClusterAndManagers() throws Exception {
+        MetaManager manager = MetaManager.instance();
+        Map<Field, Object> original = mutableState(manager);
+        MetaDriver driver = Mockito.mock(MetaDriver.class);
+        GraphMetaManager graphManager = new GraphMetaManager(driver,
+                                                             "configured");
+        try {
+            setField(manager, "metaDriver", driver);
+            setField(manager, "cluster", "configured");
+            setField(manager, "graphMetaManager", graphManager);
+
+            manager.connect("legacy-default", MetaManager.MetaDriverType.PD,
+                            null, null, null, "unused:8686");
+
+            Assert.assertEquals("configured", manager.cluster());
+            Assert.assertSame(graphManager,
+                              field(manager, "graphMetaManager").get(manager));
+        } finally {
+            restoreState(manager, original);
+        }
+    }
+
+    private static Map<Field, Object> mutableState(MetaManager manager)
+            throws IllegalAccessException {
+        Map<Field, Object> state = new HashMap<>();
+        for (Field field : MetaManager.class.getDeclaredFields()) {
+            if (Modifier.isStatic(field.getModifiers()) ||
+                Modifier.isFinal(field.getModifiers())) {
+                continue;
+            }
+            field.setAccessible(true);
+            state.put(field, field.get(manager));
+        }
+        return state;
+    }
+
+    private static void restoreState(MetaManager manager,
+                                     Map<Field, Object> state)
+            throws IllegalAccessException {
+        for (Map.Entry<Field, Object> entry : state.entrySet()) {
+            entry.getKey().set(manager, entry.getValue());
+        }
+    }
+
+    private static void setField(MetaManager manager, String name, Object value)
+            throws ReflectiveOperationException {
+        field(manager, name).set(manager, value);
+    }
+
+    private static Field field(MetaManager manager, String name)
+            throws NoSuchFieldException {
+        Field field = manager.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field;
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -23,6 +23,7 @@ import org.apache.hugegraph.auth.StandardAuthManagerV2Test;
 import org.apache.hugegraph.auth.WsAndHttpBasicAuthHandlerTest;
 import org.apache.hugegraph.core.RoleElectionStateMachineTest;
 import org.apache.hugegraph.meta.EtcdMetaDriverTest;
+import org.apache.hugegraph.meta.MetaManagerConnectionTest;
 import org.apache.hugegraph.meta.MetaManagerSchemaCacheClearEventTest;
 import org.apache.hugegraph.meta.managers.AuthMetaManagerTest;
 import org.apache.hugegraph.traversal.optimize.TraversalUtilOptimizeTest;
@@ -119,6 +120,7 @@ import org.junit.runners.Suite;
         CacheTest.LevelCacheTest.class,
         CachedSchemaTransactionTest.class,
         MetaManagerSchemaCacheClearEventTest.class,
+        MetaManagerConnectionTest.class,
         EtcdMetaDriverTest.class,
         CachedGraphTransactionTest.class,
         CacheManagerTest.class,


### PR DESCRIPTION
## Summary

- keep PD metadata connections stable when HStore graphs are opened
- propagate configured cluster names into graph runtime and container configuration
- wait for PD leader and quorum before Store startup, and make storage/service behavior explicit
- add pinned 1.5, 1.7, and master-target values presets
- gate Hubble no-auth configuration behind `allowWithoutServerAuth`

## Testing

- [x] targeted `MetaManager` regression test
- [x] HugeGraph distribution package
- [x] Helm lint and no-auth render
- [x] real Helm install and upgrade with 1 PD + 1 Store + 1 Server
- [x] Server Pod replacement with schema and data read-back

## Validation scope

The live test environment was constrained to three Pods, so multi-replica failover and multi-Server readiness remain outside this PR's runtime validation.
