### PR TITLE
fix(hstore): clear schema metadata and stabilize cluster startup

### DIFF
--- a/hugegraph-cluster-test/hugegraph-clustertest-minicluster/src/main/java/org/apache/hugegraph/ct/env/AbstractEnv.java
+++ b/hugegraph-cluster-test/hugegraph-clustertest-minicluster/src/main/java/org/apache/hugegraph/ct/env/AbstractEnv.java
@@ -19,15 +19,21 @@ package org.apache.hugegraph.ct.env;
 
 import static org.apache.hugegraph.ct.base.ClusterConstant.CONF_DIR;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.hugegraph.ct.base.HGTestLogger;
 import org.apache.hugegraph.ct.config.ClusterConfig;
 import org.apache.hugegraph.ct.config.GraphConfig;
 import org.apache.hugegraph.ct.config.PDConfig;
 import org.apache.hugegraph.ct.config.ServerConfig;
 import org.apache.hugegraph.ct.config.StoreConfig;
+import org.apache.hugegraph.ct.node.BaseNodeWrapper;
 import org.apache.hugegraph.ct.node.PDNodeWrapper;
 import org.apache.hugegraph.ct.node.ServerNodeWrapper;
 import org.apache.hugegraph.ct.node.StoreNodeWrapper;
@@ -39,6 +45,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class AbstractEnv implements BaseEnv {
 
+    private static final long NODE_START_TIMEOUT_MINUTES = 5L;
+    private static final int START_LOG_TAIL_LINES = 80;
     private static final Logger LOG = HGTestLogger.ENV_LOG;
 
     protected ClusterConfig clusterConfig;
@@ -87,36 +95,64 @@ public abstract class AbstractEnv implements BaseEnv {
     }
 
     public void startCluster() {
-        for (PDNodeWrapper pdNodeWrapper : pdNodeWrappers) {
-            pdNodeWrapper.start();
-            while (!pdNodeWrapper.isStarted()) {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+        try {
+            for (PDNodeWrapper pdNodeWrapper : pdNodeWrappers) {
+                pdNodeWrapper.start();
+                this.waitUntilStarted(pdNodeWrapper);
+            }
+            for (StoreNodeWrapper storeNodeWrapper : storeNodeWrappers) {
+                storeNodeWrapper.start();
+                this.waitUntilStarted(storeNodeWrapper);
+            }
+            for (ServerNodeWrapper serverNodeWrapper : serverNodeWrappers) {
+                serverNodeWrapper.start();
+                this.waitUntilStarted(serverNodeWrapper);
+            }
+        } catch (RuntimeException | Error e) {
+            this.stopCluster();
+            throw e;
+        }
+    }
+
+    private void waitUntilStarted(BaseNodeWrapper node) {
+        long deadline = System.nanoTime() +
+                        TimeUnit.MINUTES.toNanos(NODE_START_TIMEOUT_MINUTES);
+        while (!node.isStarted()) {
+            if (!node.isAlive()) {
+                throw this.startupFailure(node, "exited before startup");
+            }
+            if (System.nanoTime() >= deadline) {
+                throw this.startupFailure(node, String.format(
+                          "did not start within %s minutes",
+                          NODE_START_TIMEOUT_MINUTES));
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
             }
         }
-        for (StoreNodeWrapper storeNodeWrapper : storeNodeWrappers) {
-            storeNodeWrapper.start();
-            while (!storeNodeWrapper.isStarted()) {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+    }
+
+    private AssertionError startupFailure(BaseNodeWrapper node, String reason) {
+        StringBuilder message = new StringBuilder(String.format(
+                "Node '%s' %s; startup log: '%s'",
+                node.getID(), reason, node.getLogPath()));
+        try {
+            List<String> lines = FileUtils.readLines(
+                    new File(node.getLogPath()), StandardCharsets.UTF_8);
+            int from = Math.max(0, lines.size() - START_LOG_TAIL_LINES);
+            message.append(System.lineSeparator()).append("Startup log tail:");
+            for (String line : lines.subList(from, lines.size())) {
+                message.append(System.lineSeparator()).append(line);
             }
+        } catch (IOException e) {
+            message.append(System.lineSeparator())
+                   .append("Failed to read startup log: ")
+                   .append(e.getMessage());
         }
-        for (ServerNodeWrapper serverNodeWrapper : serverNodeWrappers) {
-            serverNodeWrapper.start();
-            while (!serverNodeWrapper.isStarted()) {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
+        return new AssertionError(message.toString());
     }
 
     public void stopCluster() {

--- a/hugegraph-cluster-test/hugegraph-clustertest-minicluster/src/main/java/org/apache/hugegraph/ct/node/PDNodeWrapper.java
+++ b/hugegraph-cluster-test/hugegraph-clustertest-minicluster/src/main/java/org/apache/hugegraph/ct/node/PDNodeWrapper.java
@@ -70,8 +70,8 @@ public class PDNodeWrapper extends AbstractNodeWrapper {
             String pdNodeJarPath = getFileInDir(workPath, PD_JAR_PREFIX);
             startCmd.addAll(Arrays.asList(
                     "-Dname=HugeGraphPD" + this.index,
-                    "-Xms512m",
-                    "-Xmx4g",
+                    "-Xms128m",
+                    "-Xmx512m",
                     "-XX:+HeapDumpOnOutOfMemoryError",
                     "-XX:HeapDumpPath=" + configPath + "logs",
                     "-Dlog4j.configurationFile=" + configPath + File.separator +

--- a/hugegraph-cluster-test/hugegraph-clustertest-minicluster/src/main/java/org/apache/hugegraph/ct/node/ServerNodeWrapper.java
+++ b/hugegraph-cluster-test/hugegraph-clustertest-minicluster/src/main/java/org/apache/hugegraph/ct/node/ServerNodeWrapper.java
@@ -124,6 +124,8 @@ public class ServerNodeWrapper extends AbstractNodeWrapper {
 
             startCmd.addAll(Arrays.asList(
                     "-Dname=HugeGraphServer" + this.index,
+                    "-Xms128m",
+                    "-Xmx1g",
                     "--add-exports=java.base/jdk.internal.reflect=ALL-UNNAMED",
                     "--add-modules=jdk.unsupported",
                     "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",

--- a/hugegraph-cluster-test/hugegraph-clustertest-minicluster/src/main/java/org/apache/hugegraph/ct/node/StoreNodeWrapper.java
+++ b/hugegraph-cluster-test/hugegraph-clustertest-minicluster/src/main/java/org/apache/hugegraph/ct/node/StoreNodeWrapper.java
@@ -39,7 +39,7 @@ public class StoreNodeWrapper extends AbstractNodeWrapper {
         super();
         this.fileNames = new ArrayList<>(List.of(LOG4J_FILE));
         this.workPath = STORE_LIB_PATH;
-        this.startLine = "o.a.h.s.n.StoreNodeApplication - Starting StoreNodeApplication";
+        this.startLine = "o.a.h.s.n.StoreNodeApplication - Started StoreNodeApplication";
         createNodeDir(Paths.get(STORE_TEMPLATE_PATH), getNodePath() + CONF_DIR + File.separator);
         createLogDir();
     }
@@ -48,7 +48,7 @@ public class StoreNodeWrapper extends AbstractNodeWrapper {
         super(clusterId, index);
         this.fileNames = new ArrayList<>(List.of(LOG4J_FILE));
         this.workPath = STORE_LIB_PATH;
-        this.startLine = "o.a.h.s.n.StoreNodeApplication - Starting StoreNodeApplication";
+        this.startLine = "o.a.h.s.n.StoreNodeApplication - Started StoreNodeApplication";
         createNodeDir(Paths.get(STORE_TEMPLATE_PATH), getNodePath() + CONF_DIR + File.separator);
         createLogDir();
     }
@@ -70,8 +70,8 @@ public class StoreNodeWrapper extends AbstractNodeWrapper {
                     "-Dlog4j.configurationFile=" + configPath + CONF_DIR
                     + File.separator + "log4j2.xml",
                     "-Dfastjson.parser.safeMode=true",
-                    "-Xms512m",
-                    "-Xmx2048m",
+                    "-Xms128m",
+                    "-Xmx1g",
                     "-XX:MetaspaceSize=256M",
                     "-XX:+UseG1GC",
                     "-XX:+ParallelRefProcEnabled",

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/StandardHugeGraph.java
@@ -519,6 +519,9 @@ public class StandardHugeGraph implements HugeGraph {
 
         LockUtil.lock(this.spaceGraphName(), LockUtil.GRAPH_LOCK);
         try {
+            if (this.isHstore()) {
+                ((CachedSchemaTransactionV2) this.schemaTransaction()).clear();
+            }
             this.storeProvider.clear();
         } finally {
             LockUtil.unlock(this.spaceGraphName(), LockUtil.GRAPH_LOCK);

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedSchemaTransactionV2.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/CachedSchemaTransactionV2.java
@@ -467,6 +467,7 @@ public class CachedSchemaTransactionV2 extends SchemaTransactionV2 {
         // Clear schema info firstly
         super.clear();
         this.clearCache(false);
+        this.notifySchemaCacheClear();
     }
 
     private static final class SchemaCaches<V extends SchemaElement> {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -51,6 +51,7 @@ import org.apache.hugegraph.unit.core.GraphManagerConfigTest;
 import org.apache.hugegraph.unit.core.LocksTableTest;
 import org.apache.hugegraph.unit.core.PageStateTest;
 import org.apache.hugegraph.unit.core.QueryTest;
+import org.apache.hugegraph.unit.core.StandardHugeGraphClearBackendTest;
 import org.apache.hugegraph.unit.core.RangeTest;
 import org.apache.hugegraph.unit.core.RolePermissionTest;
 import org.apache.hugegraph.unit.core.RowLockTest;
@@ -139,6 +140,7 @@ import org.junit.runners.Suite;
         AnalyzerTest.class,
         BackendMutationTest.class,
         ConditionTest.class,
+        StandardHugeGraphClearBackendTest.class,
         ConditionQueryFlattenTest.class,
         QueryTest.class,
         RangeTest.class,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/StandardHugeGraphClearBackendTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/StandardHugeGraphClearBackendTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.unit.core;
+
+import org.apache.hugegraph.HugeException;
+import org.apache.hugegraph.StandardHugeGraph;
+import org.apache.hugegraph.backend.cache.CachedSchemaTransactionV2;
+import org.apache.hugegraph.backend.store.BackendStore;
+import org.apache.hugegraph.backend.store.BackendStoreProvider;
+import org.apache.hugegraph.config.HugeConfig;
+import org.apache.hugegraph.task.TaskScheduler;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.testutil.Whitebox;
+import org.apache.hugegraph.unit.BaseUnitTest;
+import org.apache.hugegraph.unit.FakeObjects;
+import org.apache.hugegraph.util.LockUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+public class StandardHugeGraphClearBackendTest extends BaseUnitTest {
+
+    private static final String SPACE_GRAPH = "space-graph";
+
+    private StandardHugeGraph graph;
+    private BackendStoreProvider provider;
+    private CachedSchemaTransactionV2 schemaTransaction;
+
+    @Before
+    public void setup() {
+        HugeConfig config = FakeObjects.newConfig();
+        this.graph = Mockito.mock(StandardHugeGraph.class,
+                                  Mockito.CALLS_REAL_METHODS);
+        this.provider = Mockito.mock(BackendStoreProvider.class);
+        this.schemaTransaction = Mockito.mock(CachedSchemaTransactionV2.class);
+        BackendStore schemaStore = Mockito.mock(BackendStore.class);
+        BackendStore systemStore = Mockito.mock(BackendStore.class);
+        BackendStore graphStore = Mockito.mock(BackendStore.class);
+        TaskScheduler scheduler = Mockito.mock(TaskScheduler.class);
+
+        Whitebox.setInternalState(this.graph, "configuration", config);
+        Whitebox.setInternalState(this.graph, "storeProvider", this.provider);
+        Whitebox.setInternalState(this.graph, "name", "graph");
+        Whitebox.setInternalState(this.graph, "graphSpace", "space");
+
+        Mockito.doReturn(scheduler).when(this.graph).taskScheduler();
+        Mockito.doReturn(this.schemaTransaction)
+               .when(this.graph).schemaTransaction();
+        Mockito.when(this.provider.isHstore()).thenReturn(true);
+        Mockito.when(this.provider.loadSchemaStore(config))
+               .thenReturn(schemaStore);
+        Mockito.when(this.provider.loadSystemStore(config))
+               .thenReturn(systemStore);
+        Mockito.when(this.provider.loadGraphStore(config))
+               .thenReturn(graphStore);
+        LockUtil.init(SPACE_GRAPH);
+    }
+
+    @After
+    public void teardown() {
+        LockUtil.destroy(SPACE_GRAPH);
+    }
+
+    @Test
+    public void testHstoreClearSchemaBeforeStore() {
+        this.graph.clearBackend();
+
+        InOrder order = Mockito.inOrder(this.schemaTransaction, this.provider);
+        order.verify(this.schemaTransaction).clear();
+        order.verify(this.provider).clear();
+    }
+
+    @Test
+    public void testHstoreSchemaFailureStopsStoreClear() {
+        Mockito.doThrow(new HugeException("schema clear failed"))
+               .when(this.schemaTransaction).clear();
+
+        Assert.assertThrows(HugeException.class, this.graph::clearBackend);
+        Mockito.verify(this.provider, Mockito.never()).clear();
+    }
+
+    @Test
+    public void testHstoreStoreFailurePropagates() {
+        Mockito.doThrow(new HugeException("store clear failed"))
+               .when(this.provider).clear();
+
+        Assert.assertThrows(HugeException.class, this.graph::clearBackend);
+        Mockito.verify(this.schemaTransaction).clear();
+    }
+
+    @Test
+    public void testRocksdbDoesNotClearV2SchemaMetadata() {
+        Mockito.when(this.provider.isHstore()).thenReturn(false);
+
+        this.graph.clearBackend();
+
+        Mockito.verify(this.schemaTransaction, Mockito.never()).clear();
+        Mockito.verify(this.provider).clear();
+    }
+}


### PR DESCRIPTION
## Summary

- clear HStore schema metadata and local caches before clearing backend data
- broadcast schema-cache invalidation to peer Server nodes
- cover ordering, failure propagation, and non-HStore behavior with unit tests
- wait for the actual Store Started marker in cluster-test
- fail fast when a child process exits or does not become ready within 5 minutes
- print the final 80 startup-log lines, clean up started nodes, and bound child JVM heaps

## Scope

This PR restores only the HStore schema-cleanup and cluster-test startup changes. It does not restore the authorization changes or the HBase Docker CI workflow from the withdrawn follow-up series.

## Testing

- Not run locally. The Maven bootstrap was stopped before completion at the author request; repository CI is expected to validate the branch.