### PR TITLE
refactor(server): route remote Gremlin through GremlinLang

### DIFF
--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java
@@ -117,11 +117,21 @@ public class ContextGremlinServer extends GremlinServer {
     @Override
     public synchronized CompletableFuture<Void> stop() {
         try {
-            return super.stop();
-        } finally {
-            this.gremlinLangEngine.clear();
-            this.unlistenChanges();
+            return afterStop(super.stop(), this::cleanup);
+        } catch (RuntimeException | Error e) {
+            this.cleanup();
+            throw e;
         }
+    }
+
+    static CompletableFuture<Void> afterStop(CompletableFuture<Void> stop,
+                                             Runnable cleanup) {
+        return stop.whenComplete((result, error) -> cleanup.run());
+    }
+
+    private void cleanup() {
+        this.gremlinLangEngine.clear();
+        this.unlistenChanges();
     }
 
     public void injectAuthGraph() {
@@ -146,8 +156,9 @@ public class ContextGremlinServer extends GremlinServer {
                         "it may lead to gremlin query error.", gName);
             }
             // Add a traversal source for all graphs with customed rule.
-            manager.putTraversalSource(gName, g);
-            this.gremlinLangEngine.add(g);
+            GraphTraversalSource protectedSource =
+                    this.gremlinLangEngine.add(g);
+            manager.putTraversalSource(gName, protectedSource);
         }
     }
 
@@ -161,8 +172,9 @@ public class ContextGremlinServer extends GremlinServer {
         manager.putGraph(name, graph);
 
         GraphTraversalSource g = manager.getGraph(name).traversal();
-        manager.putTraversalSource(G_PREFIX + name, g);
-        this.gremlinLangEngine.add(g);
+        GraphTraversalSource protectedSource =
+                this.gremlinLangEngine.add(g);
+        manager.putTraversalSource(G_PREFIX + name, protectedSource);
 
         Whitebox.invoke(executor, "globalBindings",
                         new Class<?>[]{String.class, Object.class},

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java
@@ -27,10 +27,15 @@ import org.apache.hugegraph.auth.HugeGraphAuthProxy.Context;
 import org.apache.hugegraph.auth.HugeGraphAuthProxy.ContextThreadPoolExecutor;
 import org.apache.hugegraph.config.CoreOptions;
 import org.apache.hugegraph.event.EventHub;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngine;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
 import org.apache.hugegraph.testutil.Whitebox;
 import org.apache.hugegraph.util.Events;
 import org.apache.hugegraph.util.Log;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineManager;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.server.GraphManager;
 import org.apache.tinkerpop.gremlin.server.GremlinServer;
@@ -49,6 +54,7 @@ public class ContextGremlinServer extends GremlinServer {
     private static final String G_PREFIX = "__g_";
 
     private final EventHub eventHub;
+    private final HugeGraphGremlinLangScriptEngine gremlinLangEngine;
 
     static {
         HugeGraphAuthProxy.setContext(Context.admin());
@@ -60,6 +66,26 @@ public class ContextGremlinServer extends GremlinServer {
          */
         super(settings, newGremlinExecutorService(settings));
         this.eventHub = eventHub;
+        GremlinScriptEngineManager manager =
+                this.getServerGremlinExecutor()
+                    .getGremlinExecutor()
+                    .getScriptEngineManager();
+        GremlinScriptEngine engine = manager.getEngineByName(
+                HugeGraphGremlinLangScriptEngineFactory.INTERNAL_ENGINE_NAME);
+        if (!(engine instanceof HugeGraphGremlinLangScriptEngine)) {
+            throw new HugeException("Failed to initialize HugeGraph " +
+                                    "GremlinLang script engine");
+        }
+        this.gremlinLangEngine = (HugeGraphGremlinLangScriptEngine) engine;
+        manager.registerEngineName(
+                HugeGraphGremlinLangScriptEngineFactory.ENGINE_NAME,
+                this.gremlinLangEngine.getFactory());
+        if (manager.getEngineByName(
+                    HugeGraphGremlinLangScriptEngineFactory.ENGINE_NAME) !=
+            this.gremlinLangEngine) {
+            throw new HugeException("Failed to register public GremlinLang " +
+                                    "script engine name");
+        }
         this.listenChanges();
     }
 
@@ -93,6 +119,7 @@ public class ContextGremlinServer extends GremlinServer {
         try {
             return super.stop();
         } finally {
+            this.gremlinLangEngine.clear();
             this.unlistenChanges();
         }
     }
@@ -146,6 +173,11 @@ public class ContextGremlinServer extends GremlinServer {
         GremlinExecutor executor = this.getServerGremlinExecutor()
                                        .getGremlinExecutor();
         try {
+            TraversalSource source = manager.getTraversalSource(G_PREFIX +
+                                                                 name);
+            if (source instanceof GraphTraversalSource) {
+                this.gremlinLangEngine.remove((GraphTraversalSource) source);
+            }
             manager.removeGraph(name);
             manager.removeTraversalSource(G_PREFIX + name);
             Whitebox.invoke(executor, "globalBindings",

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/ContextGremlinServer.java
@@ -147,6 +147,7 @@ public class ContextGremlinServer extends GremlinServer {
             }
             // Add a traversal source for all graphs with customed rule.
             manager.putTraversalSource(gName, g);
+            this.gremlinLangEngine.add(g);
         }
     }
 
@@ -161,6 +162,7 @@ public class ContextGremlinServer extends GremlinServer {
 
         GraphTraversalSource g = manager.getGraph(name).traversal();
         manager.putTraversalSource(G_PREFIX + name, g);
+        this.gremlinLangEngine.add(g);
 
         Whitebox.invoke(executor, "globalBindings",
                         new Class<?>[]{String.class, Object.class},
@@ -190,6 +192,14 @@ public class ContextGremlinServer extends GremlinServer {
     }
 
     static ExecutorService newGremlinExecutorService(Settings settings) {
+        if (!HugeGraphWsAndHttpChannelizer.class.getName().equals(
+                settings.channelizer)) {
+            throw new HugeException(
+                    "The Gremlin Server channelizer must be '%s' to " +
+                    "protect remote Gremlin requests, but got '%s'",
+                    HugeGraphWsAndHttpChannelizer.class.getName(),
+                    settings.channelizer);
+        }
         if (settings.gremlinPool == 0) {
             settings.gremlinPool = CoreOptions.CPUS;
         }

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangHttpHandler.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangHttpHandler.java
@@ -21,6 +21,8 @@ import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE;
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -29,14 +31,19 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.hugegraph.util.JsonUtil;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.server.GraphManager;
 import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpHandlerUtil;
 import org.apache.tinkerpop.gremlin.util.MessageSerializer;
+import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.util.ser.SerializationException;
+import org.apache.tinkerpop.shaded.jackson.databind.JsonNode;
+import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
+import org.apache.tinkerpop.shaded.jackson.databind.node.ObjectNode;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -50,6 +57,8 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.util.ReferenceCountUtil;
 
 public class GremlinLangHttpHandler extends HttpGremlinEndpointHandler {
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     private final Map<String, MessageSerializer<?>> serializers;
 
@@ -72,14 +81,34 @@ public class GremlinLangHttpHandler extends HttpGremlinEndpointHandler {
         FullHttpRequest request = (FullHttpRequest) message;
         ByteBuf content = request.content();
         int readerIndex = content.readerIndex();
+        RequestMessage gremlinRequest;
+        boolean serialized = this.isSerializedRequest(request);
+        boolean languageProvided;
         String rejection = null;
         try {
-            RequestMessage gremlinRequest =
-                    HttpHandlerUtil.getRequestMessageFromHttpRequest(
-                            request, this.serializers);
-            rejection = GremlinLangRequestGuard.rejection(gremlinRequest);
+            languageProvided = !serialized &&
+                               this.hasLanguageArgument(request);
+            gremlinRequest = HttpHandlerUtil.getRequestMessageFromHttpRequest(
+                    request, this.serializers);
+            if (serialized) {
+                languageProvided = gremlinRequest.getArgs().containsKey(
+                        Tokens.ARGS_LANGUAGE);
+            }
+            if (!languageProvided) {
+                gremlinRequest.getArgs().remove(Tokens.ARGS_LANGUAGE);
+            }
+            if (serialized && gremlinRequest.getArgs().get(
+                    Tokens.ARGS_GREMLIN) instanceof Bytecode) {
+                rejection = "HTTP Bytecode requests are not supported; " +
+                            "use the standard WebSocket traversal protocol";
+            } else {
+                rejection = GremlinLangRequestGuard.rejection(
+                        gremlinRequest);
+            }
         } catch (SerializationException | IllegalArgumentException ignored) {
             // Let TinkerPop produce its normal malformed-request response.
+            gremlinRequest = null;
+            languageProvided = true;
         } finally {
             content.readerIndex(readerIndex);
         }
@@ -88,7 +117,94 @@ public class GremlinLangHttpHandler extends HttpGremlinEndpointHandler {
             this.sendRejection(context, request, rejection);
             return;
         }
-        super.channelRead(context, message);
+        if (gremlinRequest == null || languageProvided) {
+            super.channelRead(context, message);
+            return;
+        }
+
+        FullHttpRequest normalized;
+        try {
+            normalized = this.withDefaultLanguage(context, request,
+                                                  gremlinRequest, serialized);
+        } catch (SerializationException | IllegalArgumentException e) {
+            this.sendRejection(context, request, e.getMessage());
+            return;
+        }
+        super.channelRead(context, normalized);
+    }
+
+    private boolean isSerializedRequest(FullHttpRequest request) {
+        String contentType = request.headers().get(CONTENT_TYPE);
+        return request.method() == POST && contentType != null &&
+               !"application/json".equals(contentType) &&
+               this.serializers.containsKey(contentType);
+    }
+
+    private boolean hasLanguageArgument(FullHttpRequest request) {
+        if (request.method() == GET) {
+            String uri = request.uri();
+            return new io.netty.handler.codec.http.QueryStringDecoder(uri).
+                   parameters().containsKey(Tokens.ARGS_LANGUAGE);
+        }
+        if (request.method() != POST) {
+            return true;
+        }
+        try {
+            JsonNode body = JSON_MAPPER.readTree(
+                    request.content().toString(StandardCharsets.UTF_8));
+            return body != null && body.has(Tokens.ARGS_LANGUAGE);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("body could not be parsed", e);
+        }
+    }
+
+    private FullHttpRequest withDefaultLanguage(
+            ChannelHandlerContext context,
+            FullHttpRequest request,
+            RequestMessage gremlinRequest,
+            boolean serialized) throws SerializationException {
+        if (request.method() == GET) {
+            String separator = request.uri().contains("?") ? "&" : "?";
+            request.setUri(request.uri() + separator + Tokens.ARGS_LANGUAGE +
+                           "=" + GremlinLangRequestGuard.GREMLIN_LANG);
+            return request;
+        }
+
+        ByteBuf normalizedContent;
+        if (serialized) {
+            String contentType = request.headers().get(CONTENT_TYPE);
+            MessageSerializer<?> serializer = this.serializers.get(
+                    contentType);
+            normalizedContent = serializer.serializeRequestAsBinary(
+                    GremlinLangRequestGuard.normalize(gremlinRequest),
+                    context.alloc());
+        } else {
+            try {
+                JsonNode parsed = JSON_MAPPER.readTree(
+                        request.content().toString(StandardCharsets.UTF_8));
+                if (!(parsed instanceof ObjectNode)) {
+                    throw new IllegalArgumentException(
+                            "The request body must be a JSON object");
+                }
+                ObjectNode body = (ObjectNode) parsed;
+                body.put(Tokens.ARGS_LANGUAGE,
+                         GremlinLangRequestGuard.GREMLIN_LANG);
+                byte[] bytes = JSON_MAPPER.writeValueAsBytes(body);
+                normalizedContent = context.alloc().buffer();
+                normalizedContent.writeBytes(bytes);
+            } catch (IllegalArgumentException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        "Failed to apply the default Gremlin language", e);
+            }
+        }
+
+        FullHttpRequest normalized = request.replace(normalizedContent);
+        normalized.headers().setInt(CONTENT_LENGTH,
+                                    normalizedContent.readableBytes());
+        ReferenceCountUtil.release(request);
+        return normalized;
     }
 
     private void sendRejection(ChannelHandlerContext context,

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangHttpHandler.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangHttpHandler.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.auth;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.hugegraph.util.JsonUtil;
+import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
+import org.apache.tinkerpop.gremlin.server.GraphManager;
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler;
+import org.apache.tinkerpop.gremlin.server.handler.HttpHandlerUtil;
+import org.apache.tinkerpop.gremlin.util.MessageSerializer;
+import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.util.ser.SerializationException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.util.ReferenceCountUtil;
+
+public class GremlinLangHttpHandler extends HttpGremlinEndpointHandler {
+
+    private final Map<String, MessageSerializer<?>> serializers;
+
+    public GremlinLangHttpHandler(
+            Map<String, MessageSerializer<?>> serializers,
+            GremlinExecutor gremlinExecutor,
+            GraphManager graphManager,
+            Settings settings) {
+        super(serializers, gremlinExecutor, graphManager, settings);
+        this.serializers = serializers;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext context, Object message) {
+        if (!(message instanceof FullHttpRequest)) {
+            super.channelRead(context, message);
+            return;
+        }
+
+        FullHttpRequest request = (FullHttpRequest) message;
+        ByteBuf content = request.content();
+        int readerIndex = content.readerIndex();
+        String rejection = null;
+        try {
+            RequestMessage gremlinRequest =
+                    HttpHandlerUtil.getRequestMessageFromHttpRequest(
+                            request, this.serializers);
+            rejection = GremlinLangRequestGuard.rejection(gremlinRequest);
+        } catch (SerializationException | IllegalArgumentException ignored) {
+            // Let TinkerPop produce its normal malformed-request response.
+        } finally {
+            content.readerIndex(readerIndex);
+        }
+
+        if (rejection != null) {
+            this.sendRejection(context, request, rejection);
+            return;
+        }
+        super.channelRead(context, message);
+    }
+
+    private void sendRejection(ChannelHandlerContext context,
+                               FullHttpRequest request,
+                               String rejection) {
+        boolean keepAlive = HttpUtil.isKeepAlive(request);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("code", BAD_REQUEST.code());
+        body.put("message", rejection);
+        ByteBuf content = Unpooled.copiedBuffer(JsonUtil.toJson(body),
+                                                StandardCharsets.UTF_8);
+        FullHttpResponse response = new DefaultFullHttpResponse(
+                HTTP_1_1, BAD_REQUEST, content);
+        response.headers().set(CONTENT_TYPE,
+                               "application/json; charset=UTF-8");
+        response.headers().setInt(CONTENT_LENGTH, content.readableBytes());
+        if (keepAlive) {
+            response.headers().set(CONNECTION, KEEP_ALIVE);
+        }
+
+        ReferenceCountUtil.release(request);
+        ChannelFuture future = context.writeAndFlush(response);
+        if (!keepAlive) {
+            future.addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+}

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangHttpHandler.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangHttpHandler.java
@@ -17,6 +17,7 @@
 
 package org.apache.hugegraph.auth;
 
+import static com.codahale.metrics.MetricRegistry.name;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
@@ -29,14 +30,17 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.hugegraph.util.JsonUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.server.GraphManager;
+import org.apache.tinkerpop.gremlin.server.GremlinServer;
 import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler;
 import org.apache.tinkerpop.gremlin.server.handler.HttpHandlerUtil;
+import org.apache.tinkerpop.gremlin.server.util.MetricManager;
 import org.apache.tinkerpop.gremlin.util.MessageSerializer;
 import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
@@ -44,6 +48,8 @@ import org.apache.tinkerpop.gremlin.util.ser.SerializationException;
 import org.apache.tinkerpop.shaded.jackson.databind.JsonNode;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
 import org.apache.tinkerpop.shaded.jackson.databind.node.ObjectNode;
+
+import com.codahale.metrics.Meter;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -59,6 +65,8 @@ import io.netty.util.ReferenceCountUtil;
 public class GremlinLangHttpHandler extends HttpGremlinEndpointHandler {
 
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final Meter ERROR_METER = MetricManager.INSTANCE.getMeter(
+            name(GremlinServer.class, "errors"));
 
     private final Map<String, MessageSerializer<?>> serializers;
 
@@ -81,40 +89,48 @@ public class GremlinLangHttpHandler extends HttpGremlinEndpointHandler {
         FullHttpRequest request = (FullHttpRequest) message;
         ByteBuf content = request.content();
         int readerIndex = content.readerIndex();
-        RequestMessage gremlinRequest;
+        RequestMessage gremlinRequest = null;
+        UUID requestId = null;
         boolean serialized = this.isSerializedRequest(request);
-        boolean languageProvided;
+        boolean languageProvided = true;
         String rejection = null;
         try {
+            JsonNode jsonBody = !serialized && request.method() == POST ?
+                                this.parseJsonBody(request) : null;
             languageProvided = !serialized &&
-                               this.hasLanguageArgument(request);
-            gremlinRequest = HttpHandlerUtil.getRequestMessageFromHttpRequest(
-                    request, this.serializers);
-            if (serialized) {
-                languageProvided = gremlinRequest.getArgs().containsKey(
-                        Tokens.ARGS_LANGUAGE);
-            }
-            if (!languageProvided) {
-                gremlinRequest.getArgs().remove(Tokens.ARGS_LANGUAGE);
-            }
-            if (serialized && gremlinRequest.getArgs().get(
-                    Tokens.ARGS_GREMLIN) instanceof Bytecode) {
-                rejection = "HTTP Bytecode requests are not supported; " +
-                            "use the standard WebSocket traversal protocol";
-            } else {
-                rejection = GremlinLangRequestGuard.rejection(
-                        gremlinRequest);
+                               this.hasLanguageArgument(request, jsonBody);
+            rejection = this.rawTextRejection(jsonBody);
+            requestId = this.requestId(jsonBody);
+            if (rejection == null) {
+                gremlinRequest =
+                        HttpHandlerUtil.getRequestMessageFromHttpRequest(
+                                request, this.serializers);
+                requestId = gremlinRequest.getRequestId();
+                if (serialized) {
+                    languageProvided = gremlinRequest.getArgs().containsKey(
+                            Tokens.ARGS_LANGUAGE);
+                }
+                if (!languageProvided) {
+                    gremlinRequest.getArgs().remove(Tokens.ARGS_LANGUAGE);
+                }
+                if (serialized && gremlinRequest.getArgs().get(
+                        Tokens.ARGS_GREMLIN) instanceof Bytecode) {
+                    rejection = "HTTP Bytecode requests are not supported; " +
+                                "use the standard WebSocket traversal protocol";
+                } else {
+                    rejection = GremlinLangRequestGuard.rejection(
+                            gremlinRequest);
+                }
             }
         } catch (SerializationException | IllegalArgumentException ignored) {
             // Let TinkerPop produce its normal malformed-request response.
             gremlinRequest = null;
-            languageProvided = true;
         } finally {
             content.readerIndex(readerIndex);
         }
 
         if (rejection != null) {
-            this.sendRejection(context, request, rejection);
+            this.sendRejection(context, request, requestId, rejection);
             return;
         }
         if (gremlinRequest == null || languageProvided) {
@@ -127,7 +143,8 @@ public class GremlinLangHttpHandler extends HttpGremlinEndpointHandler {
             normalized = this.withDefaultLanguage(context, request,
                                                   gremlinRequest, serialized);
         } catch (SerializationException | IllegalArgumentException e) {
-            this.sendRejection(context, request, e.getMessage());
+            this.sendRejection(context, request,
+                               gremlinRequest.getRequestId(), e.getMessage());
             return;
         }
         super.channelRead(context, normalized);
@@ -140,21 +157,54 @@ public class GremlinLangHttpHandler extends HttpGremlinEndpointHandler {
                this.serializers.containsKey(contentType);
     }
 
-    private boolean hasLanguageArgument(FullHttpRequest request) {
+    private boolean hasLanguageArgument(FullHttpRequest request,
+                                        JsonNode jsonBody) {
         if (request.method() == GET) {
             String uri = request.uri();
             return new io.netty.handler.codec.http.QueryStringDecoder(uri).
                    parameters().containsKey(Tokens.ARGS_LANGUAGE);
         }
-        if (request.method() != POST) {
-            return true;
-        }
+        return request.method() != POST ||
+               jsonBody != null && jsonBody.has(Tokens.ARGS_LANGUAGE);
+    }
+
+    private JsonNode parseJsonBody(FullHttpRequest request) {
         try {
-            JsonNode body = JSON_MAPPER.readTree(
+            return JSON_MAPPER.readTree(
                     request.content().toString(StandardCharsets.UTF_8));
-            return body != null && body.has(Tokens.ARGS_LANGUAGE);
         } catch (Exception e) {
             throw new IllegalArgumentException("body could not be parsed", e);
+        }
+    }
+
+    private String rawTextRejection(JsonNode jsonBody) {
+        if (jsonBody == null) {
+            return null;
+        }
+        JsonNode gremlin = jsonBody.get(Tokens.ARGS_GREMLIN);
+        if (gremlin != null && !gremlin.isTextual()) {
+            return "The gremlin argument for a text eval request must be " +
+                   "a string";
+        }
+        JsonNode language = jsonBody.get(Tokens.ARGS_LANGUAGE);
+        if (jsonBody.has(Tokens.ARGS_LANGUAGE) && !language.isTextual()) {
+            return "The language argument must be a string when provided";
+        }
+        return null;
+    }
+
+    private UUID requestId(JsonNode jsonBody) {
+        if (jsonBody == null) {
+            return null;
+        }
+        JsonNode requestId = jsonBody.get(Tokens.REQUEST_ID);
+        if (requestId == null || !requestId.isTextual()) {
+            return null;
+        }
+        try {
+            return UUID.fromString(requestId.asText());
+        } catch (IllegalArgumentException ignored) {
+            return null;
         }
     }
 
@@ -209,11 +259,15 @@ public class GremlinLangHttpHandler extends HttpGremlinEndpointHandler {
 
     private void sendRejection(ChannelHandlerContext context,
                                FullHttpRequest request,
+                               UUID requestId,
                                String rejection) {
         boolean keepAlive = HttpUtil.isKeepAlive(request);
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("code", BAD_REQUEST.code());
         body.put("message", rejection);
+        if (requestId != null) {
+            body.put(Tokens.REQUEST_ID, requestId.toString());
+        }
         ByteBuf content = Unpooled.copiedBuffer(JsonUtil.toJson(body),
                                                 StandardCharsets.UTF_8);
         FullHttpResponse response = new DefaultFullHttpResponse(
@@ -226,6 +280,7 @@ public class GremlinLangHttpHandler extends HttpGremlinEndpointHandler {
         }
 
         ReferenceCountUtil.release(request);
+        ERROR_METER.mark();
         ChannelFuture future = context.writeAndFlush(response);
         if (!keepAlive) {
             future.addListener(ChannelFutureListener.CLOSE);

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuard.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuard.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.auth;
+
+import org.apache.tinkerpop.gremlin.util.Tokens;
+import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
+
+public final class GremlinLangRequestGuard {
+
+    public static final String GREMLIN_LANG = "gremlin-lang";
+
+    private static final String CYPHER_PROCESSOR = "cypher";
+    private static final String SESSION_PROCESSOR = "session";
+
+    private GremlinLangRequestGuard() {
+    }
+
+    public static String rejection(RequestMessage request) {
+        String op = request.getOp();
+        if (Tokens.OPS_BYTECODE.equals(op)) {
+            return "Remote bytecode requests are disabled; submit a " +
+                   "gremlin-lang script instead";
+        }
+
+        String processor = request.getProcessor();
+        if (CYPHER_PROCESSOR.equals(processor)) {
+            if (Tokens.OPS_EVAL.equals(op) || op.isEmpty()) {
+                return null;
+            }
+            return "The cypher processor only accepts text eval requests";
+        }
+        if (!Tokens.OPS_EVAL.equals(op) && !op.isEmpty()) {
+            return null;
+        }
+        if (SESSION_PROCESSOR.equals(processor)) {
+            return "The session processor is disabled for remote Gremlin " +
+                   "requests";
+        }
+        if (processor != null && !processor.isEmpty()) {
+            return String.format("The '%s' processor is not allowed for " +
+                                 "remote Gremlin requests", processor);
+        }
+
+        String language = request.getArg(Tokens.ARGS_LANGUAGE);
+        if (!GREMLIN_LANG.equals(language)) {
+            return String.format("Remote Gremlin requests must use %s; " +
+                                 "received '%s'", GREMLIN_LANG, language);
+        }
+        return null;
+    }
+}

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuard.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuard.java
@@ -17,8 +17,11 @@
 
 package org.apache.hugegraph.auth;
 
+import org.apache.hugegraph.security.GremlinLangRestrictionStrategy;
+import org.apache.hugegraph.security.GremlinLangVerificationStrategy;
 import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.util.BytecodeHelper;
 import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
@@ -151,9 +154,18 @@ public final class GremlinLangRequestGuard {
         }
         for (Bytecode.Instruction instruction :
              bytecode.getSourceInstructions()) {
-            if ("withoutStrategies".equals(instruction.getOperator())) {
-                return "Remote Bytecode requests cannot use " +
-                       "withoutStrategies";
+            if (!TraversalSource.Symbols.withoutStrategies.equals(
+                    instruction.getOperator())) {
+                continue;
+            }
+            for (Object argument : instruction.getArguments()) {
+                if (argument == GremlinLangRestrictionStrategy.class ||
+                    argument == GremlinLangVerificationStrategy.class) {
+                    return String.format(
+                            "Remote Bytecode requests cannot remove sandbox " +
+                            "strategy '%s'", ((Class<?>) argument).
+                            getSimpleName());
+                }
             }
         }
         return null;

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuard.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuard.java
@@ -60,6 +60,10 @@ public final class GremlinLangRequestGuard {
             return unsupported(processor, op);
         }
         if (SESSION_PROCESSOR.equals(processor)) {
+            String rejection = sessionRejection(request);
+            if (rejection != null) {
+                return rejection;
+            }
             if (Tokens.OPS_EVAL.equals(op)) {
                 return textPayloadRejection(request, true);
             }
@@ -122,6 +126,14 @@ public final class GremlinLangRequestGuard {
         if (!GREMLIN_LANG.equals(language)) {
             return String.format("Remote Gremlin requests must use %s; " +
                                  "received '%s'", GREMLIN_LANG, language);
+        }
+        return null;
+    }
+
+    private static String sessionRejection(RequestMessage request) {
+        Object session = request.getArgs().get(Tokens.ARGS_SESSION);
+        if (!(session instanceof String)) {
+            return "The session argument must be a string";
         }
         return null;
     }

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuard.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuard.java
@@ -17,6 +17,9 @@
 
 package org.apache.hugegraph.auth;
 
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.util.BytecodeHelper;
 import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
 
@@ -26,41 +29,127 @@ public final class GremlinLangRequestGuard {
 
     private static final String CYPHER_PROCESSOR = "cypher";
     private static final String SESSION_PROCESSOR = "session";
+    private static final String TRAVERSAL_PROCESSOR = "traversal";
 
     private GremlinLangRequestGuard() {
     }
 
     public static String rejection(RequestMessage request) {
         String op = request.getOp();
-        if (Tokens.OPS_BYTECODE.equals(op)) {
-            return "Remote bytecode requests are disabled; submit a " +
-                   "gremlin-lang script instead";
+        String processor = request.getProcessor();
+        if (op == null) {
+            op = "";
+        }
+        if (processor == null) {
+            processor = "";
         }
 
-        String processor = request.getProcessor();
+        if (Tokens.OPS_AUTHENTICATION.equals(op)) {
+            return processor.isEmpty() ? null : unsupported(processor, op);
+        }
         if (CYPHER_PROCESSOR.equals(processor)) {
             if (Tokens.OPS_EVAL.equals(op) || op.isEmpty()) {
-                return null;
+                return textPayloadRejection(request, false);
             }
             return "The cypher processor only accepts text eval requests";
         }
-        if (!Tokens.OPS_EVAL.equals(op) && !op.isEmpty()) {
-            return null;
+        if (TRAVERSAL_PROCESSOR.equals(processor)) {
+            if (Tokens.OPS_BYTECODE.equals(op)) {
+                return bytecodeRejection(request);
+            }
+            return unsupported(processor, op);
         }
         if (SESSION_PROCESSOR.equals(processor)) {
-            return "The session processor is disabled for remote Gremlin " +
-                   "requests";
+            if (Tokens.OPS_EVAL.equals(op)) {
+                return textPayloadRejection(request, true);
+            }
+            if (Tokens.OPS_BYTECODE.equals(op)) {
+                return bytecodeRejection(request);
+            }
+            if (Tokens.OPS_CLOSE.equals(op)) {
+                return null;
+            }
+            return unsupported(processor, op);
         }
-        if (processor != null && !processor.isEmpty()) {
-            return String.format("The '%s' processor is not allowed for " +
-                                 "remote Gremlin requests", processor);
+        if (!processor.isEmpty()) {
+            return unsupported(processor, op);
+        }
+        if (Tokens.OPS_EVAL.equals(op) || op.isEmpty()) {
+            return textPayloadRejection(request, true);
+        }
+        return unsupported(processor, op);
+    }
+
+    public static RequestMessage normalize(RequestMessage request) {
+        String rejection = rejection(request);
+        if (rejection != null) {
+            throw new IllegalArgumentException(rejection);
         }
 
-        String language = request.getArg(Tokens.ARGS_LANGUAGE);
+        String processor = request.getProcessor();
+        String op = request.getOp();
+        boolean gremlinText = (processor == null || processor.isEmpty() ||
+                               SESSION_PROCESSOR.equals(processor)) &&
+                              (Tokens.OPS_EVAL.equals(op) || op.isEmpty());
+        if (!gremlinText) {
+            return request;
+        }
+        return RequestMessage.from(request)
+                             .addArg(Tokens.ARGS_LANGUAGE,
+                                     HugeGraphGremlinLangScriptEngineFactory.
+                                     INTERNAL_ENGINE_NAME)
+                             .create();
+    }
+
+    private static String textPayloadRejection(RequestMessage request,
+                                               boolean checkLanguage) {
+        Object gremlin = request.getArgs().get(Tokens.ARGS_GREMLIN);
+        if (!(gremlin instanceof String)) {
+            return "The gremlin argument for a text eval request must be " +
+                   "a string";
+        }
+        if (!checkLanguage) {
+            return null;
+        }
+
+        if (!request.getArgs().containsKey(Tokens.ARGS_LANGUAGE)) {
+            return null;
+        }
+        Object language = request.getArgs().get(Tokens.ARGS_LANGUAGE);
+        if (!(language instanceof String)) {
+            return "The language argument must be a string when provided";
+        }
         if (!GREMLIN_LANG.equals(language)) {
             return String.format("Remote Gremlin requests must use %s; " +
                                  "received '%s'", GREMLIN_LANG, language);
         }
         return null;
+    }
+
+    private static String bytecodeRejection(RequestMessage request) {
+        Object gremlin = request.getArgs().get(Tokens.ARGS_GREMLIN);
+        if (!(gremlin instanceof Bytecode)) {
+            return "The gremlin argument for a bytecode request must be " +
+                   "Bytecode";
+        }
+        Bytecode bytecode = (Bytecode) gremlin;
+        if (BytecodeHelper.getLambdaLanguage(bytecode).isPresent()) {
+            return "Remote Bytecode requests containing a Lambda are not " +
+                   "allowed";
+        }
+        for (Bytecode.Instruction instruction :
+             bytecode.getSourceInstructions()) {
+            if ("withoutStrategies".equals(instruction.getOperator())) {
+                return "Remote Bytecode requests cannot use " +
+                       "withoutStrategies";
+            }
+        }
+        return null;
+    }
+
+    private static String unsupported(String processor, String op) {
+        String name = processor.isEmpty() ? "standard" : processor;
+        return String.format("The '%s' processor does not allow operation " +
+                             "'%s' for remote requests", name, op);
     }
 }

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestHandler.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.auth;
+
+import java.util.List;
+
+import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
+import org.apache.tinkerpop.gremlin.util.message.ResponseStatusCode;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+public class GremlinLangRequestHandler
+       extends MessageToMessageDecoder<RequestMessage> {
+
+    @Override
+    protected void decode(ChannelHandlerContext context,
+                          RequestMessage request,
+                          List<Object> output) {
+        String rejection = GremlinLangRequestGuard.rejection(request);
+        if (rejection == null) {
+            output.add(request);
+            return;
+        }
+
+        context.writeAndFlush(ResponseMessage.build(request)
+                                             .code(ResponseStatusCode.
+                                                   REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS)
+                                             .statusMessage(rejection)
+                                             .create());
+    }
+}

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestHandler.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestHandler.java
@@ -35,7 +35,7 @@ public class GremlinLangRequestHandler
                           List<Object> output) {
         String rejection = GremlinLangRequestGuard.rejection(request);
         if (rejection == null) {
-            output.add(request);
+            output.add(GremlinLangRequestGuard.normalize(request));
             return;
         }
 

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/HugeGraphWsAndHttpChannelizer.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/auth/HugeGraphWsAndHttpChannelizer.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.auth;
+
+import org.apache.tinkerpop.gremlin.server.AbstractChannelizer;
+import org.apache.tinkerpop.gremlin.server.handler.WsAndHttpChannelizerHandler;
+import org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor;
+
+import io.netty.channel.ChannelPipeline;
+
+public class HugeGraphWsAndHttpChannelizer extends AbstractChannelizer {
+
+    private static final String PIPELINE_PROTOCOL_SELECTOR =
+            "hugegraph-ws-http-selector";
+    private static final String PIPELINE_GREMLIN_LANG_GUARD =
+            "hugegraph-gremlin-lang-guard";
+
+    private WsAndHttpChannelizerHandler handler;
+
+    @Override
+    public void init(ServerGremlinExecutor serverGremlinExecutor) {
+        super.init(serverGremlinExecutor);
+        this.handler = new WsAndHttpChannelizerHandler();
+        this.handler.init(serverGremlinExecutor,
+                          new GremlinLangHttpHandler(this.serializers,
+                                                     this.gremlinExecutor,
+                                                     this.graphManager,
+                                                     this.settings));
+    }
+
+    @Override
+    public void configure(ChannelPipeline pipeline) {
+        this.handler.configure(pipeline);
+        pipeline.addAfter(PIPELINE_HTTP_REQUEST_DECODER,
+                          PIPELINE_PROTOCOL_SELECTOR, this.handler);
+    }
+
+    @Override
+    public void finalize(ChannelPipeline pipeline) {
+        pipeline.addBefore(PIPELINE_OP_SELECTOR,
+                           PIPELINE_GREMLIN_LANG_GUARD,
+                           new GremlinLangRequestHandler());
+    }
+
+    @Override
+    public boolean supportsIdleMonitor() {
+        return true;
+    }
+
+    @Override
+    public Object createIdleDetectionMessage() {
+        return this.handler.getWsChannelizer().createIdleDetectionMessage();
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangRestrictionStrategy.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangRestrictionStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.security;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+
+public final class GremlinLangRestrictionStrategy
+       extends AbstractTraversalStrategy<TraversalStrategy.DecorationStrategy>
+       implements TraversalStrategy.DecorationStrategy {
+
+    private static final GremlinLangRestrictionStrategy INSTANCE =
+            new GremlinLangRestrictionStrategy();
+
+    private GremlinLangRestrictionStrategy() {
+    }
+
+    public static GremlinLangRestrictionStrategy instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void apply(Traversal.Admin<?, ?> traversal) {
+        GremlinLangTraversalVerifier.verify(traversal);
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangRestrictionStrategy.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangRestrictionStrategy.java
@@ -37,6 +37,7 @@ public final class GremlinLangRestrictionStrategy
 
     @Override
     public void apply(Traversal.Admin<?, ?> traversal) {
+        GremlinLangTextPredicateAdapter.restore(traversal);
         GremlinLangTraversalVerifier.verify(traversal);
     }
 }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangRestrictionStrategy.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangRestrictionStrategy.java
@@ -38,6 +38,5 @@ public final class GremlinLangRestrictionStrategy
     @Override
     public void apply(Traversal.Admin<?, ?> traversal) {
         GremlinLangTextPredicateAdapter.restore(traversal);
-        GremlinLangTraversalVerifier.verify(traversal);
     }
 }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangTextPredicateAdapter.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangTextPredicateAdapter.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -35,8 +36,6 @@ import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.Token;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.hugegraph.traversal.optimize.ConditionP;
-import org.apache.tinkerpop.gremlin.jsr223.Customizer;
-import org.apache.tinkerpop.gremlin.jsr223.GremlinLangCustomizer;
 import org.apache.tinkerpop.gremlin.language.grammar.GremlinLexer;
 import org.apache.tinkerpop.gremlin.process.traversal.Compare;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
@@ -47,6 +46,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 final class GremlinLangTextPredicateAdapter {
 
@@ -54,22 +54,30 @@ final class GremlinLangTextPredicateAdapter {
     private static final String CONTAINS = "contains";
     private static final String RESERVED_BINDING_PREFIX =
             "hugegraphTextContainsInternal";
+    private static final long PLAN_CACHE_MAXIMUM_SIZE = 1024L;
+    private static final long PLAN_CACHE_EXPIRY_MINUTES = 10L;
 
     private final Cache<String, RewritePlan> plans;
 
-    GremlinLangTextPredicateAdapter(Customizer... customizers) {
-        this.plans = newPlanCache(customizers);
+    GremlinLangTextPredicateAdapter() {
+        this.plans = Caffeine.newBuilder()
+                             .maximumSize(PLAN_CACHE_MAXIMUM_SIZE)
+                             .expireAfterAccess(PLAN_CACHE_EXPIRY_MINUTES,
+                                                TimeUnit.MINUTES)
+                             .build();
     }
 
     AdaptedScript adapt(String script, ScriptContext context) {
+        rejectReservedBindings(context);
+        if (script.contains(RESERVED_BINDING_PREFIX)) {
+            rejectReservedIdentifiers(tokens(script));
+        }
         if (!mightContainTextPredicate(script)) {
             return AdaptedScript.identity(script);
         }
 
-        RewritePlan plan = this.plans == null ?
-                           parse(script) :
-                           this.plans.get(script,
-                                          GremlinLangTextPredicateAdapter::parse);
+        RewritePlan plan = this.plans.get(
+                script, GremlinLangTextPredicateAdapter::parse);
         return plan.materialize(context);
     }
 
@@ -84,25 +92,16 @@ final class GremlinLangTextPredicateAdapter {
     }
 
     private static RewritePlan parse(String script) {
-        GremlinLexer lexer = new GremlinLexer(CharStreams.fromString(script));
-        lexer.removeErrorListeners();
-        lexer.addErrorListener(ThrowingErrorListener.INSTANCE);
-        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
-        tokenStream.fill();
-
-        List<Token> tokens = new ArrayList<>();
-        for (Token token : tokenStream.getTokens()) {
-            if (token.getType() != Token.EOF) {
-                tokens.add(token);
-            }
-        }
+        List<Token> tokens = tokens(script);
+        int[] codePointOffsets = codePointToUtf16Offsets(script);
 
         List<Occurrence> occurrences = new ArrayList<>();
         for (int i = 0; i < tokens.size(); i++) {
             if (!isTextContainsPrefix(tokens, i)) {
                 continue;
             }
-            Occurrence occurrence = match(tokens, i, occurrences.size());
+            Occurrence occurrence = match(tokens, i, occurrences.size(),
+                                          codePointOffsets);
             if (occurrence == null) {
                 throw unsupportedTextContains();
             }
@@ -126,8 +125,38 @@ final class GremlinLangTextPredicateAdapter {
         return new RewritePlan(rewritten.toString(), occurrences);
     }
 
+    private static List<Token> tokens(String script) {
+        GremlinLexer lexer = new GremlinLexer(CharStreams.fromString(script));
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(ThrowingErrorListener.INSTANCE);
+        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+        tokenStream.fill();
+
+        List<Token> tokens = new ArrayList<>();
+        for (Token token : tokenStream.getTokens()) {
+            if (token.getType() != Token.EOF) {
+                tokens.add(token);
+            }
+        }
+        return tokens;
+    }
+
+    private static int[] codePointToUtf16Offsets(String script) {
+        int codePointCount = script.codePointCount(0, script.length());
+        int[] offsets = new int[codePointCount + 1];
+        int utf16Offset = 0;
+        for (int i = 0; i < codePointCount; i++) {
+            offsets[i] = utf16Offset;
+            int codePoint = script.codePointAt(utf16Offset);
+            utf16Offset += Character.charCount(codePoint);
+        }
+        offsets[codePointCount] = script.length();
+        return offsets;
+    }
+
     private static Occurrence match(List<Token> tokens, int index,
-                                    int occurrenceIndex) {
+                                    int occurrenceIndex,
+                                    int[] codePointOffsets) {
         if (index == 0 || index + 6 >= tokens.size()) {
             return null;
         }
@@ -159,8 +188,9 @@ final class GremlinLangTextPredicateAdapter {
                          decodeStringLiteral(argument.getText()) : null;
         String sourceBinding = isIdentifier(argument) ?
                                argument.getText() : null;
-        int start = tokens.get(index).getStartIndex();
-        int end = tokens.get(index + 5).getStopIndex() + 1;
+        int start = codePointOffsets[tokens.get(index).getStartIndex()];
+        int end = codePointOffsets[
+                tokens.get(index + 5).getStopIndex() + 1];
         return new Occurrence(start, end, internalBinding,
                               literal, sourceBinding);
     }
@@ -232,28 +262,30 @@ final class GremlinLangTextPredicateAdapter {
         }
     }
 
+    private static void rejectReservedBindings(ScriptContext context) {
+        rejectReservedBindings(context.getBindings(
+                ScriptContext.ENGINE_SCOPE));
+        rejectReservedBindings(context.getBindings(
+                ScriptContext.GLOBAL_SCOPE));
+    }
+
+    private static void rejectReservedBindings(Bindings bindings) {
+        if (bindings == null) {
+            return;
+        }
+        for (String name : bindings.keySet()) {
+            if (name.startsWith(RESERVED_BINDING_PREFIX)) {
+                throw new IllegalArgumentException(
+                        "Gremlin request contains a reserved " +
+                        "HugeGraph binding");
+            }
+        }
+    }
+
     private static IllegalArgumentException unsupportedTextContains() {
         return new IllegalArgumentException(
                 "Text.contains() is only supported as the final argument " +
                 "of has(), with one String literal or String binding");
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private static Cache<String, RewritePlan> newPlanCache(
-            Customizer[] customizers) {
-        for (Customizer customizer : customizers) {
-            if (!(customizer instanceof GremlinLangCustomizer)) {
-                continue;
-            }
-            GremlinLangCustomizer gremlinLang =
-                    (GremlinLangCustomizer) customizer;
-            if (!gremlinLang.isCacheEnabled()) {
-                return null;
-            }
-            return (Cache<String, RewritePlan>)
-                   gremlinLang.getCacheMaker().build();
-        }
-        return null;
     }
 
     private static void restoreCurrentTraversal(
@@ -293,8 +325,7 @@ final class GremlinLangTextPredicateAdapter {
 
         for (GValue<?> value : predicate.getGValues()) {
             if (!value.isVariable() ||
-                !value.getName().startsWith(RESERVED_BINDING_PREFIX) ||
-                !(value.get() instanceof TextContainsMarker)) {
+                !value.getName().startsWith(RESERVED_BINDING_PREFIX)) {
                 continue;
             }
             TextContainsMarker current = currentMarker(traversal,
@@ -361,7 +392,6 @@ final class GremlinLangTextPredicateAdapter {
             if (this.occurrences.isEmpty()) {
                 return AdaptedScript.identity(this.script);
             }
-            rejectReservedBindings(context);
             Map<String, Object> bindings = new LinkedHashMap<>();
             for (Occurrence occurrence : this.occurrences) {
                 String value = occurrence.resolve(context);
@@ -369,26 +399,6 @@ final class GremlinLangTextPredicateAdapter {
                              new TextContainsMarker(value));
             }
             return new AdaptedScript(this.script, bindings);
-        }
-
-        private static void rejectReservedBindings(ScriptContext context) {
-            rejectReservedBindings(context.getBindings(
-                    ScriptContext.ENGINE_SCOPE));
-            rejectReservedBindings(context.getBindings(
-                    ScriptContext.GLOBAL_SCOPE));
-        }
-
-        private static void rejectReservedBindings(Bindings bindings) {
-            if (bindings == null) {
-                return;
-            }
-            for (String name : bindings.keySet()) {
-                if (name.startsWith(RESERVED_BINDING_PREFIX)) {
-                    throw new IllegalArgumentException(
-                            "Gremlin request contains a reserved " +
-                            "HugeGraph binding");
-                }
-            }
         }
     }
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangTextPredicateAdapter.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangTextPredicateAdapter.java
@@ -1,0 +1,469 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.security;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.hugegraph.traversal.optimize.ConditionP;
+import org.apache.tinkerpop.gremlin.jsr223.Customizer;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinLangCustomizer;
+import org.apache.tinkerpop.gremlin.language.grammar.GremlinLexer;
+import org.apache.tinkerpop.gremlin.process.traversal.Compare;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.GValue;
+import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+
+import com.github.benmanes.caffeine.cache.Cache;
+
+final class GremlinLangTextPredicateAdapter {
+
+    private static final String TEXT = "Text";
+    private static final String CONTAINS = "contains";
+    private static final String RESERVED_BINDING_PREFIX =
+            "hugegraphTextContainsInternal";
+
+    private final Cache<String, RewritePlan> plans;
+
+    GremlinLangTextPredicateAdapter(Customizer... customizers) {
+        this.plans = newPlanCache(customizers);
+    }
+
+    AdaptedScript adapt(String script, ScriptContext context) {
+        if (!mightContainTextPredicate(script)) {
+            return AdaptedScript.identity(script);
+        }
+
+        RewritePlan plan = this.plans == null ?
+                           parse(script) :
+                           this.plans.get(script,
+                                          GremlinLangTextPredicateAdapter::parse);
+        return plan.materialize(context);
+    }
+
+    static void restore(Traversal.Admin<?, ?> traversal) {
+        TraversalHelper.applyTraversalRecursively(
+                GremlinLangTextPredicateAdapter::restoreCurrentTraversal,
+                traversal);
+    }
+
+    private static boolean mightContainTextPredicate(String script) {
+        return script.contains(TEXT) && script.contains(CONTAINS);
+    }
+
+    private static RewritePlan parse(String script) {
+        GremlinLexer lexer = new GremlinLexer(CharStreams.fromString(script));
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(ThrowingErrorListener.INSTANCE);
+        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+        tokenStream.fill();
+
+        List<Token> tokens = new ArrayList<>();
+        for (Token token : tokenStream.getTokens()) {
+            if (token.getType() != Token.EOF) {
+                tokens.add(token);
+            }
+        }
+
+        List<Occurrence> occurrences = new ArrayList<>();
+        for (int i = 0; i < tokens.size(); i++) {
+            if (!isTextContainsPrefix(tokens, i)) {
+                continue;
+            }
+            Occurrence occurrence = match(tokens, i, occurrences.size());
+            if (occurrence == null) {
+                throw unsupportedTextContains();
+            }
+            occurrences.add(occurrence);
+            i += 5;
+        }
+
+        if (occurrences.isEmpty()) {
+            return RewritePlan.identity(script);
+        }
+        rejectReservedIdentifiers(tokens);
+
+        StringBuilder rewritten = new StringBuilder(script.length());
+        int cursor = 0;
+        for (Occurrence occurrence : occurrences) {
+            rewritten.append(script, cursor, occurrence.start());
+            rewritten.append(occurrence.internalBinding());
+            cursor = occurrence.end();
+        }
+        rewritten.append(script, cursor, script.length());
+        return new RewritePlan(rewritten.toString(), occurrences);
+    }
+
+    private static Occurrence match(List<Token> tokens, int index,
+                                    int occurrenceIndex) {
+        if (index == 0 || index + 6 >= tokens.size()) {
+            return null;
+        }
+        if (tokens.get(index - 1).getType() != GremlinLexer.COMMA ||
+            tokens.get(index + 3).getType() != GremlinLexer.LPAREN ||
+            tokens.get(index + 5).getType() != GremlinLexer.RPAREN ||
+            tokens.get(index + 6).getType() != GremlinLexer.RPAREN) {
+            return null;
+        }
+
+        Token argument = tokens.get(index + 4);
+        if (!isString(argument) && !isIdentifier(argument)) {
+            return null;
+        }
+
+        int outerLeftParen = matchingLeftParen(tokens, index + 6);
+        if (outerLeftParen <= 0 ||
+            tokens.get(outerLeftParen - 1).getType() !=
+            GremlinLexer.K_HAS) {
+            return null;
+        }
+        int commas = topLevelCommas(tokens, outerLeftParen + 1, index);
+        if (commas != 1 && commas != 2) {
+            return null;
+        }
+
+        String internalBinding = RESERVED_BINDING_PREFIX + occurrenceIndex;
+        String literal = isString(argument) ?
+                         decodeStringLiteral(argument.getText()) : null;
+        String sourceBinding = isIdentifier(argument) ?
+                               argument.getText() : null;
+        int start = tokens.get(index).getStartIndex();
+        int end = tokens.get(index + 5).getStopIndex() + 1;
+        return new Occurrence(start, end, internalBinding,
+                              literal, sourceBinding);
+    }
+
+    private static int matchingLeftParen(List<Token> tokens,
+                                         int rightParen) {
+        int depth = 0;
+        for (int i = rightParen; i >= 0; i--) {
+            int type = tokens.get(i).getType();
+            if (type == GremlinLexer.RPAREN) {
+                depth++;
+            } else if (type == GremlinLexer.LPAREN && --depth == 0) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int topLevelCommas(List<Token> tokens, int start,
+                                      int end) {
+        int depth = 0;
+        int commas = 0;
+        for (int i = start; i < end; i++) {
+            int type = tokens.get(i).getType();
+            if (type == GremlinLexer.LPAREN) {
+                depth++;
+            } else if (type == GremlinLexer.RPAREN) {
+                depth--;
+            } else if (type == GremlinLexer.COMMA && depth == 0) {
+                commas++;
+            }
+        }
+        return commas;
+    }
+
+    private static boolean isTextContainsPrefix(List<Token> tokens,
+                                                int index) {
+        return index + 2 < tokens.size() &&
+               isIdentifier(tokens.get(index), TEXT) &&
+               tokens.get(index + 1).getType() == GremlinLexer.DOT &&
+               isIdentifier(tokens.get(index + 2), CONTAINS);
+    }
+
+    private static boolean isIdentifier(Token token, String value) {
+        return isIdentifier(token) && value.equals(token.getText());
+    }
+
+    private static boolean isIdentifier(Token token) {
+        return token.getType() == GremlinLexer.Identifier;
+    }
+
+    private static boolean isString(Token token) {
+        return token.getType() == GremlinLexer.NonEmptyStringLiteral ||
+               token.getType() == GremlinLexer.EmptyStringLiteral;
+    }
+
+    private static String decodeStringLiteral(String literal) {
+        return StringEscapeUtils.unescapeJava(
+                literal.substring(1, literal.length() - 1));
+    }
+
+    private static void rejectReservedIdentifiers(List<Token> tokens) {
+        for (Token token : tokens) {
+            if (isIdentifier(token) &&
+                token.getText().startsWith(RESERVED_BINDING_PREFIX)) {
+                throw new IllegalArgumentException(
+                        "Gremlin query uses a reserved HugeGraph binding");
+            }
+        }
+    }
+
+    private static IllegalArgumentException unsupportedTextContains() {
+        return new IllegalArgumentException(
+                "Text.contains() is only supported as the final argument " +
+                "of has(), with one String literal or String binding");
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static Cache<String, RewritePlan> newPlanCache(
+            Customizer[] customizers) {
+        for (Customizer customizer : customizers) {
+            if (!(customizer instanceof GremlinLangCustomizer)) {
+                continue;
+            }
+            GremlinLangCustomizer gremlinLang =
+                    (GremlinLangCustomizer) customizer;
+            if (!gremlinLang.isCacheEnabled()) {
+                return null;
+            }
+            return (Cache<String, RewritePlan>)
+                   gremlinLang.getCacheMaker().build();
+        }
+        return null;
+    }
+
+    private static void restoreCurrentTraversal(
+            Traversal.Admin<?, ?> traversal) {
+        for (Object step : traversal.getSteps()) {
+            if (!(step instanceof HasContainerHolder)) {
+                continue;
+            }
+            HasContainerHolder<?, ?> holder =
+                    (HasContainerHolder<?, ?>) step;
+            List<HasContainer> containers =
+                    new ArrayList<>(holder.getHasContainers());
+            for (HasContainer current : containers) {
+                TextContainsMarker marker = marker(current.getPredicate(),
+                                                   traversal);
+                if (marker == null) {
+                    continue;
+                }
+                holder.removeHasContainer(current);
+                holder.addHasContainer(new HasContainer(
+                        current.getKey(),
+                        ConditionP.textContains(marker.value())));
+            }
+        }
+    }
+
+    private static TextContainsMarker marker(
+            P<?> predicate, Traversal.Admin<?, ?> traversal) {
+        if (predicate.getBiPredicate() != Compare.eq) {
+            return null;
+        }
+        if (!predicate.isParameterized()) {
+            Object value = predicate.getValue();
+            return value instanceof TextContainsMarker ?
+                   (TextContainsMarker) value : null;
+        }
+
+        for (GValue<?> value : predicate.getGValues()) {
+            if (!value.isVariable() ||
+                !value.getName().startsWith(RESERVED_BINDING_PREFIX) ||
+                !(value.get() instanceof TextContainsMarker)) {
+                continue;
+            }
+            TextContainsMarker current = currentMarker(traversal,
+                                                       value.getName());
+            if (current == null) {
+                throw new IllegalStateException(
+                        "Missing internal Text.contains() binding");
+            }
+            traversal.getGValueManager().pinVariable(value.getName());
+            return current;
+        }
+        return null;
+    }
+
+    private static TextContainsMarker currentMarker(
+            Traversal.Admin<?, ?> traversal, String name) {
+        for (GValue<?> value : traversal.getGValueManager().getGValues()) {
+            if (value.isVariable() && name.equals(value.getName()) &&
+                value.get() instanceof TextContainsMarker) {
+                return (TextContainsMarker) value.get();
+            }
+        }
+        return null;
+    }
+
+    static final class AdaptedScript {
+
+        private final String script;
+        private final Map<String, Object> bindings;
+
+        private AdaptedScript(String script, Map<String, Object> bindings) {
+            this.script = script;
+            this.bindings = bindings;
+        }
+
+        static AdaptedScript identity(String script) {
+            return new AdaptedScript(script, Collections.emptyMap());
+        }
+
+        String script() {
+            return this.script;
+        }
+
+        Map<String, Object> bindings() {
+            return this.bindings;
+        }
+    }
+
+    private static final class RewritePlan {
+
+        private final String script;
+        private final List<Occurrence> occurrences;
+
+        private RewritePlan(String script, List<Occurrence> occurrences) {
+            this.script = script;
+            this.occurrences = List.copyOf(occurrences);
+        }
+
+        static RewritePlan identity(String script) {
+            return new RewritePlan(script, Collections.emptyList());
+        }
+
+        AdaptedScript materialize(ScriptContext context) {
+            if (this.occurrences.isEmpty()) {
+                return AdaptedScript.identity(this.script);
+            }
+            rejectReservedBindings(context);
+            Map<String, Object> bindings = new LinkedHashMap<>();
+            for (Occurrence occurrence : this.occurrences) {
+                String value = occurrence.resolve(context);
+                bindings.put(occurrence.internalBinding(),
+                             new TextContainsMarker(value));
+            }
+            return new AdaptedScript(this.script, bindings);
+        }
+
+        private static void rejectReservedBindings(ScriptContext context) {
+            rejectReservedBindings(context.getBindings(
+                    ScriptContext.ENGINE_SCOPE));
+            rejectReservedBindings(context.getBindings(
+                    ScriptContext.GLOBAL_SCOPE));
+        }
+
+        private static void rejectReservedBindings(Bindings bindings) {
+            if (bindings == null) {
+                return;
+            }
+            for (String name : bindings.keySet()) {
+                if (name.startsWith(RESERVED_BINDING_PREFIX)) {
+                    throw new IllegalArgumentException(
+                            "Gremlin request contains a reserved " +
+                            "HugeGraph binding");
+                }
+            }
+        }
+    }
+
+    private static final class Occurrence {
+
+        private final int start;
+        private final int end;
+        private final String internalBinding;
+        private final String literal;
+        private final String sourceBinding;
+
+        private Occurrence(int start, int end, String internalBinding,
+                           String literal, String sourceBinding) {
+            this.start = start;
+            this.end = end;
+            this.internalBinding = internalBinding;
+            this.literal = literal;
+            this.sourceBinding = sourceBinding;
+        }
+
+        int start() {
+            return this.start;
+        }
+
+        int end() {
+            return this.end;
+        }
+
+        String internalBinding() {
+            return this.internalBinding;
+        }
+
+        String resolve(ScriptContext context) {
+            if (this.sourceBinding == null) {
+                return this.literal;
+            }
+            Object value = context.getAttribute(this.sourceBinding);
+            if (!(value instanceof String)) {
+                throw new IllegalArgumentException(String.format(
+                        "The Text.contains() binding '%s' must be a String",
+                        this.sourceBinding));
+            }
+            return (String) value;
+        }
+    }
+
+    private static final class TextContainsMarker implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String value;
+
+        private TextContainsMarker(String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return this.value;
+        }
+    }
+
+    private static final class ThrowingErrorListener
+            extends BaseErrorListener {
+
+        private static final ThrowingErrorListener INSTANCE =
+                new ThrowingErrorListener();
+
+        @Override
+        public void syntaxError(Recognizer<?, ?> recognizer,
+                                Object offendingSymbol, int line,
+                                int charPositionInLine, String message,
+                                RecognitionException exception) {
+            throw new IllegalArgumentException(String.format(
+                    "Invalid Gremlin token at line %s, character %s: %s",
+                    line, charPositionInLine, message), exception);
+        }
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangTraversalVerifier.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangTraversalVerifier.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.security;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.CallStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.IoStep;
+
+public final class GremlinLangTraversalVerifier {
+
+    private GremlinLangTraversalVerifier() {
+    }
+
+    public static void verify(Traversal<?, ?> traversal) {
+        verify(traversal.asAdmin());
+    }
+
+    static void verify(Traversal.Admin<?, ?> traversal) {
+        for (Step<?, ?> step : traversal.getSteps()) {
+            if (step instanceof IoStep || step instanceof CallStep) {
+                throw new SecurityException(String.format(
+                        "The traversal step '%s' is not allowed for remote " +
+                        "Gremlin requests", step.getClass().getSimpleName()));
+            }
+            if (step instanceof TraversalParent) {
+                TraversalParent parent = (TraversalParent) step;
+                for (Traversal.Admin<?, ?> child : parent.getLocalChildren()) {
+                    verify(child);
+                }
+                for (Traversal.Admin<?, ?> child : parent.getGlobalChildren()) {
+                    verify(child);
+                }
+            }
+        }
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangTraversalVerifier.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangTraversalVerifier.java
@@ -20,7 +20,7 @@ package org.apache.hugegraph.security;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalParent;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.CallStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.CallStepContract;
 import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.IoStep;
 
 public final class GremlinLangTraversalVerifier {
@@ -34,7 +34,7 @@ public final class GremlinLangTraversalVerifier {
 
     static void verify(Traversal.Admin<?, ?> traversal) {
         for (Step<?, ?> step : traversal.getSteps()) {
-            if (step instanceof IoStep || step instanceof CallStep) {
+            if (step instanceof IoStep || step instanceof CallStepContract) {
                 throw new SecurityException(String.format(
                         "The traversal step '%s' is not allowed for remote " +
                         "Gremlin requests", step.getClass().getSimpleName()));

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangVerificationStrategy.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/GremlinLangVerificationStrategy.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.security;
+
+import java.util.Set;
+
+import org.apache.tinkerpop.gremlin.process.computer.traversal.strategy.decoration.VertexProgramStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ConnectiveStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.ElementIdStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.EventStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.HaltedTraverserStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.OptionsStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.PartitionStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SeedStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
+
+/*
+ * Keep this strategy in the decoration category. Optimization strategies such
+ * as PathRetractionStrategy can inspect CallStep requirements before standard
+ * verification strategies run. The explicit priors place this check after all
+ * decoration strategies that GremlinLang can construct, but before any
+ * optimization can access a forbidden step.
+ */
+public final class GremlinLangVerificationStrategy
+       extends AbstractTraversalStrategy<TraversalStrategy.DecorationStrategy>
+       implements TraversalStrategy.DecorationStrategy {
+
+    private static final GremlinLangVerificationStrategy INSTANCE =
+            new GremlinLangVerificationStrategy();
+    private static final Set<Class<? extends DecorationStrategy>> PRIORS =
+            Set.of(GremlinLangRestrictionStrategy.class,
+                   ConnectiveStrategy.class,
+                   ElementIdStrategy.class,
+                   EventStrategy.class,
+                   HaltedTraverserStrategy.class,
+                   OptionsStrategy.class,
+                   PartitionStrategy.class,
+                   SeedStrategy.class,
+                   SubgraphStrategy.class,
+                   VertexProgramStrategy.class);
+
+    private GremlinLangVerificationStrategy() {
+    }
+
+    public static GremlinLangVerificationStrategy instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Set<Class<? extends DecorationStrategy>> applyPrior() {
+        return PRIORS;
+    }
+
+    @Override
+    public void apply(Traversal.Admin<?, ?> traversal) {
+        GremlinLangTraversalVerifier.verify(traversal);
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
@@ -39,6 +39,7 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
        implements GremlinScriptEngine {
 
     private static final String TRAVERSAL_SOURCE = "g";
+    private static final String TINKERPOP_INITIALIZATION_PROBE = "1+1";
 
     private final HugeGraphGremlinLangScriptEngineFactory factory;
     private final Customizer[] customizers;
@@ -56,6 +57,17 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
     @Override
     public Object eval(String script, ScriptContext context)
             throws ScriptException {
+        /*
+         * Gremlin Server evaluates this fixed expression once for every
+         * configured engine whose registration name is not "gremlin-lang".
+         * HugeGraph uses a private registration name to avoid colliding with
+         * TinkerPop's factory, and the probe runs before traversal sources are
+         * injected. The fixed expression needs no graph access.
+         */
+        if (TINKERPOP_INITIALIZATION_PROBE.equals(script) &&
+            context.getAttribute(TRAVERSAL_SOURCE) == null) {
+            return 2;
+        }
         Delegate delegate = this.delegate(traversalSource(context));
         try {
             return verify(delegate.engine.eval(

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.security;
+
+import java.io.Reader;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.script.AbstractScriptEngine;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
+import javax.script.SimpleScriptContext;
+
+import org.apache.tinkerpop.gremlin.jsr223.Customizer;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinLangScriptEngine;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+
+public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
+       implements GremlinScriptEngine {
+
+    private static final String TRAVERSAL_SOURCE = "g";
+
+    private final HugeGraphGremlinLangScriptEngineFactory factory;
+    private final Customizer[] customizers;
+    private final ConcurrentMap<GraphTraversalSource, Delegate>
+            delegates;
+
+    HugeGraphGremlinLangScriptEngine(
+            HugeGraphGremlinLangScriptEngineFactory factory,
+            Customizer... customizers) {
+        this.factory = factory;
+        this.customizers = customizers.clone();
+        this.delegates = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public Object eval(String script, ScriptContext context)
+            throws ScriptException {
+        Delegate delegate = this.delegate(traversalSource(context));
+        try {
+            return verify(delegate.engine.eval(
+                    script,
+                    guardedContext(context, delegate.traversalSource)));
+        } catch (ScriptException e) {
+            rethrowSecurityException(e);
+            throw e;
+        }
+    }
+
+    @Override
+    public Object eval(Reader reader, ScriptContext context)
+            throws ScriptException {
+        Delegate delegate = this.delegate(traversalSource(context));
+        try {
+            return verify(delegate.engine.eval(
+                    reader,
+                    guardedContext(context, delegate.traversalSource)));
+        } catch (ScriptException e) {
+            rethrowSecurityException(e);
+            throw e;
+        }
+    }
+
+    @Override
+    public Traversal.Admin<?, ?> eval(Bytecode bytecode, Bindings bindings,
+                                      String traversalSource)
+            throws ScriptException {
+        Object source = bindings.get(traversalSource);
+        if (!(source instanceof GraphTraversalSource)) {
+            throw new IllegalArgumentException(String.format(
+                    "The binding '%s' must be a GraphTraversalSource",
+                    traversalSource));
+        }
+        Delegate delegate = this.delegate((GraphTraversalSource) source);
+        Bindings guardedBindings = new SimpleBindings(bindings);
+        guardedBindings.put(traversalSource, delegate.traversalSource);
+        Traversal.Admin<?, ?> traversal = delegate.engine.eval(
+                bytecode, guardedBindings, traversalSource);
+        GremlinLangTraversalVerifier.verify(traversal);
+        return traversal;
+    }
+
+    @Override
+    public Bindings createBindings() {
+        return new SimpleBindings();
+    }
+
+    @Override
+    public HugeGraphGremlinLangScriptEngineFactory getFactory() {
+        return this.factory;
+    }
+
+    public void remove(GraphTraversalSource traversalSource) {
+        if (traversalSource != null) {
+            this.delegates.remove(traversalSource);
+        }
+    }
+
+    public void clear() {
+        this.delegates.clear();
+    }
+
+    public int traversalSourceCount() {
+        return this.delegates.size();
+    }
+
+    private Delegate delegate(GraphTraversalSource traversalSource) {
+        return this.delegates.computeIfAbsent(
+                traversalSource,
+                source -> new Delegate(
+                        new GremlinLangScriptEngine(this.customizers),
+                        source.withStrategies(
+                                GremlinLangRestrictionStrategy.instance())));
+    }
+
+    private static GraphTraversalSource traversalSource(
+            ScriptContext context) {
+        Object source = context.getAttribute(TRAVERSAL_SOURCE);
+        if (!(source instanceof GraphTraversalSource)) {
+            throw new IllegalArgumentException(
+                    "The 'g' binding must be a GraphTraversalSource");
+        }
+        return (GraphTraversalSource) source;
+    }
+
+    private static Object verify(Object result) {
+        if (result instanceof Traversal) {
+            GremlinLangTraversalVerifier.verify((Traversal<?, ?>) result);
+        }
+        return result;
+    }
+
+    private static void rethrowSecurityException(ScriptException exception) {
+        Throwable cause = exception;
+        while (cause != null) {
+            if (cause instanceof SecurityException) {
+                throw (SecurityException) cause;
+            }
+            cause = cause.getCause();
+        }
+    }
+
+    private static ScriptContext guardedContext(
+            ScriptContext context,
+            GraphTraversalSource traversalSource) {
+        SimpleScriptContext guarded = new SimpleScriptContext();
+        guarded.setReader(context.getReader());
+        guarded.setWriter(context.getWriter());
+        guarded.setErrorWriter(context.getErrorWriter());
+
+        Bindings engineBindings = new SimpleBindings();
+        Bindings original = context.getBindings(ScriptContext.ENGINE_SCOPE);
+        if (original != null) {
+            engineBindings.putAll(original);
+        }
+        engineBindings.put(TRAVERSAL_SOURCE, traversalSource);
+        guarded.setBindings(engineBindings, ScriptContext.ENGINE_SCOPE);
+
+        Bindings global = context.getBindings(ScriptContext.GLOBAL_SCOPE);
+        if (global != null) {
+            guarded.setBindings(global, ScriptContext.GLOBAL_SCOPE);
+        }
+        return guarded;
+    }
+
+    private static final class Delegate {
+
+        private final GremlinLangScriptEngine engine;
+        private final GraphTraversalSource traversalSource;
+
+        private Delegate(GremlinLangScriptEngine engine,
+                         GraphTraversalSource traversalSource) {
+            this.engine = engine;
+            this.traversalSource = traversalSource;
+        }
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
@@ -240,7 +240,8 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
         GraphTraversalSource protectedSource = traversalSource;
         if (!isProtected(protectedSource)) {
             protectedSource = traversalSource.withStrategies(
-                    GremlinLangRestrictionStrategy.instance());
+                    GremlinLangRestrictionStrategy.instance(),
+                    GremlinLangVerificationStrategy.instance());
         }
         return new Delegate(
                 new GremlinLangScriptEngine(this.customizers),
@@ -256,9 +257,11 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
 
     private static boolean isProtected(
             GraphTraversalSource traversalSource) {
-        return traversalSource.getStrategies()
-                              .getStrategy(
+        return traversalSource.getStrategies().getStrategy(
                                       GremlinLangRestrictionStrategy.class)
+                              .isPresent() &&
+               traversalSource.getStrategies().getStrategy(
+                                      GremlinLangVerificationStrategy.class)
                               .isPresent();
     }
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
@@ -17,6 +17,7 @@
 
 package org.apache.hugegraph.security;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Map;
@@ -48,6 +49,7 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
 
     private final HugeGraphGremlinLangScriptEngineFactory factory;
     private final Customizer[] customizers;
+    private final GremlinLangTextPredicateAdapter textPredicateAdapter;
     private final ConcurrentMap<GraphTraversalSource, Delegate>
             delegates;
     private final ConcurrentMap<GraphTraversalSource, Delegate>
@@ -60,6 +62,8 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
             Customizer... customizers) {
         this.factory = factory;
         this.customizers = customizers.clone();
+        this.textPredicateAdapter =
+                new GremlinLangTextPredicateAdapter(this.customizers);
         this.delegates = new ConcurrentHashMap<>();
         this.protectedDelegates = new ConcurrentHashMap<>();
         this.explicitRegistration = new AtomicBoolean(false);
@@ -82,10 +86,13 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
             return 2;
         }
         Delegate delegate = this.delegate(traversalSource(context));
+        GremlinLangTextPredicateAdapter.AdaptedScript adapted =
+                this.textPredicateAdapter.adapt(script, context);
         try {
             return verify(delegate.engine.eval(
-                    script,
-                    guardedContext(context, delegate.traversalSource)));
+                    adapted.script(),
+                    guardedContext(context, delegate.traversalSource,
+                                   adapted.bindings())));
         } catch (ScriptException e) {
             rethrowSecurityException(e);
             throw e;
@@ -95,14 +102,10 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
     @Override
     public Object eval(Reader reader, ScriptContext context)
             throws ScriptException {
-        Delegate delegate = this.delegate(traversalSource(context));
         try {
-            return verify(delegate.engine.eval(
-                    reader,
-                    guardedContext(context, delegate.traversalSource)));
-        } catch (ScriptException e) {
-            rethrowSecurityException(e);
-            throw e;
+            return this.eval(readFully(reader), context);
+        } catch (IOException e) {
+            throw new ScriptException(e);
         }
     }
 
@@ -288,7 +291,8 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
 
     private static ScriptContext guardedContext(
             ScriptContext context,
-            GraphTraversalSource traversalSource) {
+            GraphTraversalSource traversalSource,
+            Map<String, Object> additionalBindings) {
         SimpleScriptContext guarded = new SimpleScriptContext();
         guarded.setReader(context.getReader());
         guarded.setWriter(context.getWriter());
@@ -299,6 +303,7 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
         if (original != null) {
             engineBindings.putAll(original);
         }
+        engineBindings.putAll(additionalBindings);
         engineBindings.put(TRAVERSAL_SOURCE, traversalSource);
         guarded.setBindings(engineBindings, ScriptContext.ENGINE_SCOPE);
 
@@ -307,6 +312,16 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
             guarded.setBindings(global, ScriptContext.GLOBAL_SCOPE);
         }
         return guarded;
+    }
+
+    private static String readFully(Reader reader) throws IOException {
+        StringBuilder script = new StringBuilder();
+        char[] buffer = new char[8192];
+        int length;
+        while ((length = reader.read(buffer)) != -1) {
+            script.append(buffer, 0, length);
+        }
+        return script.toString();
     }
 
     private static final class Delegate {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
@@ -18,6 +18,9 @@
 package org.apache.hugegraph.security;
 
 import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -41,6 +44,7 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
 
     private static final String TRAVERSAL_SOURCE = "g";
     private static final String TINKERPOP_INITIALIZATION_PROBE = "1+1";
+    private static final SourceRegistry SOURCES = new SourceRegistry();
 
     private final HugeGraphGremlinLangScriptEngineFactory factory;
     private final Customizer[] customizers;
@@ -131,7 +135,8 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
         return this.factory;
     }
 
-    public GraphTraversalSource add(GraphTraversalSource traversalSource) {
+    public synchronized GraphTraversalSource add(
+            GraphTraversalSource traversalSource) {
         if (traversalSource == null) {
             throw new IllegalArgumentException(
                     "The traversal source can't be null");
@@ -141,10 +146,11 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
                 traversalSource, this::newDelegate);
         this.protectedDelegates.putIfAbsent(delegate.traversalSource,
                                             delegate);
+        SOURCES.register(delegate.traversalSource, this);
         return delegate.traversalSource;
     }
 
-    public void remove(GraphTraversalSource traversalSource) {
+    public synchronized void remove(GraphTraversalSource traversalSource) {
         if (traversalSource == null) {
             return;
         }
@@ -153,13 +159,27 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
             delegate = this.protectedDelegates.get(traversalSource);
         }
         if (delegate != null) {
-            this.delegates.remove(delegate.registrationSource, delegate);
-            this.protectedDelegates.remove(delegate.traversalSource,
-                                           delegate);
+            if (this.explicitRegistration.get()) {
+                SOURCES.retire(delegate.traversalSource);
+            } else {
+                SOURCES.detach(delegate.traversalSource, this);
+                this.removeLocal(delegate.traversalSource);
+            }
         }
     }
 
-    public void clear() {
+    public synchronized void clear() {
+        if (this.explicitRegistration.get()) {
+            for (GraphTraversalSource source :
+                 new ArrayList<>(this.protectedDelegates.keySet())) {
+                SOURCES.retire(source);
+            }
+        } else {
+            for (GraphTraversalSource source :
+                 new ArrayList<>(this.protectedDelegates.keySet())) {
+                SOURCES.detach(source, this);
+            }
+        }
         this.delegates.clear();
         this.protectedDelegates.clear();
     }
@@ -173,12 +193,15 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
         if (delegate == null) {
             delegate = this.protectedDelegates.get(traversalSource);
         }
-        if (delegate == null && !this.explicitRegistration.get() &&
-            isProtected(traversalSource)) {
-            delegate = this.delegates.computeIfAbsent(
-                    traversalSource, this::newDelegate);
-            this.protectedDelegates.putIfAbsent(delegate.traversalSource,
-                                                delegate);
+        if (delegate == null && !this.explicitRegistration.get()) {
+            delegate = SOURCES.attach(traversalSource, this);
+            if (delegate == null &&
+                (SOURCES.isRetired(traversalSource) ||
+                 isProtected(traversalSource))) {
+                throw new IllegalArgumentException(
+                        "The protected 'g' binding must reference an active " +
+                        "GraphTraversalSource");
+            }
         }
         if (delegate == null) {
             String requirement = this.explicitRegistration.get() ?
@@ -190,6 +213,26 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
         return delegate;
     }
 
+    private Delegate attachLocal(GraphTraversalSource traversalSource) {
+        Delegate delegate = this.delegates.computeIfAbsent(
+                traversalSource, this::newProtectedDelegate);
+        this.protectedDelegates.putIfAbsent(delegate.traversalSource,
+                                            delegate);
+        return delegate;
+    }
+
+    private void removeLocal(GraphTraversalSource traversalSource) {
+        Delegate delegate = this.protectedDelegates.get(traversalSource);
+        if (delegate == null) {
+            delegate = this.delegates.get(traversalSource);
+        }
+        if (delegate != null) {
+            this.delegates.remove(delegate.registrationSource, delegate);
+            this.protectedDelegates.remove(delegate.traversalSource,
+                                           delegate);
+        }
+    }
+
     private Delegate newDelegate(GraphTraversalSource traversalSource) {
         GraphTraversalSource protectedSource = traversalSource;
         if (!isProtected(protectedSource)) {
@@ -199,6 +242,13 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
         return new Delegate(
                 new GremlinLangScriptEngine(this.customizers),
                 traversalSource, protectedSource);
+    }
+
+    private Delegate newProtectedDelegate(
+            GraphTraversalSource traversalSource) {
+        return new Delegate(
+                new GremlinLangScriptEngine(this.customizers),
+                traversalSource, traversalSource);
     }
 
     private static boolean isProtected(
@@ -271,6 +321,74 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
             this.engine = engine;
             this.registrationSource = registrationSource;
             this.traversalSource = traversalSource;
+        }
+    }
+
+    private static final class SourceRegistry {
+
+        private final Map<GraphTraversalSource, SourceEntry> sources;
+        private final Map<GraphTraversalSource, Boolean> retiredSources;
+
+        private SourceRegistry() {
+            this.sources = new WeakHashMap<>();
+            this.retiredSources = new WeakHashMap<>();
+        }
+
+        private synchronized void register(GraphTraversalSource source,
+                                           HugeGraphGremlinLangScriptEngine
+                                                   engine) {
+            SourceEntry entry = this.sources.computeIfAbsent(
+                    source, key -> new SourceEntry());
+            this.retiredSources.remove(source);
+            entry.engines.put(engine, Boolean.TRUE);
+        }
+
+        private synchronized Delegate attach(
+                GraphTraversalSource source,
+                HugeGraphGremlinLangScriptEngine engine) {
+            SourceEntry entry = this.sources.get(source);
+            if (entry == null) {
+                return null;
+            }
+            Delegate delegate = engine.attachLocal(source);
+            entry.engines.put(engine, Boolean.TRUE);
+            return delegate;
+        }
+
+        private synchronized boolean isRetired(
+                GraphTraversalSource source) {
+            return this.retiredSources.containsKey(source);
+        }
+
+        private synchronized void detach(
+                GraphTraversalSource source,
+                HugeGraphGremlinLangScriptEngine engine) {
+            SourceEntry entry = this.sources.get(source);
+            if (entry != null) {
+                entry.engines.remove(engine);
+            }
+        }
+
+        private synchronized void retire(GraphTraversalSource source) {
+            SourceEntry entry = this.sources.remove(source);
+            this.retiredSources.put(source, Boolean.TRUE);
+            if (entry == null) {
+                return;
+            }
+            for (HugeGraphGremlinLangScriptEngine engine :
+                 new ArrayList<>(entry.engines.keySet())) {
+                engine.removeLocal(source);
+            }
+            entry.engines.clear();
+        }
+    }
+
+    private static final class SourceEntry {
+
+        private final Map<HugeGraphGremlinLangScriptEngine, Boolean> engines;
+
+        private SourceEntry() {
+            this.engines = new WeakHashMap<>();
         }
     }
 }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
@@ -20,6 +20,7 @@ package org.apache.hugegraph.security;
 import java.io.Reader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.script.AbstractScriptEngine;
 import javax.script.Bindings;
@@ -45,6 +46,7 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
     private final Customizer[] customizers;
     private final ConcurrentMap<GraphTraversalSource, Delegate>
             delegates;
+    private final AtomicBoolean initializationProbeAllowed;
 
     HugeGraphGremlinLangScriptEngine(
             HugeGraphGremlinLangScriptEngineFactory factory,
@@ -52,6 +54,7 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
         this.factory = factory;
         this.customizers = customizers.clone();
         this.delegates = new ConcurrentHashMap<>();
+        this.initializationProbeAllowed = new AtomicBoolean(true);
     }
 
     @Override
@@ -65,7 +68,8 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
          * injected. The fixed expression needs no graph access.
          */
         if (TINKERPOP_INITIALIZATION_PROBE.equals(script) &&
-            context.getAttribute(TRAVERSAL_SOURCE) == null) {
+            context.getAttribute(TRAVERSAL_SOURCE) == null &&
+            this.initializationProbeAllowed.compareAndSet(true, false)) {
             return 2;
         }
         Delegate delegate = this.delegate(traversalSource(context));
@@ -122,6 +126,14 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
         return this.factory;
     }
 
+    public void add(GraphTraversalSource traversalSource) {
+        if (traversalSource == null) {
+            throw new IllegalArgumentException(
+                    "The traversal source can't be null");
+        }
+        this.delegates.computeIfAbsent(traversalSource, this::newDelegate);
+    }
+
     public void remove(GraphTraversalSource traversalSource) {
         if (traversalSource != null) {
             this.delegates.remove(traversalSource);
@@ -137,12 +149,20 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
     }
 
     private Delegate delegate(GraphTraversalSource traversalSource) {
-        return this.delegates.computeIfAbsent(
-                traversalSource,
-                source -> new Delegate(
-                        new GremlinLangScriptEngine(this.customizers),
-                        source.withStrategies(
-                                GremlinLangRestrictionStrategy.instance())));
+        Delegate delegate = this.delegates.get(traversalSource);
+        if (delegate == null) {
+            throw new IllegalArgumentException(
+                    "The 'g' binding must be a registered " +
+                    "GraphTraversalSource");
+        }
+        return delegate;
+    }
+
+    private Delegate newDelegate(GraphTraversalSource traversalSource) {
+        return new Delegate(
+                new GremlinLangScriptEngine(this.customizers),
+                traversalSource.withStrategies(
+                        GremlinLangRestrictionStrategy.instance()));
     }
 
     private static GraphTraversalSource traversalSource(

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
@@ -34,6 +34,7 @@ import javax.script.SimpleBindings;
 import javax.script.SimpleScriptContext;
 
 import org.apache.tinkerpop.gremlin.jsr223.Customizer;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinLangCustomizer;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinLangScriptEngine;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
@@ -61,9 +62,8 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
             HugeGraphGremlinLangScriptEngineFactory factory,
             Customizer... customizers) {
         this.factory = factory;
-        this.customizers = customizers.clone();
-        this.textPredicateAdapter =
-                new GremlinLangTextPredicateAdapter(this.customizers);
+        this.customizers = withoutTraversalCache(customizers);
+        this.textPredicateAdapter = new GremlinLangTextPredicateAdapter();
         this.delegates = new ConcurrentHashMap<>();
         this.protectedDelegates = new ConcurrentHashMap<>();
         this.explicitRegistration = new AtomicBoolean(false);
@@ -260,6 +260,21 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
                               .getStrategy(
                                       GremlinLangRestrictionStrategy.class)
                               .isPresent();
+    }
+
+    private static Customizer[] withoutTraversalCache(
+            Customizer[] customizers) {
+        Customizer[] safeCustomizers = customizers.clone();
+        for (int i = 0; i < safeCustomizers.length; i++) {
+            if (!(safeCustomizers[i] instanceof GremlinLangCustomizer)) {
+                continue;
+            }
+            GremlinLangCustomizer gremlinLang =
+                    (GremlinLangCustomizer) safeCustomizers[i];
+            safeCustomizers[i] = new GremlinLangCustomizer(
+                    false, gremlinLang.getCacheMaker());
+        }
+        return safeCustomizers;
     }
 
     private static GraphTraversalSource traversalSource(

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngine.java
@@ -46,6 +46,9 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
     private final Customizer[] customizers;
     private final ConcurrentMap<GraphTraversalSource, Delegate>
             delegates;
+    private final ConcurrentMap<GraphTraversalSource, Delegate>
+            protectedDelegates;
+    private final AtomicBoolean explicitRegistration;
     private final AtomicBoolean initializationProbeAllowed;
 
     HugeGraphGremlinLangScriptEngine(
@@ -54,6 +57,8 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
         this.factory = factory;
         this.customizers = customizers.clone();
         this.delegates = new ConcurrentHashMap<>();
+        this.protectedDelegates = new ConcurrentHashMap<>();
+        this.explicitRegistration = new AtomicBoolean(false);
         this.initializationProbeAllowed = new AtomicBoolean(true);
     }
 
@@ -126,22 +131,37 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
         return this.factory;
     }
 
-    public void add(GraphTraversalSource traversalSource) {
+    public GraphTraversalSource add(GraphTraversalSource traversalSource) {
         if (traversalSource == null) {
             throw new IllegalArgumentException(
                     "The traversal source can't be null");
         }
-        this.delegates.computeIfAbsent(traversalSource, this::newDelegate);
+        this.explicitRegistration.set(true);
+        Delegate delegate = this.delegates.computeIfAbsent(
+                traversalSource, this::newDelegate);
+        this.protectedDelegates.putIfAbsent(delegate.traversalSource,
+                                            delegate);
+        return delegate.traversalSource;
     }
 
     public void remove(GraphTraversalSource traversalSource) {
-        if (traversalSource != null) {
-            this.delegates.remove(traversalSource);
+        if (traversalSource == null) {
+            return;
+        }
+        Delegate delegate = this.delegates.get(traversalSource);
+        if (delegate == null) {
+            delegate = this.protectedDelegates.get(traversalSource);
+        }
+        if (delegate != null) {
+            this.delegates.remove(delegate.registrationSource, delegate);
+            this.protectedDelegates.remove(delegate.traversalSource,
+                                           delegate);
         }
     }
 
     public void clear() {
         this.delegates.clear();
+        this.protectedDelegates.clear();
     }
 
     public int traversalSourceCount() {
@@ -151,18 +171,42 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
     private Delegate delegate(GraphTraversalSource traversalSource) {
         Delegate delegate = this.delegates.get(traversalSource);
         if (delegate == null) {
+            delegate = this.protectedDelegates.get(traversalSource);
+        }
+        if (delegate == null && !this.explicitRegistration.get() &&
+            isProtected(traversalSource)) {
+            delegate = this.delegates.computeIfAbsent(
+                    traversalSource, this::newDelegate);
+            this.protectedDelegates.putIfAbsent(delegate.traversalSource,
+                                                delegate);
+        }
+        if (delegate == null) {
+            String requirement = this.explicitRegistration.get() ?
+                                 "registered" : "protected";
             throw new IllegalArgumentException(
-                    "The 'g' binding must be a registered " +
+                    "The 'g' binding must be a " + requirement + " " +
                     "GraphTraversalSource");
         }
         return delegate;
     }
 
     private Delegate newDelegate(GraphTraversalSource traversalSource) {
+        GraphTraversalSource protectedSource = traversalSource;
+        if (!isProtected(protectedSource)) {
+            protectedSource = traversalSource.withStrategies(
+                    GremlinLangRestrictionStrategy.instance());
+        }
         return new Delegate(
                 new GremlinLangScriptEngine(this.customizers),
-                traversalSource.withStrategies(
-                        GremlinLangRestrictionStrategy.instance()));
+                traversalSource, protectedSource);
+    }
+
+    private static boolean isProtected(
+            GraphTraversalSource traversalSource) {
+        return traversalSource.getStrategies()
+                              .getStrategy(
+                                      GremlinLangRestrictionStrategy.class)
+                              .isPresent();
     }
 
     private static GraphTraversalSource traversalSource(
@@ -218,11 +262,14 @@ public class HugeGraphGremlinLangScriptEngine extends AbstractScriptEngine
     private static final class Delegate {
 
         private final GremlinLangScriptEngine engine;
+        private final GraphTraversalSource registrationSource;
         private final GraphTraversalSource traversalSource;
 
         private Delegate(GremlinLangScriptEngine engine,
+                         GraphTraversalSource registrationSource,
                          GraphTraversalSource traversalSource) {
             this.engine = engine;
+            this.registrationSource = registrationSource;
             this.traversalSource = traversalSource;
         }
     }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngineFactory.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngineFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.security;
+
+import java.util.List;
+
+import org.apache.tinkerpop.gremlin.jsr223.AbstractGremlinScriptEngineFactory;
+import org.apache.tinkerpop.gremlin.jsr223.Customizer;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinLangScriptEngineFactory;
+
+public class HugeGraphGremlinLangScriptEngineFactory
+       extends AbstractGremlinScriptEngineFactory {
+
+    public static final String ENGINE_NAME = "gremlin-lang";
+    public static final String INTERNAL_ENGINE_NAME =
+            "hugegraph-gremlin-lang";
+
+    private static final GremlinLangScriptEngineFactory BASE_FACTORY =
+            new GremlinLangScriptEngineFactory();
+
+    private final Customizer[] fixedCustomizers;
+    private volatile HugeGraphGremlinLangScriptEngine engine;
+
+    public HugeGraphGremlinLangScriptEngineFactory() {
+        super(INTERNAL_ENGINE_NAME, BASE_FACTORY.getLanguageName(),
+              BASE_FACTORY.getExtensions(), BASE_FACTORY.getMimeTypes());
+        this.fixedCustomizers = null;
+    }
+
+    public HugeGraphGremlinLangScriptEngineFactory(
+            Customizer... customizers) {
+        super(INTERNAL_ENGINE_NAME, BASE_FACTORY.getLanguageName(),
+              BASE_FACTORY.getExtensions(), BASE_FACTORY.getMimeTypes());
+        this.fixedCustomizers = customizers.clone();
+    }
+
+    @Override
+    public synchronized HugeGraphGremlinLangScriptEngine getScriptEngine() {
+        if (this.engine == null) {
+            Customizer[] customizers = this.customizers();
+            this.engine = new HugeGraphGremlinLangScriptEngine(this,
+                                                                customizers);
+        }
+        return this.engine;
+    }
+
+    @Override
+    public List<String> getNames() {
+        return List.of(INTERNAL_ENGINE_NAME);
+    }
+
+    @Override
+    public String getMethodCallSyntax(String object, String method,
+                                      String... args) {
+        return BASE_FACTORY.getMethodCallSyntax(object, method, args);
+    }
+
+    @Override
+    public String getOutputStatement(String value) {
+        return BASE_FACTORY.getOutputStatement(value);
+    }
+
+    private Customizer[] customizers() {
+        if (this.fixedCustomizers != null) {
+            return this.fixedCustomizers.clone();
+        }
+        if (this.manager == null) {
+            return new Customizer[0];
+        }
+        List<Customizer> customizers = this.manager.getCustomizers(
+                ENGINE_NAME);
+        return customizers.toArray(new Customizer[0]);
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngineFactory.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/security/HugeGraphGremlinLangScriptEngineFactory.java
@@ -38,14 +38,14 @@ public class HugeGraphGremlinLangScriptEngineFactory
 
     public HugeGraphGremlinLangScriptEngineFactory() {
         super(INTERNAL_ENGINE_NAME, BASE_FACTORY.getLanguageName(),
-              BASE_FACTORY.getExtensions(), BASE_FACTORY.getMimeTypes());
+              List.of(), List.of());
         this.fixedCustomizers = null;
     }
 
     public HugeGraphGremlinLangScriptEngineFactory(
             Customizer... customizers) {
         super(INTERNAL_ENGINE_NAME, BASE_FACTORY.getLanguageName(),
-              BASE_FACTORY.getExtensions(), BASE_FACTORY.getMimeTypes());
+              List.of(), List.of());
         this.fixedCustomizers = customizers.clone();
     }
 

--- a/hugegraph-server/hugegraph-core/src/main/resources/META-INF/services/org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineFactory
+++ b/hugegraph-server/hugegraph-core/src/main/resources/META-INF/services/org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineFactory
@@ -1,0 +1,1 @@
+org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-server.yaml
@@ -21,11 +21,23 @@
 # timeout in ms of gremlin query
 evaluationTimeout: 30000
 
-channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
+channelizer: org.apache.hugegraph.auth.HugeGraphWsAndHttpChannelizer
 # don't set graph at here, this happens after support for dynamically adding graph
 graphs: {
 }
 scriptEngines: {
+  # Internal registration name; remote clients still use gremlin-lang.
+  hugegraph-gremlin-lang: {
+    plugins: {
+      org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin: {
+        cacheEnabled: true,
+        caffeine: "maximumSize=1024,expireAfterAccess=10m"
+      },
+      org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin: {
+        resolver: DefaultVariableResolver
+      }
+    }
+  },
   gremlin-groovy: {
     staticImports: [
       org.opencypher.gremlin.process.traversal.CustomPredicates.*',

--- a/hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/static/conf/gremlin-server.yaml
@@ -30,8 +30,9 @@ scriptEngines: {
   hugegraph-gremlin-lang: {
     plugins: {
       org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin: {
-        cacheEnabled: true,
-        caffeine: "maximumSize=1024,expireAfterAccess=10m"
+        # Parsed traversals can retain mutable request bindings.
+        # HugeGraph caches only immutable Text.contains() rewrite plans.
+        cacheEnabled: false
       },
       org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin: {
         resolver: DefaultVariableResolver

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft1/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft1/gremlin-server.yaml
@@ -21,11 +21,23 @@ port: 8181
 # timeout in ms of gremlin query
 evaluationTimeout: 60000
 
-channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
+channelizer: org.apache.hugegraph.auth.HugeGraphWsAndHttpChannelizer
 # don't set graph at here, this happens after support for dynamically adding graph
 graphs: {
 }
 scriptEngines: {
+  # Internal registration name; remote clients still use gremlin-lang.
+  hugegraph-gremlin-lang: {
+    plugins: {
+      org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin: {
+        cacheEnabled: true,
+        caffeine: "maximumSize=1024,expireAfterAccess=10m"
+      },
+      org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin: {
+        resolver: DefaultVariableResolver
+      }
+    }
+  },
   gremlin-groovy: {
     plugins: {
       org.apache.hugegraph.plugin.HugeGraphGremlinPlugin: {},

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft1/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft1/gremlin-server.yaml
@@ -30,8 +30,9 @@ scriptEngines: {
   hugegraph-gremlin-lang: {
     plugins: {
       org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin: {
-        cacheEnabled: true,
-        caffeine: "maximumSize=1024,expireAfterAccess=10m"
+        # Parsed traversals can retain mutable request bindings.
+        # HugeGraph caches only immutable Text.contains() rewrite plans.
+        cacheEnabled: false
       },
       org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin: {
         resolver: DefaultVariableResolver

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft2/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft2/gremlin-server.yaml
@@ -30,8 +30,9 @@ scriptEngines: {
   hugegraph-gremlin-lang: {
     plugins: {
       org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin: {
-        cacheEnabled: true,
-        caffeine: "maximumSize=1024,expireAfterAccess=10m"
+        # Parsed traversals can retain mutable request bindings.
+        # HugeGraph caches only immutable Text.contains() rewrite plans.
+        cacheEnabled: false
       },
       org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin: {
         resolver: DefaultVariableResolver

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft2/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft2/gremlin-server.yaml
@@ -21,11 +21,23 @@ port: 8182
 # timeout in ms of gremlin query
 evaluationTimeout: 60000
 
-channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
+channelizer: org.apache.hugegraph.auth.HugeGraphWsAndHttpChannelizer
 # don't set graph at here, this happens after support for dynamically adding graph
 graphs: {
 }
 scriptEngines: {
+  # Internal registration name; remote clients still use gremlin-lang.
+  hugegraph-gremlin-lang: {
+    plugins: {
+      org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin: {
+        cacheEnabled: true,
+        caffeine: "maximumSize=1024,expireAfterAccess=10m"
+      },
+      org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin: {
+        resolver: DefaultVariableResolver
+      }
+    }
+  },
   gremlin-groovy: {
     plugins: {
       org.apache.hugegraph.plugin.HugeGraphGremlinPlugin: {},

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft3/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft3/gremlin-server.yaml
@@ -21,11 +21,23 @@ port: 8183
 # timeout in ms of gremlin query
 evaluationTimeout: 60000
 
-channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
+channelizer: org.apache.hugegraph.auth.HugeGraphWsAndHttpChannelizer
 # don't set graph at here, this happens after support for dynamically adding graph
 graphs: {
 }
 scriptEngines: {
+  # Internal registration name; remote clients still use gremlin-lang.
+  hugegraph-gremlin-lang: {
+    plugins: {
+      org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin: {
+        cacheEnabled: true,
+        caffeine: "maximumSize=1024,expireAfterAccess=10m"
+      },
+      org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin: {
+        resolver: DefaultVariableResolver
+      }
+    }
+  },
   gremlin-groovy: {
     plugins: {
       org.apache.hugegraph.plugin.HugeGraphGremlinPlugin: {},

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft3/gremlin-server.yaml
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/conf-raft3/gremlin-server.yaml
@@ -30,8 +30,9 @@ scriptEngines: {
   hugegraph-gremlin-lang: {
     plugins: {
       org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin: {
-        cacheEnabled: true,
-        caffeine: "maximumSize=1024,expireAfterAccess=10m"
+        # Parsed traversals can retain mutable request bindings.
+        # HugeGraph caches only immutable Text.contains() rewrite plans.
+        cacheEnabled: false
       },
       org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin: {
         resolver: DefaultVariableResolver

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -59,6 +59,11 @@ EOF
 
 cat > "$SMOKE_SCRIPT" <<EOF
 import org.apache.tinkerpop.gremlin.driver.Cluster
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection
+import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource
+import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1
+
+import java.util.UUID
 
 cluster = Cluster.open('conf/remote.yaml')
 client = cluster.connect().alias(['g': '__g_DEFAULT-hugegraph'])
@@ -69,7 +74,52 @@ try {
     if (count < 0L) {
         throw new IllegalStateException('Unexpected vertex count: ' + count)
     }
-    println('${SMOKE_MARKER}-' + count)
+
+    // The Console config uses untyped GraphSON for legacy result objects.
+    // GLV Bytecode needs a typed serializer, so exercise its standard
+    // GraphBinary protocol with a separate connection.
+    glvCluster = Cluster.build()
+                        .addContactPoint('localhost')
+                        .port(8182)
+                        .credentials('admin', 'pa')
+                        .serializer(new GraphBinaryMessageSerializerV1())
+                        .create()
+    try {
+        remote = DriverRemoteConnection.using(
+                glvCluster, '__g_DEFAULT-hugegraph')
+        remoteG = AnonymousTraversalSource.traversal().withRemote(remote)
+        try {
+            bytecodeCount = remoteG.V().count().next()
+            if (bytecodeCount != count) {
+                throw new IllegalStateException(
+                        'Bytecode count differs from text count: ' +
+                        bytecodeCount + ' != ' + count)
+            }
+        } finally {
+            remoteG.close()
+        }
+    } finally {
+        glvCluster.close()
+    }
+
+    session = cluster.connect(
+            'hugegraph-smoke-' + UUID.randomUUID().toString())
+                     .alias(['g': '__g_DEFAULT-hugegraph'])
+    try {
+        sessionResults = session.submit(remoteScript).all().get()
+        sessionCount = sessionResults[0].getLong()
+        if (sessionCount != count) {
+            throw new IllegalStateException(
+                    'Session count differs from text count: ' +
+                    sessionCount + ' != ' + count)
+        }
+    } finally {
+        session.close()
+    }
+
+    println('${SMOKE_MARKER}-text-' + count +
+            '-bytecode-' + bytecodeCount +
+            '-session-' + sessionCount)
 } finally {
     client.close()
     cluster.close()

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-gremlin-console-smoke-test.sh
@@ -63,12 +63,13 @@ import org.apache.tinkerpop.gremlin.driver.Cluster
 cluster = Cluster.open('conf/remote.yaml')
 client = cluster.connect().alias(['g': '__g_DEFAULT-hugegraph'])
 try {
-    remoteScript = "def count = g.V().count().next(); " +
-                   "if (count < 0L) " +
-                   "throw new IllegalStateException('Unexpected vertex count: ' + count); " +
-                   "'${SMOKE_MARKER}-' + count"
+    remoteScript = "g.V().count()"
     results = client.submit(remoteScript).all().get()
-    println(results[0].object)
+    count = results[0].getLong()
+    if (count < 0L) {
+        throw new IllegalStateException('Unexpected vertex count: ' + count)
+    }
+    println('${SMOKE_MARKER}-' + count)
 } finally {
     client.close()
     cluster.close()

--- a/hugegraph-server/hugegraph-dist/src/assembly/travis/run-server-e2e-smoke-test.sh
+++ b/hugegraph-server/hugegraph-dist/src/assembly/travis/run-server-e2e-smoke-test.sh
@@ -137,7 +137,7 @@ verify_graph() {
 
     request POST /gremlin 200 \
         "$(jq -cn --arg query "g.V().hasLabel('$VERTEX_LABEL').count()" \
-             '{gremlin:$query, bindings:{}, language:"gremlin-groovy",
+             '{gremlin:$query, bindings:{},
                aliases:{g:"__g_DEFAULT-hugegraph"}}')"
     assert_json '.result.data == [2]'
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/api/GremlinApiTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/api/GremlinApiTest.java
@@ -17,11 +17,9 @@
 
 package org.apache.hugegraph.api;
 
-import java.util.List;
 import java.util.Map;
 
 import org.apache.hugegraph.testutil.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -37,22 +35,23 @@ public class GremlinApiTest extends BaseApiTest {
         String body = "{" +
                       "\"gremlin\":\"g.V()\"," +
                       "\"bindings\":{}," +
-                      "\"language\":\"gremlin-groovy\"," +
+                      "\"language\":\"gremlin-lang\"," +
                       "\"aliases\":{\"g\":\"__g_DEFAULT-hugegraph\"}}";
         assertResponseStatus(200, client().post(path, body));
     }
 
     @Test
     public void testGet() {
-        Map<String, Object> params = ImmutableMap.of("gremlin",
-                                                     "this.binding.'DEFAULT-hugegraph'.traversal" +
-                                                     "().V()");
+        Map<String, Object> params = ImmutableMap.of(
+                "gremlin", "g.V()",
+                "language", "gremlin-lang",
+                "aliases.g", "__g_DEFAULT-hugegraph");
         Response r = client().get(path, params);
         Assert.assertEquals(r.readEntity(String.class), 200, r.getStatus());
     }
 
     @Test
-    public void testScript() {
+    public void testRemoteGroovyScriptIsRejected() {
         String bodyTemplate = "{" +
                               "\"gremlin\":\"%s\"," +
                               "\"bindings\":{}," +
@@ -80,19 +79,11 @@ public class GremlinApiTest extends BaseApiTest {
                         "'city','235e1153928149578691cf79258e90eb');" +
                         "marko.addEdge('knows',vadas,'date','20160110');";
         String body = String.format(bodyTemplate, script);
-        assertResponseStatus(200, client().post(path, body));
-
-        String queryV = "g.V()";
-        body = String.format(bodyTemplate, queryV);
-        assertResponseStatus(200, client().post(path, body));
-
-        String queryE = "g.E()";
-        body = String.format(bodyTemplate, queryE);
-        assertResponseStatus(200, client().post(path, body));
+        assertResponseStatus(400, client().post(path, body));
     }
 
     @Test
-    public void testClearAndInit() {
+    public void testRemoteAdminGroovyIsRejected() {
         String body = "{" +
                       "\"gremlin\":\"graph.backendStoreFeatures()" +
                       "                       .supportsSharedStorage();\"," +
@@ -100,48 +91,11 @@ public class GremlinApiTest extends BaseApiTest {
                       "\"language\":\"gremlin-groovy\"," +
                       "\"aliases\":{\"graph\":\"DEFAULT-hugegraph\"," +
                       "\"g\":\"__g_DEFAULT-hugegraph\"}}";
-        String content = assertResponseStatus(200, client().post(path, body));
-        Map<?, ?> result = assertJsonContains(content, "result");
-        @SuppressWarnings({"unchecked"})
-        Object data = ((List<Object>) assertMapContains(result, "data")).get(0);
-        boolean supportsSharedStorage = (boolean) data;
-        Assume.assumeTrue("Can't clear non-shared-storage backend",
-                          supportsSharedStorage);
-
-        body = "{" +
-               "\"gremlin\":\"" +
-               "  if (!graph.backendStoreFeatures()" +
-               "                .supportsSharedStorage())" +
-               "    return;" +
-               "  def auth = graph.hugegraph().authManager();" +
-               "  def admin = auth.findUser('admin');" +
-               "  graph.clearBackend();" +
-               "  graph.initBackend();" +
-               "  try {" +
-               "    auth.createUser(admin);" +
-               "  } catch(Exception e) {" +
-               "  }" +
-               "\"," +
-               "\"bindings\":{}," +
-               "\"language\":\"gremlin-groovy\"," +
-               "\"aliases\":{\"graph\":\"DEFAULT-hugegraph\"," +
-               "\"g\":\"__g_DEFAULT-hugegraph\"}}";
-
-        assertResponseStatus(200, client().post(path, body));
-
-        body = "{" +
-               "\"gremlin\":\"graph.serverStarted(" +
-               "              GlobalMasterInfo.master('server1'))\"," +
-               "\"bindings\":{}," +
-               "\"language\":\"gremlin-groovy\"," +
-               "\"aliases\":{\"graph\":\"DEFAULT-hugegraph\"," +
-               "\"g\":\"__g_DEFAULT-hugegraph\"}}";
-        assertResponseStatus(200, client().post(path, body));
+        assertResponseStatus(400, client().post(path, body));
     }
 
-    //FIXME: non-pd will not delete admin, but pd mode will
     @Test
-    public void testTruncate() {
+    public void testRemoteTruncateGroovyIsRejected() {
         String body = "{"
                       + "\"gremlin\":\""
                       + "  def auth = graph.hugegraph().authManager();"
@@ -158,7 +112,7 @@ public class GremlinApiTest extends BaseApiTest {
                       + "\"g\":\"__g_DEFAULT-hugegraph\"}"
                       + "}";
 
-        assertResponseStatus(200, client().post(path, body));
+        assertResponseStatus(400, client().post(path, body));
     }
 
     @Test
@@ -194,7 +148,7 @@ public class GremlinApiTest extends BaseApiTest {
                       "\"gremlin\":\"g.addV('person').property(T.id, '1')" +
                       ".property('foo', '123').property('bar', '123')\"," +
                       "\"bindings\":{}," +
-                      "\"language\":\"gremlin-groovy\"," +
+                      "\"language\":\"gremlin-lang\"," +
                       "\"aliases\":{\"g\":\"__g_DEFAULT-hugegraph\"}}";
         assertResponseStatus(200, client().post(path, body));
 
@@ -203,7 +157,7 @@ public class GremlinApiTest extends BaseApiTest {
                ".property(single, 'foo', '123')" +
                ".property(list, 'bar', '123')\"," +
                "\"bindings\":{}," +
-               "\"language\":\"gremlin-groovy\"," +
+               "\"language\":\"gremlin-lang\"," +
                "\"aliases\":{\"g\":\"__g_DEFAULT-hugegraph\"}}";
         assertResponseStatus(200, client().post(path, body));
 
@@ -212,7 +166,7 @@ public class GremlinApiTest extends BaseApiTest {
                ".property(list, 'foo', '123')" +
                ".property(list, 'bar', '123')\"," +
                "\"bindings\":{}," +
-               "\"language\":\"gremlin-groovy\"," +
+               "\"language\":\"gremlin-lang\"," +
                "\"aliases\":{\"g\":\"__g_DEFAULT-hugegraph\"}}";
         assertResponseStatus(400, client().post(path, body));
 
@@ -221,25 +175,19 @@ public class GremlinApiTest extends BaseApiTest {
                ".property(single, 'foo', '123')" +
                ".property(single, 'bar', '123')\"," +
                "\"bindings\":{}," +
-               "\"language\":\"gremlin-groovy\"," +
+               "\"language\":\"gremlin-lang\"," +
                "\"aliases\":{\"g\":\"__g_DEFAULT-hugegraph\"}}";
         assertResponseStatus(200, client().post(path, body));
     }
 
     @Test
-    public void testFileSerialize() {
+    public void testRemoteFileGroovyIsRejected() {
         String body = "{" +
                       "\"gremlin\":\"File file = new File('test.text')\"," +
                       "\"bindings\":{}," +
                       "\"language\":\"gremlin-groovy\"," +
                       "\"aliases\":{\"g\":\"__g_DEFAULT-hugegraph\"}}";
-        Response r = client().post(path, body);
-        String content = r.readEntity(String.class);
-        Assert.assertEquals(content, 200, r.getStatus());
-        Map<?, ?> result = assertJsonContains(content, "result");
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        Map data = ((List<Map>) assertMapContains(result, "data")).get(0);
-        Assert.assertEquals("test.text", data.get("file"));
+        assertResponseStatus(400, client().post(path, body));
     }
 
     @Test
@@ -247,7 +195,7 @@ public class GremlinApiTest extends BaseApiTest {
         String body = "{" +
                       "\"gremlin\":\"g.V().order().by(desc)\"," +
                       "\"bindings\":{}," +
-                      "\"language\":\"gremlin-groovy\"," +
+                      "\"language\":\"gremlin-lang\"," +
                       "\"aliases\":{\"g\":\"__g_DEFAULT-hugegraph\"}}";
         Response response = client().post(path, body);
         assertResponseStatus(200, response);
@@ -258,7 +206,7 @@ public class GremlinApiTest extends BaseApiTest {
         String body = "{" +
                       "\"gremlin\":\"g.V().order().by(asc)\"," +
                       "\"bindings\":{}," +
-                      "\"language\":\"gremlin-groovy\"," +
+                      "\"language\":\"gremlin-lang\"," +
                       "\"aliases\":{\"g\":\"__g_DEFAULT-hugegraph\"}}";
         Response response = client().post(path, body);
         assertResponseStatus(200, response);
@@ -269,7 +217,7 @@ public class GremlinApiTest extends BaseApiTest {
         String body = "{" +
                       "\"gremlin\":\"g.E().order().by(desc)\"," +
                       "\"bindings\":{}," +
-                      "\"language\":\"gremlin-groovy\"," +
+                      "\"language\":\"gremlin-lang\"," +
                       "\"aliases\":{\"g\":\"__g_DEFAULT-hugegraph\"}}";
         Response response = client().post(path, body);
         assertResponseStatus(200, response);
@@ -280,7 +228,7 @@ public class GremlinApiTest extends BaseApiTest {
         String body = "{" +
                       "\"gremlin\":\"g.E().order().by(asc)\"," +
                       "\"bindings\":{}," +
-                      "\"language\":\"gremlin-groovy\"," +
+                      "\"language\":\"gremlin-lang\"," +
                       "\"aliases\":{\"g\":\"__g_DEFAULT-hugegraph\"}}";
         Response response = client().post(path, body);
         assertResponseStatus(200, response);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
@@ -193,6 +193,19 @@ public class GremlinLangRequestGuardTest {
     }
 
     @Test
+    public void testRejectsNonStringSessionForEval() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                                               .processor("session")
+                                               .addArg(Tokens.ARGS_GREMLIN,
+                                                       "g.V().count()")
+                                               .addArg(Tokens.ARGS_SESSION, 1)
+                                               .create();
+
+        Assert.assertContains("string",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
     public void testAllowsTraversalBytecodeWithoutLambda() {
         RequestMessage request = bytecode("traversal", new Bytecode());
 
@@ -210,6 +223,17 @@ public class GremlinLangRequestGuardTest {
                                                .create();
 
         Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsNonStringSessionForBytecode() {
+        RequestMessage request = RequestMessage.from(
+                bytecode("session", new Bytecode()))
+                                               .addArg(Tokens.ARGS_SESSION, 1)
+                                               .create();
+
+        Assert.assertContains("string",
+                              GremlinLangRequestGuard.rejection(request));
     }
 
     @Test
@@ -241,6 +265,37 @@ public class GremlinLangRequestGuardTest {
                                                .create();
 
         Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsNonStringSessionForClose() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_CLOSE)
+                                               .processor("session")
+                                               .addArg(Tokens.ARGS_SESSION, 1)
+                                               .create();
+
+        Assert.assertContains("string",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testWebSocketHandlerRejectsNonStringSession() {
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new GremlinLangRequestHandler());
+        RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                                               .processor("session")
+                                               .addArg(Tokens.ARGS_GREMLIN,
+                                                       "g.V().count()")
+                                               .addArg(Tokens.ARGS_SESSION, 1)
+                                               .create();
+
+        Assert.assertFalse(channel.writeInbound(request));
+        ResponseMessage response = channel.readOutbound();
+        Assert.assertEquals(
+                ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS,
+                response.getStatus().getCode());
+        Assert.assertContains("string", response.getStatus().getMessage());
+        channel.finishAndReleaseAll();
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
@@ -24,7 +24,9 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.concurrent.ExecutorService;
 
+import org.apache.hugegraph.HugeException;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.tinkerpop.gremlin.server.Settings;
 import org.apache.tinkerpop.gremlin.util.Tokens;
@@ -40,6 +42,30 @@ import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 
 public class GremlinLangRequestGuardTest {
+
+    private static final String STANDARD_CHANNELIZER =
+            "org.apache.tinkerpop.gremlin.server.channel." +
+            "WsAndHttpChannelizer";
+
+    @Test
+    public void testRejectsUnprotectedServerChannelizer() {
+        Settings settings = new Settings();
+        settings.channelizer = STANDARD_CHANNELIZER;
+        settings.gremlinPool = 1;
+        ExecutorService executor = null;
+
+        try {
+            executor = ContextGremlinServer.newGremlinExecutorService(
+                    settings);
+            Assert.fail("Expected an unprotected channelizer error");
+        } catch (HugeException e) {
+            Assert.assertContains("channelizer", e.getMessage());
+        } finally {
+            if (executor != null) {
+                executor.shutdownNow();
+            }
+        }
+    }
 
     @Test
     public void testAllowsStandardGremlinLangEval() {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.auth;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpMethod.POST;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.util.Tokens;
+import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
+import org.apache.tinkerpop.gremlin.util.message.ResponseStatusCode;
+import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.util.ser.GraphSONUntypedMessageSerializerV1;
+import org.junit.Test;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+
+public class GremlinLangRequestGuardTest {
+
+    @Test
+    public void testAllowsStandardGremlinLangEval() {
+        RequestMessage request = eval("gremlin-lang");
+
+        Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsMissingLanguage() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                                               .addArg(Tokens.ARGS_GREMLIN,
+                                                       "g.V().count()")
+                                               .create();
+
+        Assert.assertContains("gremlin-lang",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsGroovy() {
+        RequestMessage request = eval("gremlin-groovy");
+
+        Assert.assertContains("gremlin-groovy",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsGroovyFromHttpRequest() {
+        RequestMessage request = RequestMessage.build("")
+                                               .addArg(Tokens.ARGS_GREMLIN,
+                                                       "g.V().count()")
+                                               .addArg(Tokens.ARGS_LANGUAGE,
+                                                       "gremlin-groovy")
+                                               .create();
+
+        Assert.assertContains("gremlin-groovy",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsSessionProcessor() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                                               .processor("session")
+                                               .addArg(Tokens.ARGS_GREMLIN,
+                                                       "g.V().count()")
+                                               .addArg(Tokens.ARGS_LANGUAGE,
+                                                       "gremlin-lang")
+                                               .create();
+
+        Assert.assertContains("session",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsBytecode() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_BYTECODE)
+                                               .create();
+
+        Assert.assertContains("bytecode",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testAllowsCypherProcessor() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                                               .processor("cypher")
+                                               .addArg(Tokens.ARGS_GREMLIN,
+                                                       "MATCH (n) RETURN n")
+                                               .create();
+
+        Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsBytecodeWithCypherProcessor() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_BYTECODE)
+                                               .processor("cypher")
+                                               .create();
+
+        Assert.assertContains("bytecode",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testWebSocketHandlerRejectsGroovyBeforeOpSelector() {
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new GremlinLangRequestHandler());
+
+        Assert.assertFalse(channel.writeInbound(eval("gremlin-groovy")));
+        ResponseMessage response = channel.readOutbound();
+        Assert.assertEquals(ResponseStatusCode.REQUEST_ERROR_INVALID_REQUEST_ARGUMENTS,
+                            response.getStatus().getCode());
+        Assert.assertContains("gremlin-groovy",
+                              response.getStatus().getMessage());
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testWebSocketHandlerForwardsGremlinLang() {
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new GremlinLangRequestHandler());
+        RequestMessage request = eval("gremlin-lang");
+
+        Assert.assertTrue(channel.writeInbound(request));
+        Assert.assertSame(request, channel.readInbound());
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testHttpHandlerRejectsGroovyBeforeEvaluation() {
+        String json = "{\"gremlin\":\"g.V().count()\"," +
+                      "\"language\":\"gremlin-groovy\"}";
+
+        assertHttpBadRequest(json, "gremlin-groovy");
+    }
+
+    @Test
+    public void testHttpHandlerRejectsMissingLanguageBeforeEvaluation() {
+        assertHttpBadRequest("{\"gremlin\":\"g.V().count()\"}",
+                             "gremlin-lang");
+    }
+
+    @Test
+    public void testHttpHandlerKeepsMalformedRequestResponse() {
+        assertHttpBadRequest("{\"gremlin\"", "body could not be parsed");
+    }
+
+    private static void assertHttpBadRequest(String json,
+                                             String expectedMessage) {
+        GremlinLangHttpHandler handler = new GremlinLangHttpHandler(
+                Collections.singletonMap(
+                        "application/json",
+                        new GraphSONUntypedMessageSerializerV1()),
+                null, null, new Settings());
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+                HTTP_1_1, POST, "/gremlin",
+                Unpooled.copiedBuffer(json, StandardCharsets.UTF_8));
+        request.headers().set(CONTENT_TYPE, "application/json");
+
+        Assert.assertFalse(channel.writeInbound(request));
+        FullHttpResponse response = channel.readOutbound();
+        Assert.assertEquals(BAD_REQUEST, response.status());
+        Assert.assertContains(expectedMessage,
+                              response.content().toString(StandardCharsets.UTF_8));
+        response.release();
+        channel.finishAndReleaseAll();
+    }
+
+    private static RequestMessage eval(String language) {
+        return RequestMessage.build(Tokens.OPS_EVAL)
+                             .addArg(Tokens.ARGS_GREMLIN, "g.V().count()")
+                             .addArg(Tokens.ARGS_LANGUAGE, language)
+                             .create();
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
@@ -37,9 +37,12 @@ import java.util.function.Function;
 import javax.script.Bindings;
 
 import org.apache.hugegraph.HugeException;
+import org.apache.hugegraph.security.GremlinLangRestrictionStrategy;
+import org.apache.hugegraph.security.GremlinLangVerificationStrategy;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.LazyBarrierStrategy;
 import org.apache.tinkerpop.gremlin.server.GraphManager;
 import org.apache.tinkerpop.gremlin.server.GremlinServer;
 import org.apache.tinkerpop.gremlin.server.Settings;
@@ -253,12 +256,50 @@ public class GremlinLangRequestGuardTest {
     }
 
     @Test
-    public void testRejectsBytecodeThatRemovesTraversalStrategies() {
+    public void testAllowsBytecodeThatRemovesQueryStrategy() {
         Bytecode bytecode = new Bytecode();
-        bytecode.addSource("withoutStrategies", Object.class);
+        bytecode.addSource("withoutStrategies", LazyBarrierStrategy.class);
         RequestMessage request = bytecode("traversal", bytecode);
 
-        Assert.assertContains("withoutStrategies",
+        Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testAllowsSessionBytecodeThatRemovesQueryStrategy() {
+        Bytecode bytecode = new Bytecode();
+        bytecode.addSource("withoutStrategies", LazyBarrierStrategy.class);
+        RequestMessage request = RequestMessage.from(
+                bytecode("session", bytecode))
+                                               .addArg(Tokens.ARGS_SESSION,
+                                                       "session-id")
+                                               .create();
+
+        Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsBytecodeThatRemovesRestrictionStrategy() {
+        Bytecode bytecode = new Bytecode();
+        bytecode.addSource("withoutStrategies",
+                           GremlinLangRestrictionStrategy.class);
+        RequestMessage request = bytecode("traversal", bytecode);
+
+        Assert.assertContains("GremlinLangRestrictionStrategy",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsSessionBytecodeThatRemovesVerificationStrategy() {
+        Bytecode bytecode = new Bytecode();
+        bytecode.addSource("withoutStrategies",
+                           GremlinLangVerificationStrategy.class);
+        RequestMessage request = RequestMessage.from(
+                bytecode("session", bytecode))
+                                               .addArg(Tokens.ARGS_SESSION,
+                                                       "session-id")
+                                               .create();
+
+        Assert.assertContains("GremlinLangVerificationStrategy",
                               GremlinLangRequestGuard.rejection(request));
     }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.hugegraph.auth;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
@@ -24,19 +25,34 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import javax.script.Bindings;
 
 import org.apache.hugegraph.HugeException;
 import org.apache.hugegraph.testutil.Assert;
+import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.server.GraphManager;
 import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.util.MessageSerializer;
 import org.apache.tinkerpop.gremlin.util.Tokens;
+import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.apache.tinkerpop.gremlin.util.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.util.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.util.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
 import org.apache.tinkerpop.gremlin.util.ser.GraphSONUntypedMessageSerializerV1;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -68,6 +84,20 @@ public class GremlinLangRequestGuardTest {
     }
 
     @Test
+    public void testServerCleanupWaitsForAsyncStopCompletion() {
+        CompletableFuture<Void> stop = new CompletableFuture<>();
+        AtomicBoolean cleaned = new AtomicBoolean(false);
+
+        CompletableFuture<Void> result = ContextGremlinServer.afterStop(
+                stop, () -> cleaned.set(true));
+
+        Assert.assertFalse(cleaned.get());
+        stop.complete(null);
+        result.join();
+        Assert.assertTrue(cleaned.get());
+    }
+
+    @Test
     public void testAllowsStandardGremlinLangEval() {
         RequestMessage request = eval("gremlin-lang");
 
@@ -75,13 +105,53 @@ public class GremlinLangRequestGuardTest {
     }
 
     @Test
-    public void testRejectsMissingLanguage() {
+    public void testDefaultsMissingLanguageToGremlinLang() {
         RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
                                                .addArg(Tokens.ARGS_GREMLIN,
                                                        "g.V().count()")
                                                .create();
 
-        Assert.assertContains("gremlin-lang",
+        Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+        RequestMessage normalized = GremlinLangRequestGuard.normalize(request);
+        Assert.assertEquals("hugegraph-gremlin-lang",
+                            normalized.getArg(Tokens.ARGS_LANGUAGE));
+        Assert.assertEquals(request.getRequestId(), normalized.getRequestId());
+    }
+
+    @Test
+    public void testRejectsExplicitNullLanguage() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                                               .addArg(Tokens.ARGS_GREMLIN,
+                                                       "g.V().count()")
+                                               .addArg(Tokens.ARGS_LANGUAGE,
+                                                       null)
+                                               .create();
+
+        Assert.assertContains("string",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsNonStringLanguage() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                                               .addArg(Tokens.ARGS_GREMLIN,
+                                                       "g.V().count()")
+                                               .addArg(Tokens.ARGS_LANGUAGE,
+                                                       1)
+                                               .create();
+
+        Assert.assertContains("string",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsNonStringEvalPayload() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                                               .addArg(Tokens.ARGS_GREMLIN,
+                                                       new Bytecode())
+                                               .create();
+
+        Assert.assertContains("string",
                               GremlinLangRequestGuard.rejection(request));
     }
 
@@ -107,25 +177,87 @@ public class GremlinLangRequestGuardTest {
     }
 
     @Test
-    public void testRejectsSessionProcessor() {
+    public void testAllowsSessionEval() {
         RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
                                                .processor("session")
                                                .addArg(Tokens.ARGS_GREMLIN,
                                                        "g.V().count()")
-                                               .addArg(Tokens.ARGS_LANGUAGE,
-                                                       "gremlin-lang")
+                                               .addArg(Tokens.ARGS_SESSION,
+                                                       "session-id")
                                                .create();
 
-        Assert.assertContains("session",
+        Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+        RequestMessage normalized = GremlinLangRequestGuard.normalize(request);
+        Assert.assertEquals("hugegraph-gremlin-lang",
+                            normalized.getArg(Tokens.ARGS_LANGUAGE));
+    }
+
+    @Test
+    public void testAllowsTraversalBytecodeWithoutLambda() {
+        RequestMessage request = bytecode("traversal", new Bytecode());
+
+        Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+        Assert.assertSame(request,
+                          GremlinLangRequestGuard.normalize(request));
+    }
+
+    @Test
+    public void testAllowsSessionBytecodeWithoutLambda() {
+        RequestMessage request = RequestMessage.from(
+                bytecode("session", new Bytecode()))
+                                               .addArg(Tokens.ARGS_SESSION,
+                                                       "session-id")
+                                               .create();
+
+        Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsBytecodeWithLambda() {
+        Bytecode bytecode = new Bytecode();
+        bytecode.addStep("filter", Lambda.predicate("true"));
+        RequestMessage request = bytecode("traversal", bytecode);
+
+        Assert.assertContains("Lambda",
                               GremlinLangRequestGuard.rejection(request));
     }
 
     @Test
-    public void testRejectsBytecode() {
-        RequestMessage request = RequestMessage.build(Tokens.OPS_BYTECODE)
+    public void testRejectsBytecodeThatRemovesTraversalStrategies() {
+        Bytecode bytecode = new Bytecode();
+        bytecode.addSource("withoutStrategies", Object.class);
+        RequestMessage request = bytecode("traversal", bytecode);
+
+        Assert.assertContains("withoutStrategies",
+                              GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testAllowsLegacySessionClose() {
+        RequestMessage request = RequestMessage.build(Tokens.OPS_CLOSE)
+                                               .processor("session")
+                                               .addArg(Tokens.ARGS_SESSION,
+                                                       "session-id")
                                                .create();
 
-        Assert.assertContains("bytecode",
+        Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testAllowsAuthenticationOperation() {
+        RequestMessage request = RequestMessage.build(
+                Tokens.OPS_AUTHENTICATION).create();
+
+        Assert.assertNull(GremlinLangRequestGuard.rejection(request));
+    }
+
+    @Test
+    public void testRejectsUnknownProcessorAndOperation() {
+        RequestMessage request = RequestMessage.build("future-operation")
+                                               .processor("future-processor")
+                                               .create();
+
+        Assert.assertContains("future-processor",
                               GremlinLangRequestGuard.rejection(request));
     }
 
@@ -142,12 +274,11 @@ public class GremlinLangRequestGuardTest {
 
     @Test
     public void testRejectsBytecodeWithCypherProcessor() {
-        RequestMessage request = RequestMessage.build(Tokens.OPS_BYTECODE)
-                                               .processor("cypher")
-                                               .create();
+        RequestMessage request = bytecode("cypher", new Bytecode());
 
-        Assert.assertContains("bytecode",
-                              GremlinLangRequestGuard.rejection(request));
+        Assert.assertContains("text eval",
+                              GremlinLangRequestGuard.rejection(request).
+                              toLowerCase());
     }
 
     @Test
@@ -165,13 +296,32 @@ public class GremlinLangRequestGuardTest {
     }
 
     @Test
-    public void testWebSocketHandlerForwardsGremlinLang() {
+    public void testWebSocketHandlerNormalizesGremlinLang() {
         EmbeddedChannel channel = new EmbeddedChannel(
                 new GremlinLangRequestHandler());
         RequestMessage request = eval("gremlin-lang");
 
         Assert.assertTrue(channel.writeInbound(request));
-        Assert.assertSame(request, channel.readInbound());
+        RequestMessage normalized = channel.readInbound();
+        Assert.assertEquals("hugegraph-gremlin-lang",
+                            normalized.getArg(Tokens.ARGS_LANGUAGE));
+        Assert.assertEquals(request.getRequestId(), normalized.getRequestId());
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testWebSocketHandlerDefaultsMissingLanguage() {
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new GremlinLangRequestHandler());
+        RequestMessage request = RequestMessage.build(Tokens.OPS_EVAL)
+                                               .addArg(Tokens.ARGS_GREMLIN,
+                                                       "g.V().count()")
+                                               .create();
+
+        Assert.assertTrue(channel.writeInbound(request));
+        RequestMessage normalized = channel.readInbound();
+        Assert.assertEquals("hugegraph-gremlin-lang",
+                            normalized.getArg(Tokens.ARGS_LANGUAGE));
         channel.finishAndReleaseAll();
     }
 
@@ -184,9 +334,163 @@ public class GremlinLangRequestGuardTest {
     }
 
     @Test
-    public void testHttpHandlerRejectsMissingLanguageBeforeEvaluation() {
-        assertHttpBadRequest("{\"gremlin\":\"g.V().count()\"}",
-                             "gremlin-lang");
+    public void testHttpHandlerRejectsExplicitNullLanguageBeforeEvaluation() {
+        assertHttpBadRequest("{\"gremlin\":\"g.V().count()\"," +
+                             "\"language\":null}", "gremlin-lang");
+    }
+
+    @Test
+    public void testHttpHandlerDefaultsMissingLanguageToGremlinLang() {
+        GremlinExecutor gremlinExecutor = Mockito.mock(
+                GremlinExecutor.class);
+        GraphManager graphManager = Mockito.mock(GraphManager.class);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CompletableFuture<Object> pending = new CompletableFuture<>();
+        Mockito.when(gremlinExecutor.getExecutorService())
+               .thenReturn(executor);
+        Mockito.when(gremlinExecutor.eval(
+                       Mockito.eq("g.V().count()"), Mockito.anyString(),
+                       Mockito.any(Bindings.class), Mockito.isNull(),
+                       Mockito.<Function<Object, Object>>any()))
+               .thenReturn(pending);
+
+        GremlinLangHttpHandler handler = new GremlinLangHttpHandler(
+                Collections.singletonMap(
+                        "application/json",
+                        new GraphSONUntypedMessageSerializerV1()),
+                gremlinExecutor, graphManager, new Settings());
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+                HTTP_1_1, POST, "/gremlin",
+                Unpooled.copiedBuffer("{\"gremlin\":\"g.V().count()\"}",
+                                      StandardCharsets.UTF_8));
+        request.headers().set(CONTENT_TYPE, "application/json");
+
+        try {
+            Assert.assertFalse(channel.writeInbound(request));
+            Mockito.verify(gremlinExecutor).eval(
+                    Mockito.eq("g.V().count()"),
+                    Mockito.eq(GremlinLangRequestGuard.GREMLIN_LANG),
+                    Mockito.any(Bindings.class), Mockito.isNull(),
+                    Mockito.<Function<Object, Object>>any());
+        } finally {
+            pending.cancel(true);
+            executor.shutdownNow();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    public void testHttpHandlerDefaultsSerializedTextToGremlinLang()
+            throws Exception {
+        GraphBinaryMessageSerializerV1 graphBinary =
+                new GraphBinaryMessageSerializerV1();
+        String mimeType = graphBinary.mimeTypesSupported()[0];
+        Map<String, MessageSerializer<?>> serializers = Map.of(
+                        mimeType, graphBinary,
+                        "application/json",
+                        new GraphSONUntypedMessageSerializerV1());
+        GremlinExecutor gremlinExecutor = Mockito.mock(
+                GremlinExecutor.class);
+        GraphManager graphManager = Mockito.mock(GraphManager.class);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CompletableFuture<Object> pending = new CompletableFuture<>();
+        Mockito.when(gremlinExecutor.getExecutorService())
+               .thenReturn(executor);
+        Mockito.when(gremlinExecutor.eval(
+                       Mockito.eq("g.V().count()"), Mockito.anyString(),
+                       Mockito.any(Bindings.class), Mockito.isNull(),
+                       Mockito.<Function<Object, Object>>any()))
+               .thenReturn(pending);
+
+        GremlinLangHttpHandler handler = new GremlinLangHttpHandler(
+                serializers, gremlinExecutor, graphManager, new Settings());
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+        RequestMessage gremlinRequest = RequestMessage.build(Tokens.OPS_EVAL)
+                                                      .addArg(
+                                                              Tokens.ARGS_GREMLIN,
+                                                              "g.V().count()")
+                                                      .create();
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+                HTTP_1_1, POST, "/gremlin",
+                graphBinary.serializeRequestAsBinary(
+                        gremlinRequest, UnpooledByteBufAllocator.DEFAULT));
+        request.headers().set(CONTENT_TYPE, mimeType);
+        request.headers().set(ACCEPT, "application/json");
+
+        try {
+            Assert.assertFalse(channel.writeInbound(request));
+            Mockito.verify(gremlinExecutor).eval(
+                    Mockito.eq("g.V().count()"),
+                    Mockito.eq("hugegraph-gremlin-lang"),
+                    Mockito.any(Bindings.class), Mockito.isNull(),
+                    Mockito.<Function<Object, Object>>any());
+        } finally {
+            pending.cancel(true);
+            executor.shutdownNow();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    public void testHttpHandlerRejectsSerializedBytecode() throws Exception {
+        GraphBinaryMessageSerializerV1 serializer =
+                new GraphBinaryMessageSerializerV1();
+        String mimeType = serializer.mimeTypesSupported()[0];
+        RequestMessage gremlinRequest = bytecode("traversal",
+                                                 new Bytecode());
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+                HTTP_1_1, POST, "/gremlin",
+                serializer.serializeRequestAsBinary(
+                        gremlinRequest, UnpooledByteBufAllocator.DEFAULT));
+        request.headers().set(CONTENT_TYPE, mimeType);
+        GremlinLangHttpHandler handler = new GremlinLangHttpHandler(
+                Collections.singletonMap(mimeType, serializer),
+                null, null, new Settings());
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+        Assert.assertFalse(channel.writeInbound(request));
+        FullHttpResponse response = channel.readOutbound();
+        Assert.assertEquals(BAD_REQUEST, response.status());
+        Assert.assertContains(
+                "standard WebSocket traversal",
+                response.content().toString(StandardCharsets.UTF_8));
+        response.release();
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testHttpHandlerRejectsSerializedNonStringLanguage()
+            throws Exception {
+        GraphBinaryMessageSerializerV1 serializer =
+                new GraphBinaryMessageSerializerV1();
+        String mimeType = serializer.mimeTypesSupported()[0];
+        RequestMessage gremlinRequest = RequestMessage.build(Tokens.OPS_EVAL)
+                                                      .addArg(
+                                                              Tokens.ARGS_GREMLIN,
+                                                              "g.V()")
+                                                      .addArg(
+                                                              Tokens.ARGS_LANGUAGE,
+                                                              1)
+                                                      .create();
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+                HTTP_1_1, POST, "/gremlin",
+                serializer.serializeRequestAsBinary(
+                        gremlinRequest, UnpooledByteBufAllocator.DEFAULT));
+        request.headers().set(CONTENT_TYPE, mimeType);
+        GremlinLangHttpHandler handler = new GremlinLangHttpHandler(
+                Collections.singletonMap(mimeType, serializer),
+                null, null, new Settings());
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+        Assert.assertFalse(channel.writeInbound(request));
+        FullHttpResponse response = channel.readOutbound();
+        Assert.assertEquals(BAD_REQUEST, response.status());
+        Assert.assertContains(
+                "must be a string",
+                response.content().toString(StandardCharsets.UTF_8));
+        response.release();
+        channel.finishAndReleaseAll();
     }
 
     @Test
@@ -220,6 +524,16 @@ public class GremlinLangRequestGuardTest {
         return RequestMessage.build(Tokens.OPS_EVAL)
                              .addArg(Tokens.ARGS_GREMLIN, "g.V().count()")
                              .addArg(Tokens.ARGS_LANGUAGE, language)
+                             .create();
+    }
+
+    private static RequestMessage bytecode(String processor,
+                                           Bytecode bytecode) {
+        return RequestMessage.build(Tokens.OPS_BYTECODE)
+                             .processor(processor)
+                             .addArg(Tokens.ARGS_GREMLIN, bytecode)
+                             .addArg(Tokens.ARGS_ALIASES,
+                                     Map.of("g", "__g_hugegraph"))
                              .create();
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/auth/GremlinLangRequestGuardTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.hugegraph.auth;
 
+import static com.codahale.metrics.MetricRegistry.name;
 import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.netty.handler.codec.http.HttpMethod.POST;
@@ -26,6 +27,7 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -39,7 +41,9 @@ import org.apache.hugegraph.testutil.Assert;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.server.GraphManager;
+import org.apache.tinkerpop.gremlin.server.GremlinServer;
 import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.server.util.MetricManager;
 import org.apache.tinkerpop.gremlin.util.MessageSerializer;
 import org.apache.tinkerpop.gremlin.util.Tokens;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
@@ -50,6 +54,8 @@ import org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1;
 import org.apache.tinkerpop.gremlin.util.ser.GraphSONUntypedMessageSerializerV1;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import com.codahale.metrics.Meter;
 
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -391,7 +397,73 @@ public class GremlinLangRequestGuardTest {
     @Test
     public void testHttpHandlerRejectsExplicitNullLanguageBeforeEvaluation() {
         assertHttpBadRequest("{\"gremlin\":\"g.V().count()\"," +
-                             "\"language\":null}", "gremlin-lang");
+                             "\"language\":null}",
+                             "language argument must be a string");
+    }
+
+    @Test
+    public void testHttpHandlerRejectsNonStringGremlinBeforeCoercion() {
+        String[] values = {"1", "true", "{}", "[]", "null"};
+
+        for (String value : values) {
+            assertHttpBadRequest("{\"gremlin\":" + value + "}",
+                                 "gremlin argument for a text eval request " +
+                                 "must be a string");
+        }
+    }
+
+    @Test
+    public void testHttpHandlerRejectsNonStringLanguageBeforeCoercion() {
+        String[] values = {"1", "true", "{}", "[]", "null"};
+
+        for (String value : values) {
+            assertHttpBadRequest("{\"gremlin\":\"g.V()\"," +
+                                 "\"language\":" + value + "}",
+                                 "language argument must be a string");
+        }
+    }
+
+    @Test
+    public void testHttpHandlerValidatesJsonContentTypeWithCharset() {
+        assertHttpBadRequest("{\"gremlin\":\"g.V()\",\"language\":1}",
+                             "application/json; charset=UTF-8",
+                             "language argument must be a string");
+    }
+
+    @Test
+    public void testHttpHandlerRejectionKeepsRequestId() {
+        UUID requestId = UUID.randomUUID();
+        String response = assertHttpBadRequest(
+                "{\"requestId\":\"" + requestId + "\"," +
+                "\"gremlin\":\"g.V()\",\"language\":1}",
+                "language argument must be a string");
+
+        Assert.assertContains(requestId.toString(), response);
+    }
+
+    @Test
+    public void testHttpHandlerParsedRejectionKeepsRequestId() {
+        UUID requestId = UUID.randomUUID();
+        String response = assertHttpBadRequest(
+                "{\"requestId\":\"" + requestId + "\"," +
+                "\"gremlin\":\"g.V()\"," +
+                "\"language\":\"gremlin-groovy\"}",
+                "gremlin-groovy");
+
+        Assert.assertContains(requestId.toString(), response);
+    }
+
+    @Test
+    public void testHttpHandlerRejectionMarksErrorMetric() {
+        Meter errorMeter = MetricManager.INSTANCE.getMeter(
+                name(GremlinServer.class, "errors"));
+        long count = errorMeter.getCount();
+
+        assertHttpBadRequest("{\"gremlin\":\"g.V()\"," +
+                             "\"language\":\"gremlin-groovy\"}",
+                             "gremlin-groovy");
+
+        Assert.assertEquals(count + 1L, errorMeter.getCount());
     }
 
     @Test
@@ -553,8 +625,15 @@ public class GremlinLangRequestGuardTest {
         assertHttpBadRequest("{\"gremlin\"", "body could not be parsed");
     }
 
-    private static void assertHttpBadRequest(String json,
-                                             String expectedMessage) {
+    private static String assertHttpBadRequest(String json,
+                                               String expectedMessage) {
+        return assertHttpBadRequest(json, "application/json",
+                                    expectedMessage);
+    }
+
+    private static String assertHttpBadRequest(String json,
+                                               String contentType,
+                                               String expectedMessage) {
         GremlinLangHttpHandler handler = new GremlinLangHttpHandler(
                 Collections.singletonMap(
                         "application/json",
@@ -564,15 +643,17 @@ public class GremlinLangRequestGuardTest {
         DefaultFullHttpRequest request = new DefaultFullHttpRequest(
                 HTTP_1_1, POST, "/gremlin",
                 Unpooled.copiedBuffer(json, StandardCharsets.UTF_8));
-        request.headers().set(CONTENT_TYPE, "application/json");
+        request.headers().set(CONTENT_TYPE, contentType);
 
         Assert.assertFalse(channel.writeInbound(request));
         FullHttpResponse response = channel.readOutbound();
         Assert.assertEquals(BAD_REQUEST, response.status());
-        Assert.assertContains(expectedMessage,
-                              response.content().toString(StandardCharsets.UTF_8));
+        String responseBody = response.content().toString(
+                StandardCharsets.UTF_8);
+        Assert.assertContains(expectedMessage, responseBody);
         response.release();
         channel.finishAndReleaseAll();
+        return responseBody;
     }
 
     private static RequestMessage eval(String language) {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CoreTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CoreTestSuite.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
         VertexCoreTest.class,
         EdgeCoreTest.class,
         CountStrategyCoreTest.class,
+        GremlinLangTextContainsCoreTest.class,
         TinkerPop37StepsCoreTest.class,
         ParentAndSubEdgeCoreTest.class,
         PropertyCoreTest.VertexPropertyCoreTest.class,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/GremlinLangTextContainsCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/GremlinLangTextContainsCoreTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.core;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
+
+import org.apache.hugegraph.schema.SchemaManager;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngine;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.tinkerpop.gremlin.jsr223.Customizer;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin;
+import org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.junit.Test;
+
+public class GremlinLangTextContainsCoreTest extends BaseCoreTest {
+
+    @Test
+    public void testTextContainsUsesHugeGraphSearchIndexSemantics()
+            throws Exception {
+        SchemaManager schema = graph().schema();
+        schema.propertyKey("name").asText().create();
+        schema.propertyKey("description").asText().create();
+        schema.vertexLabel("dog")
+              .properties("name", "description")
+              .primaryKeys("name")
+              .create();
+        schema.indexLabel("dogByDescription").onV("dog")
+              .search().by("description").create();
+
+        graph().addVertex(T.label, "dog", "name", "Bella",
+                          "description", "black hair and eyes");
+        graph().addVertex(T.label, "dog", "name", "Daisy",
+                          "description", "yellow hair yellow tail");
+        graph().addVertex(T.label, "dog", "name", "Coco",
+                          "description", "yellow hair golden tail");
+        this.commitTx();
+
+        try (GraphTraversalSource g = graph().traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = engine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+            try {
+                bindings.put("keyword", "yellow hair");
+                Assert.assertEquals(3L, engine.eval(
+                        "g.V().has('description', " +
+                        "Text.contains(keyword)).count().next()",
+                        bindings));
+
+                bindings.put("keyword", "black golden");
+                Assert.assertEquals(2L, engine.eval(
+                        "g.V().has('description', " +
+                        "Text.contains(keyword)).count().next()",
+                        bindings));
+
+                bindings.put("keyword", "(hair)");
+                Assert.assertEquals(3L, engine.eval(
+                        "g.V().has('description', " +
+                        "Text.contains(keyword)).count().next()",
+                        bindings));
+
+                bindings.put("keyword", "(black|golden)");
+                Assert.assertEquals(2L, engine.eval(
+                        "g.V().has('description', " +
+                        "Text.contains(keyword)).count().next()",
+                        bindings));
+            } finally {
+                engine.clear();
+            }
+        }
+    }
+
+    private static HugeGraphGremlinLangScriptEngine engine(
+            GraphTraversalSource g) {
+        List<Customizer> customizers = new ArrayList<>();
+        GremlinLangPlugin cache = GremlinLangPlugin.build()
+                                                   .cacheEnabled(true)
+                                                   .caffeine(
+                                                           "maximumSize=16")
+                                                   .create();
+        VariableResolverPlugin variables =
+                VariableResolverPlugin.build()
+                                      .resolver("DefaultVariableResolver")
+                                      .create();
+        customizers.addAll(Arrays.asList(
+                cache.getCustomizers("gremlin-lang").get()));
+        customizers.addAll(Arrays.asList(
+                variables.getCustomizers("gremlin-lang").get()));
+        HugeGraphGremlinLangScriptEngineFactory factory =
+                new HugeGraphGremlinLangScriptEngineFactory(
+                        customizers.toArray(new Customizer[0]));
+        HugeGraphGremlinLangScriptEngine engine = factory.getScriptEngine();
+        engine.add(g);
+        return engine;
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -20,6 +20,7 @@ package org.apache.hugegraph.unit;
 import org.apache.hugegraph.api.auth.GraphSpaceAuthPayloadTest;
 import org.apache.hugegraph.api.auth.GraphSpaceGroupAPITest;
 import org.apache.hugegraph.api.cypher.CypherClientTest;
+import org.apache.hugegraph.auth.GremlinLangRequestGuardTest;
 import org.apache.hugegraph.auth.StandardAuthManagerV2Test;
 import org.apache.hugegraph.auth.WsAndHttpBasicAuthHandlerTest;
 import org.apache.hugegraph.core.RoleElectionStateMachineTest;
@@ -85,6 +86,7 @@ import org.apache.hugegraph.unit.serializer.StoreSerializerTest;
 import org.apache.hugegraph.unit.serializer.TableBackendEntryTest;
 import org.apache.hugegraph.unit.serializer.TextBackendEntryTest;
 import org.apache.hugegraph.unit.serializer.TextSerializerTest;
+import org.apache.hugegraph.unit.security.HugeGraphGremlinLangScriptEngineTest;
 import org.apache.hugegraph.unit.store.RamIntObjectMapTest;
 import org.apache.hugegraph.unit.util.CompressUtilTest;
 import org.apache.hugegraph.unit.util.JsonUtilTest;
@@ -110,6 +112,7 @@ import org.junit.runners.Suite;
         /* api gremlin */
         GremlinQueryAPITest.class,
         CypherClientTest.class,
+        GremlinLangRequestGuardTest.class,
         WsAndHttpBasicAuthHandlerTest.class,
         GraphSpaceGroupAPITest.class,
         GraphSpaceAuthPayloadTest.class,
@@ -187,6 +190,10 @@ import org.junit.runners.Suite;
 
         /* config */
         GremlinConfigCompatibilityTest.class,
+
+        /* security */
+        HugeGraphGremlinLangScriptEngineTest.class,
+
         /* rocksdb */
         RocksDBSessionsTest.class,
         RocksDBSessionTest.class,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/config/GremlinConfigCompatibilityTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/config/GremlinConfigCompatibilityTest.java
@@ -99,6 +99,14 @@ public class GremlinConfigCompatibilityTest extends BaseUnitTest {
     private static final String IO_REGISTRY =
             "org.apache.hugegraph.io.HugeGraphIoRegistry";
     private static final String GREMLIN_SERVER_CONFIG = "gremlin-server.yaml";
+    private static final String HUGEGRAPH_CHANNELIZER =
+            "org.apache.hugegraph.auth.HugeGraphWsAndHttpChannelizer";
+    private static final String GREMLIN_LANG_PLUGIN =
+            "org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin";
+    private static final String VARIABLE_RESOLVER_PLUGIN =
+            "org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin";
+    private static final String HUGEGRAPH_GREMLIN_LANG =
+            "hugegraph-gremlin-lang";
     private static final String REMOTE_OBJECTS_CONFIG = "remote-objects.yaml";
     private static final List<String> GREMLIN_SERVER_CONFIG_VARIANTS =
             Arrays.asList(
@@ -213,6 +221,37 @@ public class GremlinConfigCompatibilityTest extends BaseUnitTest {
             }
             Assert.assertTrue("No GraphBinary serializer in " + variant,
                               found);
+        }
+    }
+
+    @Test
+    public void testGremlinServerConfigVariantsEnableGuardedGremlinLang()
+            throws Exception {
+        Path assembly = serverAssemblyPath();
+
+        for (String variant : GREMLIN_SERVER_CONFIG_VARIANTS) {
+            Settings settings = Settings.read(assembly.resolve(variant)
+                                                   .toString());
+            Assert.assertEquals(variant, HUGEGRAPH_CHANNELIZER,
+                                settings.channelizer);
+            Assert.assertTrue(variant,
+                              settings.scriptEngines.containsKey(
+                                      "gremlin-groovy"));
+            Settings.ScriptEngineSettings gremlinLang =
+                    settings.scriptEngines.get(HUGEGRAPH_GREMLIN_LANG);
+            Assert.assertNotNull(variant, gremlinLang);
+
+            Map<String, Object> cache = gremlinLang.plugins.get(
+                    GREMLIN_LANG_PLUGIN);
+            Assert.assertEquals(variant, true, cache.get("cacheEnabled"));
+            Assert.assertEquals(variant,
+                                "maximumSize=1024,expireAfterAccess=10m",
+                                cache.get("caffeine"));
+
+            Map<String, Object> variables = gremlinLang.plugins.get(
+                    VARIABLE_RESOLVER_PLUGIN);
+            Assert.assertEquals(variant, "DefaultVariableResolver",
+                                variables.get("resolver"));
         }
     }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/config/GremlinConfigCompatibilityTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/config/GremlinConfigCompatibilityTest.java
@@ -243,10 +243,8 @@ public class GremlinConfigCompatibilityTest extends BaseUnitTest {
 
             Map<String, Object> cache = gremlinLang.plugins.get(
                     GREMLIN_LANG_PLUGIN);
-            Assert.assertEquals(variant, true, cache.get("cacheEnabled"));
-            Assert.assertEquals(variant,
-                                "maximumSize=1024,expireAfterAccess=10m",
-                                cache.get("caffeine"));
+            Assert.assertEquals(variant, false, cache.get("cacheEnabled"));
+            Assert.assertFalse(variant, cache.containsKey("caffeine"));
 
             Map<String, Object> variables = gremlinLang.plugins.get(
                     VARIABLE_RESOLVER_PLUGIN);

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
@@ -29,7 +29,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import javax.script.Bindings;
+import javax.script.ScriptContext;
 import javax.script.SimpleBindings;
+import javax.script.SimpleScriptContext;
 
 import org.apache.hugegraph.HugeFactory;
 import org.apache.hugegraph.HugeGraph;
@@ -91,7 +93,7 @@ public class HugeGraphGremlinLangScriptEngineTest {
     }
 
     @Test
-    public void testCacheHitUsesCurrentBindingValues() throws Exception {
+    public void testRepeatedEvalUsesCurrentBindingValues() throws Exception {
         TinkerGraph graph = TinkerGraph.open();
         graph.addVertex(T.label, "person", "name", "marko");
         graph.addVertex(T.label, "person", "name", "stephen");
@@ -142,7 +144,7 @@ public class HugeGraphGremlinLangScriptEngineTest {
     }
 
     @Test
-    public void testTextContainsCacheHitUsesCurrentBinding()
+    public void testRepeatedTextContainsUsesCurrentBinding()
             throws Exception {
         try (TinkerGraph graph = TinkerGraph.open();
              GraphTraversalSource g = graph.traversal()) {
@@ -153,16 +155,46 @@ public class HugeGraphGremlinLangScriptEngineTest {
             bindings.put("g", g);
 
             bindings.put("keyword", "ark");
-            Assert.assertEquals("marko", engine.eval(
+            Traversal<?, ?> first = (Traversal<?, ?>) engine.eval(
                     "g.V().has('name', Text.contains(keyword))" +
-                    ".values('name').next()",
-                    bindings));
+                    ".values('name')",
+                    bindings);
+            Assert.assertEquals("marko", first.next());
 
             bindings.put("keyword", "teph");
-            Assert.assertEquals("stephen", engine.eval(
+            Traversal<?, ?> second = (Traversal<?, ?>) engine.eval(
                     "g.V().has('name', Text.contains(keyword))" +
-                    ".values('name').next()",
-                    bindings));
+                    ".values('name')",
+                    bindings);
+            Assert.assertEquals("stephen", second.next());
+        }
+    }
+
+    @Test
+    public void testTextContainsDoesNotReuseDirectResolverValue()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "marko");
+            graph.addVertex("name", "stephen");
+            HugeGraphGremlinLangScriptEngine engine = engine(true, false);
+            engine.add(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            bindings.put("keyword", "ark");
+            Traversal<?, ?> first = (Traversal<?, ?>) engine.eval(
+                    "g.V().has('name', Text.contains(keyword))" +
+                    ".values('name')",
+                    bindings);
+            Assert.assertEquals("marko", first.next());
+
+            bindings.put("keyword", "teph");
+            Traversal<?, ?> second = (Traversal<?, ?>) engine.eval(
+                    "g.V().has('name', Text.contains(keyword))" +
+                    ".values('name')",
+                    bindings);
+            Assert.assertEquals("stephen", second.next());
         }
     }
 
@@ -275,6 +307,38 @@ public class HugeGraphGremlinLangScriptEngineTest {
     }
 
     @Test
+    public void testTextContainsSupportsSupplementaryUnicode()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("tag", "😀", "name", "marko",
+                            "city", "北😀京");
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Traversal<?, ?> beforePredicate = (Traversal<?, ?>) engine.eval(
+                    "g.V().has('tag', '😀').has('name', " +
+                    "Text.contains('ark')).values('name')",
+                    bindings);
+            Assert.assertEquals("marko", beforePredicate.next());
+
+            Traversal<?, ?> insidePredicate = (Traversal<?, ?>) engine.eval(
+                    "g.V().has('city', Text.contains('😀')).values('name')",
+                    bindings);
+            Assert.assertEquals("marko", insidePredicate.next());
+
+            Traversal<?, ?> multiplePredicates =
+                    (Traversal<?, ?>) engine.eval(
+                            "g.V().has('tag', '😀').has('name', " +
+                            "Text.contains('ark')).has('city', " +
+                            "Text.contains('😀京')).values('name')",
+                            bindings);
+            Assert.assertEquals("marko", multiplePredicates.next());
+        }
+    }
+
+    @Test
     public void testTextPContainingKeepsTinkerPopSemantics()
             throws Exception {
         try (TinkerGraph graph = TinkerGraph.open();
@@ -339,6 +403,7 @@ public class HugeGraphGremlinLangScriptEngineTest {
     public void testTextContainsRejectsReservedBindings() throws Exception {
         try (TinkerGraph graph = TinkerGraph.open();
              GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "hugegraphTextContainsInternal0");
             HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
             Bindings bindings = new SimpleBindings();
             bindings.put("g", g);
@@ -347,8 +412,39 @@ public class HugeGraphGremlinLangScriptEngineTest {
             Assert.assertThrows(IllegalArgumentException.class,
                                 () -> engine.eval(
                                         "g.V().has('name', " +
+                                        "hugegraphTextContainsInternal0)",
+                                        bindings),
+                                e -> Assert.assertContains("reserved",
+                                                           e.getMessage()));
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> engine.eval(
+                                        "g.V().has('name', " +
                                         "Text.contains('ark'))",
                                         bindings),
+                                e -> Assert.assertContains("reserved",
+                                                           e.getMessage()));
+
+            Bindings safeBindings = new SimpleBindings();
+            safeBindings.put("g", g);
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> engine.eval(
+                                        "g.V().has('name', " +
+                                        "hugegraphTextContainsInternal0)",
+                                        safeBindings),
+                                e -> Assert.assertContains("reserved",
+                                                           e.getMessage()));
+            Assert.assertTrue(((Traversal<?, ?>) engine.eval(
+                    "g.V().has('name', " +
+                    "'hugegraphTextContainsInternal0')",
+                    safeBindings)).hasNext());
+
+            SimpleScriptContext context = new SimpleScriptContext();
+            context.setBindings(safeBindings, ScriptContext.ENGINE_SCOPE);
+            Bindings globalBindings = new SimpleBindings();
+            globalBindings.put("hugegraphTextContainsInternal0", "ark");
+            context.setBindings(globalBindings, ScriptContext.GLOBAL_SCOPE);
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> engine.eval("g.V().count()", context),
                                 e -> Assert.assertContains("reserved",
                                                            e.getMessage()));
         }
@@ -382,7 +478,7 @@ public class HugeGraphGremlinLangScriptEngineTest {
     }
 
     @Test
-    public void testConcurrentTextContainsCacheHitsKeepBindingsIsolated()
+    public void testConcurrentTextContainsRequestsKeepBindingsIsolated()
             throws Exception {
         try (TinkerGraph graph = TinkerGraph.open();
              GraphTraversalSource g = graph.traversal()) {
@@ -400,14 +496,18 @@ public class HugeGraphGremlinLangScriptEngineTest {
                         Bindings bindings = new SimpleBindings();
                         bindings.put("g", g);
                         bindings.put("keyword", keyword);
-                        return engine.eval(
-                                "g.V().has('name', " +
-                                "Text.contains(keyword)).count().next()",
-                                bindings);
+                        Traversal<?, ?> traversal =
+                                (Traversal<?, ?>) engine.eval(
+                                        "g.V().has('name', " +
+                                        "Text.contains(keyword))" +
+                                        ".values('name')",
+                                        bindings);
+                        return traversal.next();
                     }));
                 }
-                for (Future<Object> result : results) {
-                    Assert.assertEquals(1L, result.get());
+                for (int i = 0; i < requests; i++) {
+                    Assert.assertEquals("value-" + (char) ('a' + i),
+                                        results.get(i).get());
                 }
             } finally {
                 executor.shutdownNow();
@@ -509,7 +609,7 @@ public class HugeGraphGremlinLangScriptEngineTest {
     }
 
     @Test
-    public void testConcurrentCacheHitsKeepBindingValuesIsolated()
+    public void testConcurrentRequestsKeepBindingValuesIsolated()
             throws Exception {
         try (TinkerGraph graph = TinkerGraph.open();
              GraphTraversalSource g = graph.traversal()) {
@@ -539,6 +639,43 @@ public class HugeGraphGremlinLangScriptEngineTest {
             } finally {
                 executor.shutdownNow();
             }
+        }
+    }
+
+    @Test
+    public void testParameterizedTraversalRequestsKeepValuesIsolated()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "warm");
+            graph.addVertex("name", "first");
+            graph.addVertex("name", "second");
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            String script = "g.V().has('name', name).values('name')";
+
+            Bindings warmBindings = new SimpleBindings();
+            warmBindings.put("g", g);
+            warmBindings.put("name", "warm");
+            Traversal<?, ?> warm = (Traversal<?, ?>) engine.eval(
+                    script, warmBindings);
+            Assert.assertEquals("warm", warm.next());
+
+            Bindings firstBindings = new SimpleBindings();
+            firstBindings.put("g", g);
+            firstBindings.put("name", "first");
+            Traversal<?, ?> first = (Traversal<?, ?>) engine.eval(
+                    script, firstBindings);
+
+            Bindings secondBindings = new SimpleBindings();
+            secondBindings.put("g", g);
+            secondBindings.put("name", "second");
+            Traversal<?, ?> second = (Traversal<?, ?>) engine.eval(
+                    script, secondBindings);
+
+            first.asAdmin().applyStrategies();
+            second.asAdmin().applyStrategies();
+            Assert.assertEquals("first", first.next());
+            Assert.assertEquals("second", second.next());
         }
     }
 
@@ -889,6 +1026,11 @@ public class HugeGraphGremlinLangScriptEngineTest {
 
     private static HugeGraphGremlinLangScriptEngine engine(
             boolean cacheEnabled) {
+        return engine(cacheEnabled, true);
+    }
+
+    private static HugeGraphGremlinLangScriptEngine engine(
+            boolean cacheEnabled, boolean defaultVariableResolver) {
         List<Customizer> customizers = new ArrayList<>();
         GremlinLangPlugin cache = cacheEnabled ?
                                   GremlinLangPlugin.build()
@@ -899,14 +1041,17 @@ public class HugeGraphGremlinLangScriptEngineTest {
                                   GremlinLangPlugin.build()
                                                    .cacheEnabled(false)
                                                    .create();
-        VariableResolverPlugin variables =
-                VariableResolverPlugin.build()
-                                      .resolver("DefaultVariableResolver")
-                                      .create();
         customizers.addAll(Arrays.asList(
                 cache.getCustomizers("gremlin-lang").get()));
-        customizers.addAll(Arrays.asList(
-                variables.getCustomizers("gremlin-lang").get()));
+        if (defaultVariableResolver) {
+            VariableResolverPlugin variables =
+                    VariableResolverPlugin.build()
+                                          .resolver(
+                                                  "DefaultVariableResolver")
+                                          .create();
+            customizers.addAll(Arrays.asList(
+                    variables.getCustomizers("gremlin-lang").get()));
+        }
         HugeGraphGremlinLangScriptEngineFactory factory =
                 new HugeGraphGremlinLangScriptEngineFactory(
                         customizers.toArray(new Customizer[0]));

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.unit.security;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
+
+import org.apache.hugegraph.security.GremlinLangTraversalVerifier;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngine;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.tinkerpop.gremlin.jsr223.CachedGremlinScriptEngineManager;
+import org.apache.tinkerpop.gremlin.jsr223.Customizer;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineManager;
+import org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.junit.Test;
+
+public class HugeGraphGremlinLangScriptEngineTest {
+
+    @Test
+    public void testManagerRegistersPublicNameToHugeGraphEngine() {
+        GremlinScriptEngineManager manager =
+                new CachedGremlinScriptEngineManager();
+        manager.addPlugin(GremlinLangPlugin.build()
+                                           .cacheEnabled(true)
+                                           .caffeine("maximumSize=16")
+                                           .create());
+        manager.addPlugin(VariableResolverPlugin.build()
+                                                .resolver(
+                                                        "DefaultVariableResolver")
+                                                .create());
+
+        GremlinScriptEngine internal = manager.getEngineByName(
+                HugeGraphGremlinLangScriptEngineFactory.INTERNAL_ENGINE_NAME);
+        Assert.assertInstanceOf(HugeGraphGremlinLangScriptEngine.class,
+                                internal);
+        manager.registerEngineName(
+                HugeGraphGremlinLangScriptEngineFactory.ENGINE_NAME,
+                internal.getFactory());
+
+        Assert.assertSame(internal, manager.getEngineByName(
+                HugeGraphGremlinLangScriptEngineFactory.ENGINE_NAME));
+    }
+
+    @Test
+    public void testCacheHitUsesCurrentBindingValues() throws Exception {
+        TinkerGraph graph = TinkerGraph.open();
+        graph.addVertex(T.label, "person", "name", "marko");
+        graph.addVertex(T.label, "person", "name", "stephen");
+        GraphTraversalSource g = graph.traversal();
+        HugeGraphGremlinLangScriptEngine engine = engine();
+        Bindings bindings = new SimpleBindings();
+        bindings.put("g", g);
+
+        bindings.put("name", "marko");
+        Traversal<?, ?> first = (Traversal<?, ?>) engine.eval(
+                "g.V().has('name', name).values('name')", bindings);
+        Assert.assertEquals("marko", first.next());
+
+        bindings.put("name", "stephen");
+        Traversal<?, ?> second = (Traversal<?, ?>) engine.eval(
+                "g.V().has('name', name).values('name')", bindings);
+        Assert.assertEquals("stephen", second.next());
+        Assert.assertEquals(1, engine.traversalSourceCount());
+        g.close();
+        graph.close();
+    }
+
+    @Test
+    public void testCacheKeepsTraversalSourcesIsolated() throws Exception {
+        try (TinkerGraph firstGraph = TinkerGraph.open();
+             TinkerGraph secondGraph = TinkerGraph.open();
+             GraphTraversalSource first = firstGraph.traversal();
+             GraphTraversalSource second = secondGraph.traversal()) {
+            firstGraph.addVertex();
+            secondGraph.addVertex();
+            secondGraph.addVertex();
+            HugeGraphGremlinLangScriptEngine engine = engine();
+
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", first);
+            Assert.assertEquals(1L, engine.eval(
+                    "g.V().count().next()", bindings));
+
+            bindings.put("g", second);
+            Assert.assertEquals(2L, engine.eval(
+                    "g.V().count().next()", bindings));
+            Assert.assertEquals(2, engine.traversalSourceCount());
+        }
+    }
+
+    @Test
+    public void testConcurrentCacheHitsKeepBindingValuesIsolated()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            int requests = 32;
+            for (int i = 0; i < requests; i++) {
+                graph.addVertex("name", "person-" + i);
+            }
+
+            HugeGraphGremlinLangScriptEngine engine = engine();
+            ExecutorService executor = Executors.newFixedThreadPool(8);
+            try {
+                List<Future<Object>> results = new ArrayList<>();
+                for (int i = 0; i < requests; i++) {
+                    String name = "person-" + i;
+                    results.add(executor.submit(() -> {
+                        Bindings bindings = new SimpleBindings();
+                        bindings.put("g", g);
+                        bindings.put("name", name);
+                        return engine.eval(
+                                "g.V().has('name', name).count().next()",
+                                bindings);
+                    }));
+                }
+                for (Future<Object> result : results) {
+                    Assert.assertEquals(1L, result.get());
+                }
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    public void testRemoveTraversalSourceDropsItsDelegate() throws Exception {
+        TinkerGraph graph = TinkerGraph.open();
+        GraphTraversalSource g = graph.traversal();
+        HugeGraphGremlinLangScriptEngine engine = engine();
+        Bindings bindings = new SimpleBindings();
+        bindings.put("g", g);
+
+        engine.eval("g.V().count()", bindings);
+        Assert.assertEquals(1, engine.traversalSourceCount());
+
+        engine.remove(g);
+        Assert.assertEquals(0, engine.traversalSourceCount());
+        g.close();
+        graph.close();
+    }
+
+    @Test
+    public void testAllowsSafeTerminalExecution() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = engine();
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Assert.assertEquals(0L,
+                                engine.eval("g.V().count().next()",
+                                            bindings));
+        }
+    }
+
+    @Test
+    public void testVerifierAllowsNormalTraversal() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            GremlinLangTraversalVerifier.verify(g.V().hasLabel("person"));
+        }
+    }
+
+    @Test
+    public void testVerifierRejectsIoStep() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            Assert.assertThrows(SecurityException.class,
+                                () -> GremlinLangTraversalVerifier.verify(
+                                        g.io("graph.json")),
+                                e -> Assert.assertContains("IoStep",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testVerifierRejectsCallStep() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            Assert.assertThrows(SecurityException.class,
+                                () -> GremlinLangTraversalVerifier.verify(
+                                        g.call("service")),
+                                e -> Assert.assertContains("CallStep",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testVerifierRejectsCallStepBeforeTerminalExecution()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = engine();
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Assert.assertThrows(SecurityException.class,
+                                () -> engine.eval(
+                                        "g.call('service').iterate()",
+                                        bindings),
+                                e -> Assert.assertContains("CallStep",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testVerifierRejectsIoStepBeforeTerminalExecution()
+            throws Exception {
+        Path directory = Files.createTempDirectory("hugegraph-gremlin-lang");
+        Path output = directory.resolve("graph.json");
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = engine();
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Assert.assertThrows(SecurityException.class,
+                                () -> engine.eval(
+                                        String.format(
+                                                "g.io('%s').write().iterate()",
+                                                output),
+                                        bindings),
+                                e -> Assert.assertContains("IoStep",
+                                                           e.getMessage()));
+            Assert.assertFalse(Files.exists(output));
+        } finally {
+            Files.deleteIfExists(output);
+            Files.deleteIfExists(directory);
+        }
+    }
+
+    private static HugeGraphGremlinLangScriptEngine engine() {
+        List<Customizer> customizers = new ArrayList<>();
+        GremlinLangPlugin cache = GremlinLangPlugin.build()
+                                                   .cacheEnabled(true)
+                                                   .caffeine("maximumSize=16")
+                                                   .create();
+        VariableResolverPlugin variables = VariableResolverPlugin.build()
+                                                                  .resolver("DefaultVariableResolver")
+                                                                  .create();
+        customizers.addAll(Arrays.asList(
+                cache.getCustomizers("gremlin-lang").get()));
+        customizers.addAll(Arrays.asList(
+                variables.getCustomizers("gremlin-lang").get()));
+        HugeGraphGremlinLangScriptEngineFactory factory =
+                new HugeGraphGremlinLangScriptEngineFactory(
+                        customizers.toArray(new Customizer[0]));
+        return factory.getScriptEngine();
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -41,6 +42,7 @@ import org.apache.hugegraph.auth.RolePermission;
 import org.apache.hugegraph.backend.query.Condition;
 import org.apache.hugegraph.security.GremlinLangRestrictionStrategy;
 import org.apache.hugegraph.security.GremlinLangTraversalVerifier;
+import org.apache.hugegraph.security.GremlinLangVerificationStrategy;
 import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngine;
 import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
 import org.apache.hugegraph.testutil.Assert;
@@ -58,8 +60,13 @@ import org.apache.tinkerpop.gremlin.process.traversal.Compare;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.TextP;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.CallStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
@@ -842,7 +849,8 @@ public class HugeGraphGremlinLangScriptEngineTest {
         try (TinkerGraph graph = TinkerGraph.open();
              GraphTraversalSource g = graph.traversal();
              GraphTraversalSource protectedSource = g.withStrategies(
-                     GremlinLangRestrictionStrategy.instance())) {
+                     GremlinLangRestrictionStrategy.instance(),
+                     GremlinLangVerificationStrategy.instance())) {
             HugeGraphGremlinLangScriptEngine sessionEngine = engine();
             Bindings bindings = new SimpleBindings();
             bindings.put("g", protectedSource);
@@ -943,6 +951,51 @@ public class HugeGraphGremlinLangScriptEngineTest {
                                         g.call("service")),
                                 e -> Assert.assertContains("CallStep",
                                                            e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testVerifierRejectsStepAddedByLaterDecorationStrategy()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = engine();
+            GraphTraversalSource protectedSource = engine.add(g);
+            try (GraphTraversalSource decoratedSource =
+                         protectedSource.withStrategies(
+                                 LateCallStepStrategy.instance())) {
+                Traversal<?, ?> traversal = decoratedSource.V();
+
+                Assert.assertThrows(SecurityException.class,
+                                    () -> traversal.asAdmin()
+                                                   .applyStrategies(),
+                                    e -> Assert.assertContains(
+                                            "CallStep", e.getMessage()));
+            }
+        }
+    }
+
+    @Test
+    public void testVerifierRunsAfterSubgraphDecorationStrategy()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = engine();
+            GraphTraversalSource protectedSource = engine.add(g);
+            SubgraphStrategy subgraph = SubgraphStrategy.build()
+                                                         .vertices(__.call(
+                                                                 "service"))
+                                                         .create();
+            try (GraphTraversalSource decoratedSource =
+                         protectedSource.withStrategies(subgraph)) {
+                Traversal<?, ?> traversal = decoratedSource.V();
+
+                Assert.assertThrows(SecurityException.class,
+                                    () -> traversal.asAdmin()
+                                                   .applyStrategies(),
+                                    e -> Assert.assertContains(
+                                            "CallStep", e.getMessage()));
+            }
         }
     }
 
@@ -1083,5 +1136,38 @@ public class HugeGraphGremlinLangScriptEngineTest {
             engine.add(traversalSource);
         }
         return engine;
+    }
+
+    private static final class LateCallStepStrategy
+            extends AbstractTraversalStrategy<
+                    TraversalStrategy.DecorationStrategy>
+            implements TraversalStrategy.DecorationStrategy {
+
+        private static final LateCallStepStrategy INSTANCE =
+                new LateCallStepStrategy();
+
+        private LateCallStepStrategy() {
+        }
+
+        private static LateCallStepStrategy instance() {
+            return INSTANCE;
+        }
+
+        @Override
+        public Set<Class<? extends DecorationStrategy>> applyPrior() {
+            return Collections.singleton(
+                    GremlinLangRestrictionStrategy.class);
+        }
+
+        @Override
+        public Set<Class<? extends DecorationStrategy>> applyPost() {
+            return Collections.singleton(
+                    GremlinLangVerificationStrategy.class);
+        }
+
+        @Override
+        public void apply(Traversal.Admin<?, ?> traversal) {
+            traversal.addStep(new CallStep<>(traversal, false, "service"));
+        }
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
@@ -68,6 +68,15 @@ import org.junit.Test;
 public class HugeGraphGremlinLangScriptEngineTest {
 
     @Test
+    public void testFactoryDoesNotClaimTinkerPopDiscoveryAliases() {
+        HugeGraphGremlinLangScriptEngineFactory factory =
+                new HugeGraphGremlinLangScriptEngineFactory();
+
+        Assert.assertTrue(factory.getExtensions().isEmpty());
+        Assert.assertTrue(factory.getMimeTypes().isEmpty());
+    }
+
+    @Test
     public void testManagerRegistersPublicNameToHugeGraphEngine() {
         GremlinScriptEngineManager manager =
                 new CachedGremlinScriptEngineManager();

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.hugegraph.unit.security;
 
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -35,6 +36,7 @@ import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.auth.HugeGraphAuthProxy;
 import org.apache.hugegraph.auth.HugeAuthenticator;
 import org.apache.hugegraph.auth.RolePermission;
+import org.apache.hugegraph.backend.query.Condition;
 import org.apache.hugegraph.security.GremlinLangRestrictionStrategy;
 import org.apache.hugegraph.security.GremlinLangTraversalVerifier;
 import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngine;
@@ -50,8 +52,13 @@ import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineManager;
 import org.apache.tinkerpop.gremlin.jsr223.JavaTranslator;
 import org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.Compare;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.TextP;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.junit.Test;
@@ -105,6 +112,307 @@ public class HugeGraphGremlinLangScriptEngineTest {
         Assert.assertEquals(1, engine.traversalSourceCount());
         g.close();
         graph.close();
+    }
+
+    @Test
+    public void testTextContainsLiteralUsesHugeGraphPredicate()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "marko");
+            graph.addVertex("name", "stephen");
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Traversal<?, ?> traversal = (Traversal<?, ?>) engine.eval(
+                    "g.V().has('name', Text.contains('ark'))" +
+                    ".values('name')",
+                    bindings);
+            traversal.asAdmin().applyStrategies();
+            HasContainerHolder<?, ?> step =
+                    TraversalHelper.getStepsOfAssignableClass(
+                            HasContainerHolder.class,
+                            traversal.asAdmin()).get(0);
+            Assert.assertSame(Condition.RelationType.TEXT_CONTAINS,
+                              step.getHasContainers().get(0)
+                                  .getBiPredicate());
+            Assert.assertEquals("marko", traversal.next());
+        }
+    }
+
+    @Test
+    public void testTextContainsCacheHitUsesCurrentBinding()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "marko");
+            graph.addVertex("name", "stephen");
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            bindings.put("keyword", "ark");
+            Assert.assertEquals("marko", engine.eval(
+                    "g.V().has('name', Text.contains(keyword))" +
+                    ".values('name').next()",
+                    bindings));
+
+            bindings.put("keyword", "teph");
+            Assert.assertEquals("stephen", engine.eval(
+                    "g.V().has('name', Text.contains(keyword))" +
+                    ".values('name').next()",
+                    bindings));
+        }
+    }
+
+    @Test
+    public void testTextContainsSupportsNestedAndThreeArgumentHas()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex(T.label, "person", "name", "marko");
+            graph.addVertex(T.label, "software", "name", "lop");
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+            bindings.put("keyword", "ark");
+
+            Assert.assertEquals("marko", engine.eval(
+                    "g.V().where(__.has('name', " +
+                    "Text.contains(keyword))).values('name').next()",
+                    bindings));
+            Assert.assertEquals("marko", engine.eval(
+                    "g.V().has('person', 'name', " +
+                    "Text.contains(keyword)).values('name').next()",
+                    bindings));
+        }
+    }
+
+    @Test
+    public void testTextContainsSupportsReaderAndMultiplePredicates()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "marko", "city", "santa fe");
+            graph.addVertex("name", "marko", "city", "beijing");
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+            bindings.put("namePart", "ark");
+            bindings.put("cityPart", "anta");
+
+            Assert.assertEquals("santa fe", engine.eval(
+                    new StringReader(
+                            "g.V().has('name', " +
+                            "Text.contains(namePart)).has('city', " +
+                            "Text.contains(cityPart)).values('city').next()"),
+                    bindings));
+        }
+    }
+
+    @Test
+    public void testTextContainsWorksWhenParserCacheIsDisabled()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "marko");
+            HugeGraphGremlinLangScriptEngine engine = engine(false);
+            engine.add(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Assert.assertEquals("marko", engine.eval(
+                    "g.V().has('name', Text.contains('ark'))" +
+                    ".values('name').next()",
+                    bindings));
+        }
+    }
+
+    @Test
+    public void testTextContainsIgnoresStringContents()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "Text.contains('ark')");
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Assert.assertEquals("Text.contains('ark')", engine.eval(
+                    "g.V().has('name', \"Text.contains('ark')\")" +
+                    ".values('name').next()",
+                    bindings));
+        }
+    }
+
+    @Test
+    public void testTextContainsSupportsDoubleQuotesEmptyAndLineComments()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "marko");
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Assert.assertEquals("marko", engine.eval(
+                    "g.V().has(\"name\", Text.contains(\"ark\"))" +
+                    ".values('name').next()",
+                    bindings));
+            Assert.assertEquals(1L, engine.eval(
+                    "g.V().has('name', Text.contains('')).count().next()",
+                    bindings));
+            Assert.assertEquals("marko", engine.eval(
+                    "g.V().has('name', Text.\n// HugeGraph predicate\n" +
+                    "contains('ark')).values('name').next()",
+                    bindings));
+            Assert.assertEquals(1L, engine.eval(
+                    "// Text.contains('ignored')\n" +
+                    "g.V().count().next()",
+                    bindings));
+        }
+    }
+
+    @Test
+    public void testTextPContainingKeepsTinkerPopSemantics()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "marko");
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Traversal<?, ?> traversal = (Traversal<?, ?>) engine.eval(
+                    "g.V().has('name', TextP.containing('ark'))",
+                    bindings);
+            traversal.asAdmin().applyStrategies();
+            HasContainerHolder<?, ?> step =
+                    TraversalHelper.getStepsOfAssignableClass(
+                            HasContainerHolder.class,
+                            traversal.asAdmin()).get(0);
+            P<?> predicate = step.getHasContainers().get(0).getPredicate();
+            Assert.assertSame(TextP.containing("ark").getBiPredicate(),
+                              predicate.getBiPredicate());
+            Assert.assertEquals("ark", predicate.getValue());
+        }
+    }
+
+    @Test
+    public void testTextContainsRejectsUnsupportedForms() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+            bindings.put("keyword", 1);
+
+            assertUnsupportedTextContains(engine, bindings,
+                    "g.V().values('name').is(Text.contains('ark'))");
+            assertUnsupportedTextContains(engine, bindings,
+                    "g.V().has('name', Text.contains('a', 'b'))");
+            assertUnsupportedTextContains(engine, bindings,
+                    "g.V().has('name', Text.contains(keyword.toString()))");
+            assertUnsupportedTextContains(engine, bindings,
+                    "g.V().has('name', " +
+                    "org.apache.hugegraph.Text.contains('ark'))");
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> engine.eval(
+                                        "g.V().has('name', " +
+                                        "Text.contains(keyword))",
+                                        bindings),
+                                e -> Assert.assertContains("must be a String",
+                                                           e.getMessage()));
+            bindings.put("keyword", null);
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> engine.eval(
+                                        "g.V().has('name', " +
+                                        "Text.contains(keyword))",
+                                        bindings),
+                                e -> Assert.assertContains("must be a String",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testTextContainsRejectsReservedBindings() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+            bindings.put("hugegraphTextContainsInternal0", "ark");
+
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> engine.eval(
+                                        "g.V().has('name', " +
+                                        "Text.contains('ark'))",
+                                        bindings),
+                                e -> Assert.assertContains("reserved",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testBytecodeCannotForgeTextContainsMarker()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "hugegraphTextContainsInternal0");
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+            Bytecode bytecode = g.V()
+                                 .has("name",
+                                      "hugegraphTextContainsInternal0")
+                                 .asAdmin().getBytecode();
+
+            Traversal.Admin<?, ?> traversal = engine.eval(bytecode,
+                                                          bindings, "g");
+            traversal.applyStrategies();
+            HasContainerHolder<?, ?> step =
+                    TraversalHelper.getStepsOfAssignableClass(
+                            HasContainerHolder.class, traversal).get(0);
+            Assert.assertSame(Compare.eq,
+                              step.getHasContainers().get(0)
+                                  .getBiPredicate());
+            Assert.assertTrue(traversal.hasNext());
+        }
+    }
+
+    @Test
+    public void testConcurrentTextContainsCacheHitsKeepBindingsIsolated()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            int requests = 16;
+            for (int i = 0; i < requests; i++) {
+                graph.addVertex("name", "value-" + (char) ('a' + i));
+            }
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            ExecutorService executor = Executors.newFixedThreadPool(8);
+            try {
+                List<Future<Object>> results = new ArrayList<>();
+                for (int i = 0; i < requests; i++) {
+                    String keyword = "value-" + (char) ('a' + i);
+                    results.add(executor.submit(() -> {
+                        Bindings bindings = new SimpleBindings();
+                        bindings.put("g", g);
+                        bindings.put("keyword", keyword);
+                        return engine.eval(
+                                "g.V().has('name', " +
+                                "Text.contains(keyword)).count().next()",
+                                bindings);
+                    }));
+                }
+                for (Future<Object> result : results) {
+                    Assert.assertEquals(1L, result.get());
+                }
+            } finally {
+                executor.shutdownNow();
+            }
+        }
     }
 
     @Test
@@ -576,10 +884,20 @@ public class HugeGraphGremlinLangScriptEngineTest {
     }
 
     private static HugeGraphGremlinLangScriptEngine engine() {
+        return engine(true);
+    }
+
+    private static HugeGraphGremlinLangScriptEngine engine(
+            boolean cacheEnabled) {
         List<Customizer> customizers = new ArrayList<>();
-        GremlinLangPlugin cache = GremlinLangPlugin.build()
+        GremlinLangPlugin cache = cacheEnabled ?
+                                  GremlinLangPlugin.build()
                                                    .cacheEnabled(true)
-                                                   .caffeine("maximumSize=16")
+                                                   .caffeine(
+                                                           "maximumSize=16")
+                                                   .create() :
+                                  GremlinLangPlugin.build()
+                                                   .cacheEnabled(false)
                                                    .create();
         VariableResolverPlugin variables =
                 VariableResolverPlugin.build()
@@ -593,6 +911,15 @@ public class HugeGraphGremlinLangScriptEngineTest {
                 new HugeGraphGremlinLangScriptEngineFactory(
                         customizers.toArray(new Customizer[0]));
         return factory.getScriptEngine();
+    }
+
+    private static void assertUnsupportedTextContains(
+            HugeGraphGremlinLangScriptEngine engine, Bindings bindings,
+            String script) {
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> engine.eval(script, bindings),
+                            e -> Assert.assertContains("only supported",
+                                                       e.getMessage()));
     }
 
     private static HugeGraphGremlinLangScriptEngine registeredEngine(

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -78,7 +79,7 @@ public class HugeGraphGremlinLangScriptEngineTest {
         graph.addVertex(T.label, "person", "name", "marko");
         graph.addVertex(T.label, "person", "name", "stephen");
         GraphTraversalSource g = graph.traversal();
-        HugeGraphGremlinLangScriptEngine engine = engine();
+        HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
         Bindings bindings = new SimpleBindings();
         bindings.put("g", g);
 
@@ -105,7 +106,8 @@ public class HugeGraphGremlinLangScriptEngineTest {
             firstGraph.addVertex();
             secondGraph.addVertex();
             secondGraph.addVertex();
-            HugeGraphGremlinLangScriptEngine engine = engine();
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(
+                    first, second);
 
             Bindings bindings = new SimpleBindings();
             bindings.put("g", first);
@@ -129,7 +131,7 @@ public class HugeGraphGremlinLangScriptEngineTest {
                 graph.addVertex("name", "person-" + i);
             }
 
-            HugeGraphGremlinLangScriptEngine engine = engine();
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
             ExecutorService executor = Executors.newFixedThreadPool(8);
             try {
                 List<Future<Object>> results = new ArrayList<>();
@@ -157,7 +159,7 @@ public class HugeGraphGremlinLangScriptEngineTest {
     public void testRemoveTraversalSourceDropsItsDelegate() throws Exception {
         TinkerGraph graph = TinkerGraph.open();
         GraphTraversalSource g = graph.traversal();
-        HugeGraphGremlinLangScriptEngine engine = engine();
+        HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
         Bindings bindings = new SimpleBindings();
         bindings.put("g", g);
 
@@ -165,6 +167,11 @@ public class HugeGraphGremlinLangScriptEngineTest {
         Assert.assertEquals(1, engine.traversalSourceCount());
 
         engine.remove(g);
+        Assert.assertEquals(0, engine.traversalSourceCount());
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> engine.eval("g.V().count()", bindings),
+                            e -> Assert.assertContains("registered",
+                                                       e.getMessage()));
         Assert.assertEquals(0, engine.traversalSourceCount());
         g.close();
         graph.close();
@@ -174,7 +181,7 @@ public class HugeGraphGremlinLangScriptEngineTest {
     public void testAllowsSafeTerminalExecution() throws Exception {
         try (TinkerGraph graph = TinkerGraph.open();
              GraphTraversalSource g = graph.traversal()) {
-            HugeGraphGremlinLangScriptEngine engine = engine();
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
             Bindings bindings = new SimpleBindings();
             bindings.put("g", g);
 
@@ -191,6 +198,11 @@ public class HugeGraphGremlinLangScriptEngineTest {
 
         Assert.assertEquals(2, engine.eval("1+1", new SimpleBindings()));
         Assert.assertEquals(0, engine.traversalSourceCount());
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> engine.eval("1+1", new SimpleBindings()),
+                            e -> Assert.assertContains(
+                                    "GraphTraversalSource",
+                                    e.getMessage()));
     }
 
     @Test
@@ -241,7 +253,7 @@ public class HugeGraphGremlinLangScriptEngineTest {
             throws Exception {
         try (TinkerGraph graph = TinkerGraph.open();
              GraphTraversalSource g = graph.traversal()) {
-            HugeGraphGremlinLangScriptEngine engine = engine();
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
             Bindings bindings = new SimpleBindings();
             bindings.put("g", g);
 
@@ -255,13 +267,52 @@ public class HugeGraphGremlinLangScriptEngineTest {
     }
 
     @Test
+    public void testVerifierRejectsParameterizedCallStep() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+            bindings.put("params",
+                         Collections.singletonMap("key", "value"));
+
+            Assert.assertThrows(SecurityException.class,
+                                () -> engine.eval(
+                                        "g.call('service', params)",
+                                        bindings),
+                                e -> Assert.assertContains("CallStep",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testVerifierRejectsParameterizedCallStepBeforeTerminalExecution()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+            bindings.put("params",
+                         Collections.singletonMap("key", "value"));
+
+            Assert.assertThrows(SecurityException.class,
+                                () -> engine.eval(
+                                        "g.call('service', params).iterate()",
+                                        bindings),
+                                e -> Assert.assertContains("CallStep",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
     public void testVerifierRejectsIoStepBeforeTerminalExecution()
             throws Exception {
         Path directory = Files.createTempDirectory("hugegraph-gremlin-lang");
         Path output = directory.resolve("graph.json");
         try (TinkerGraph graph = TinkerGraph.open();
              GraphTraversalSource g = graph.traversal()) {
-            HugeGraphGremlinLangScriptEngine engine = engine();
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
             Bindings bindings = new SimpleBindings();
             bindings.put("g", g);
 
@@ -286,9 +337,10 @@ public class HugeGraphGremlinLangScriptEngineTest {
                                                    .cacheEnabled(true)
                                                    .caffeine("maximumSize=16")
                                                    .create();
-        VariableResolverPlugin variables = VariableResolverPlugin.build()
-                                                                  .resolver("DefaultVariableResolver")
-                                                                  .create();
+        VariableResolverPlugin variables =
+                VariableResolverPlugin.build()
+                                      .resolver("DefaultVariableResolver")
+                                      .create();
         customizers.addAll(Arrays.asList(
                 cache.getCustomizers("gremlin-lang").get()));
         customizers.addAll(Arrays.asList(
@@ -297,5 +349,14 @@ public class HugeGraphGremlinLangScriptEngineTest {
                 new HugeGraphGremlinLangScriptEngineFactory(
                         customizers.toArray(new Customizer[0]));
         return factory.getScriptEngine();
+    }
+
+    private static HugeGraphGremlinLangScriptEngine registeredEngine(
+            GraphTraversalSource... traversalSources) {
+        HugeGraphGremlinLangScriptEngine engine = engine();
+        for (GraphTraversalSource traversalSource : traversalSources) {
+            engine.add(traversalSource);
+        }
+        return engine;
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
@@ -30,10 +30,18 @@ import java.util.concurrent.Future;
 import javax.script.Bindings;
 import javax.script.SimpleBindings;
 
+import org.apache.hugegraph.HugeFactory;
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.auth.HugeGraphAuthProxy;
+import org.apache.hugegraph.auth.HugeAuthenticator;
+import org.apache.hugegraph.auth.RolePermission;
+import org.apache.hugegraph.security.GremlinLangRestrictionStrategy;
 import org.apache.hugegraph.security.GremlinLangTraversalVerifier;
 import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngine;
 import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
 import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.task.TaskManager;
+import org.apache.hugegraph.unit.FakeObjects;
 import org.apache.tinkerpop.gremlin.jsr223.CachedGremlinScriptEngineManager;
 import org.apache.tinkerpop.gremlin.jsr223.Customizer;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin;
@@ -97,6 +105,75 @@ public class HugeGraphGremlinLangScriptEngineTest {
         Assert.assertEquals(1, engine.traversalSourceCount());
         g.close();
         graph.close();
+    }
+
+    @Test
+    public void testProtectsHugeGraphAuthTraversalSource() throws Exception {
+        HugeGraph graph = HugeFactory.open(FakeObjects.newConfig());
+        HugeGraphAuthProxy proxy = new HugeGraphAuthProxy(graph);
+        HugeAuthenticator.User user = new HugeAuthenticator.User(
+                "sandbox-test", RolePermission.admin());
+        TaskManager.setContext(user.toJson());
+        HugeGraphGremlinLangScriptEngine mainEngine = engine();
+        HugeGraphGremlinLangScriptEngine sessionEngine = engine();
+        GraphTraversalSource source = proxy.traversal();
+        GraphTraversalSource protectedSource = null;
+        GraphTraversalSource replacement = null;
+        GraphTraversalSource protectedReplacement = null;
+        try {
+            protectedSource = mainEngine.add(source);
+            Assert.assertEquals(source.getClass(),
+                                protectedSource.getClass());
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", protectedSource);
+
+            Assert.assertEquals(0L, mainEngine.eval(
+                    "g.V().count().next()", bindings));
+            Assert.assertEquals(0L, mainEngine.eval(
+                    "g.V().count().next()", bindings));
+            Assert.assertEquals(0L, sessionEngine.eval(
+                    "g.V().count().next()", bindings));
+
+            Bytecode bytecode = new Bytecode();
+            bytecode.addStep("V");
+            bytecode.addStep("count");
+            Traversal.Admin<?, ?> mainTraversal = mainEngine.eval(
+                    bytecode, bindings, "g");
+            Assert.assertEquals(0L, mainTraversal.next());
+            Traversal.Admin<?, ?> sessionTraversal = sessionEngine.eval(
+                    bytecode, bindings, "g");
+            Assert.assertEquals(0L, sessionTraversal.next());
+
+            mainEngine.remove(protectedSource);
+            Assert.assertEquals(0, sessionEngine.traversalSourceCount());
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> sessionEngine.eval(
+                                        "g.V().count().next()", bindings),
+                                e -> Assert.assertContains("active",
+                                                           e.getMessage()));
+
+            replacement = proxy.traversal();
+            protectedReplacement = mainEngine.add(replacement);
+            bindings.put("g", protectedReplacement);
+            Assert.assertEquals(0L, sessionEngine.eval(
+                    "g.V().count().next()", bindings));
+        } finally {
+            mainEngine.clear();
+            sessionEngine.clear();
+            if (protectedReplacement != null) {
+                protectedReplacement.close();
+            }
+            if (replacement != null) {
+                replacement.close();
+            }
+            if (protectedSource != null) {
+                protectedSource.close();
+            }
+            source.close();
+            graph.close();
+            HugeGraphAuthProxy.resetContext();
+            TaskManager.resetContext();
+        }
     }
 
     @Test
@@ -240,6 +317,55 @@ public class HugeGraphGremlinLangScriptEngineTest {
     }
 
     @Test
+    public void testRemovingSourceInvalidatesSessionEngine() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex();
+            HugeGraphGremlinLangScriptEngine mainEngine = engine();
+            GraphTraversalSource protectedSource = mainEngine.add(g);
+            HugeGraphGremlinLangScriptEngine sessionEngine = engine();
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", protectedSource);
+            Assert.assertEquals(1L, sessionEngine.eval(
+                    "g.V().count().next()", bindings));
+
+            mainEngine.remove(protectedSource);
+
+            Assert.assertEquals(0, sessionEngine.traversalSourceCount());
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> sessionEngine.eval(
+                                        "g.V().count().next()", bindings),
+                                e -> Assert.assertContains("active",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testClearingSourcesInvalidatesSessionEngine()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex();
+            HugeGraphGremlinLangScriptEngine mainEngine = engine();
+            GraphTraversalSource protectedSource = mainEngine.add(g);
+            HugeGraphGremlinLangScriptEngine sessionEngine = engine();
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", protectedSource);
+            Assert.assertEquals(1L, sessionEngine.eval(
+                    "g.V().count().next()", bindings));
+
+            mainEngine.clear();
+
+            Assert.assertEquals(0, sessionEngine.traversalSourceCount());
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> sessionEngine.eval(
+                                        "g.V().count().next()", bindings),
+                                e -> Assert.assertContains("active",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
     public void testSessionEngineRejectsUnprotectedTraversalSource()
             throws Exception {
         try (TinkerGraph graph = TinkerGraph.open();
@@ -252,6 +378,25 @@ public class HugeGraphGremlinLangScriptEngineTest {
                                 () -> sessionEngine.eval(
                                         "g.V().count()", bindings),
                                 e -> Assert.assertContains("protected",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testSessionEngineRejectsUnregisteredProtectedSource()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal();
+             GraphTraversalSource protectedSource = g.withStrategies(
+                     GremlinLangRestrictionStrategy.instance())) {
+            HugeGraphGremlinLangScriptEngine sessionEngine = engine();
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", protectedSource);
+
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> sessionEngine.eval(
+                                        "g.V().count()", bindings),
+                                e -> Assert.assertContains("active",
                                                            e.getMessage()));
         }
     }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
@@ -39,7 +39,9 @@ import org.apache.tinkerpop.gremlin.jsr223.Customizer;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineManager;
+import org.apache.tinkerpop.gremlin.jsr223.JavaTranslator;
 import org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin;
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -175,6 +177,103 @@ public class HugeGraphGremlinLangScriptEngineTest {
         Assert.assertEquals(0, engine.traversalSourceCount());
         g.close();
         graph.close();
+    }
+
+    @Test
+    public void testProtectedSourceBlocksBytecodeIoTraversal()
+            throws Exception {
+        Path directory = Files.createTempDirectory("hugegraph-bytecode");
+        Path output = directory.resolve("graph.json");
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = engine();
+            GraphTraversalSource protectedSource = engine.add(g);
+            Bytecode bytecode = g.io(output.toString())
+                                 .write().asAdmin().getBytecode();
+            Traversal.Admin<?, ?> traversal = JavaTranslator.of(
+                    protectedSource).translate(bytecode);
+
+            Assert.assertThrows(SecurityException.class,
+                                traversal::iterate,
+                                e -> Assert.assertContains("IoStep",
+                                                           e.getMessage()));
+            Assert.assertFalse(Files.exists(output));
+        } finally {
+            Files.deleteIfExists(output);
+            Files.deleteIfExists(directory);
+        }
+    }
+
+    @Test
+    public void testProtectedSourceAllowsSafeBytecodeTraversal()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex();
+            HugeGraphGremlinLangScriptEngine engine = engine();
+            GraphTraversalSource protectedSource = engine.add(g);
+            Bytecode bytecode = g.V().count().asAdmin().getBytecode();
+            Traversal.Admin<?, ?> traversal = JavaTranslator.of(
+                    protectedSource).translate(bytecode);
+
+            Assert.assertEquals(1L, traversal.next());
+        }
+    }
+
+    @Test
+    public void testSessionEngineLazilyUsesProtectedTraversalSource()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex();
+            HugeGraphGremlinLangScriptEngine mainEngine = engine();
+            GraphTraversalSource protectedSource = mainEngine.add(g);
+            HugeGraphGremlinLangScriptEngine sessionEngine = engine();
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", protectedSource);
+
+            Assert.assertEquals(1L, sessionEngine.eval(
+                    "g.V().count().next()", bindings));
+            Assert.assertEquals(1,
+                                sessionEngine.traversalSourceCount());
+        }
+    }
+
+    @Test
+    public void testSessionEngineRejectsUnprotectedTraversalSource()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine sessionEngine = engine();
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> sessionEngine.eval(
+                                        "g.V().count()", bindings),
+                                e -> Assert.assertContains("protected",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testRemovedProtectedSourceCannotRecreateDelegate()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeGraphGremlinLangScriptEngine engine = engine();
+            GraphTraversalSource protectedSource = engine.add(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", protectedSource);
+
+            engine.remove(protectedSource);
+
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> engine.eval("g.V()", bindings),
+                                e -> Assert.assertContains("registered",
+                                                           e.getMessage()));
+            Assert.assertEquals(0, engine.traversalSourceCount());
+        }
     }
 
     @Test

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
@@ -67,6 +67,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.CallStep;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.LazyBarrierStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
@@ -753,6 +754,43 @@ public class HugeGraphGremlinLangScriptEngineTest {
             Bytecode bytecode = g.V().count().asAdmin().getBytecode();
             Traversal.Admin<?, ?> traversal = JavaTranslator.of(
                     protectedSource).translate(bytecode);
+
+            Assert.assertEquals(1L, traversal.next());
+        }
+    }
+
+    @Test
+    public void testTextAllowsRemovingQueryStrategy() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex();
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+
+            Traversal<?, ?> traversal = (Traversal<?, ?>) engine.eval(
+                    "g.withoutStrategies(LazyBarrierStrategy).V().count()",
+                    bindings);
+
+            Assert.assertEquals(1L, traversal.next());
+        }
+    }
+
+    @Test
+    public void testBytecodeAllowsRemovingQueryStrategy() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal();
+             GraphTraversalSource requestSource =
+                     g.withoutStrategies(LazyBarrierStrategy.class)) {
+            graph.addVertex();
+            HugeGraphGremlinLangScriptEngine engine = registeredEngine(g);
+            Bindings bindings = new SimpleBindings();
+            bindings.put("g", g);
+            Bytecode bytecode = requestSource.V().count().asAdmin()
+                                             .getBytecode();
+
+            Traversal.Admin<?, ?> traversal = engine.eval(bytecode, bindings,
+                                                          "g");
 
             Assert.assertEquals(1L, traversal.next());
         }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/security/HugeGraphGremlinLangScriptEngineTest.java
@@ -185,6 +185,26 @@ public class HugeGraphGremlinLangScriptEngineTest {
     }
 
     @Test
+    public void testAllowsTinkerPopInitializationProbeWithoutTraversalSource()
+            throws Exception {
+        HugeGraphGremlinLangScriptEngine engine = engine();
+
+        Assert.assertEquals(2, engine.eval("1+1", new SimpleBindings()));
+        Assert.assertEquals(0, engine.traversalSourceCount());
+    }
+
+    @Test
+    public void testRejectsOtherScriptsWithoutTraversalSource() {
+        HugeGraphGremlinLangScriptEngine engine = engine();
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> engine.eval("2+2", new SimpleBindings()),
+                            e -> Assert.assertContains(
+                                    "GraphTraversalSource",
+                                    e.getMessage()));
+    }
+
+    @Test
     public void testVerifierAllowsNormalTraversal() throws Exception {
         try (TinkerGraph graph = TinkerGraph.open();
              GraphTraversalSource g = graph.traversal()) {


### PR DESCRIPTION
## Purpose of the PR

- Follow-up to [#197](https://github.com/hugegraph/hugegraph/pull/197), which upgraded the development branch to TinkerPop 3.8.1.
- Phase 3 sandbox design: [Phase 3 Gremlin security sandbox refactoring](https://hugegraph.feishu.cn/wiki/V6dKwaQEVi6tdskgtmscFh0dnMN).

This is the first of three PRs for the Phase 3 security-sandbox refactoring. It moves remote HTTP and WebSocket Gremlin text requests from `GremlinGroovyScriptEngine` to TinkerPop 3.8.1's `GremlinLangScriptEngine`. It also keeps compatible WebSocket GLV Bytecode and Session requests on protected traversal sources. Groovy remains available only to trusted deployment-time scripts.

The complete Phase 3 goal is broader than this PR: strings originating from HTTP, WebSocket, Job API, Store gRPC, Schema Template, or database metadata must not reach Groovy `eval` or `compile`. This PR establishes and verifies that boundary for HTTP and WebSocket Gremlin requests.

## Main Changes

- Add one request guard for the Gremlin Server HTTP and WebSocket paths:
  - text requests without `language` default to `gremlin-lang`;
  - explicit `gremlin-lang` remains supported, while remote Groovy and other script languages are rejected;
  - standard and Session text requests are supported;
  - traversal and Session Bytecode are supported over WebSocket when they contain no Lambda; ordinary `withoutStrategies()` operations remain compatible, while attempts to remove HugeGraph sandbox strategies are rejected;
  - Session identifiers are checked before TinkerPop casts them.
- Add HugeGraph HTTP/WebSocket handlers and a channelizer so both protocols enforce the same rules. Server startup fails closed if a configuration selects another channelizer.
- Register a HugeGraph `GremlinLangScriptEngine` wrapper that:
  - keeps the TinkerPop 3.8.1 parser cache disabled because cached `Traversal` state is unsafe to reuse across parameterized requests;
  - creates isolated delegates for each `GraphTraversalSource` and uses the current request bindings on every evaluation;
  - shares registered traversal-source state with Session engines;
  - invalidates main and Session delegates together when a graph is removed or the server stops;
  - does not claim TinkerPop standard extension or MIME aliases; the server registers the public `gremlin-lang` name explicitly.
- Preserve HugeGraph's real `HugeGraphAuthProxy.GraphTraversalSourceProxy` and its provider/auth strategies. Session engines may attach only to the exact protected sources registered by the main engine.
- Reject `IoStep` and `CallStep` before traversal execution, including parameterized `CallStepPlaceholder` and terminal steps such as `iterate()`.
- Keep `ScriptFileGremlinPlugin`, PRELOAD, and the internal Gremlin-Groovy engine available for trusted deployment configuration and local files.
- Apply the same Gremlin Server configuration to the regular distribution and Raft test configurations.

## Phase 3 PR Boundary

The red block is the scope of this PR. Blue blocks are follow-up PRs. The green block is the trusted deployment-time Groovy path that remains available.

```mermaid
flowchart TB
    subgraph CURRENT["PR #203 — this PR"]
        direction LR
        HTTP["HTTP text"] --> GUARD["Default missing language to gremlin-lang<br/>Reject remote Groovy<br/>Validate Session and Bytecode"]
        WS["WebSocket text / Bytecode<br/>Standard or Session"] --> GUARD
        GUARD -->|Text| ENGINE["HugeGraph GremlinLang engine<br/>Parser cache disabled"]
        GUARD -->|Bytecode| TRANSLATE["JavaTranslator"]
        ENGINE --> SOURCE["Registered protected<br/>GraphTraversalSource"]
        TRANSLATE --> SOURCE
        SOURCE --> STEPS["Reject IoStep and CallStep"]
        STEPS --> EXECUTE["HugeGraph traversal execution"]
    end

    subgraph SCHEMA["Follow-up PR — Schema Template"]
        direction LR
        TEMPLATE["Schema Template<br/>Database metadata"] --> PARSER["Restricted parser"]
        PARSER --> PLAN["Typed Schema plan"]
        PLAN --> BUILDER["SchemaManager Builder API"]
    end

    subgraph REMAINING["Follow-up PR — remaining remote strings"]
        direction LR
        JOB["Gremlin Job / algorithms"] --> JOB_LANG["GremlinLang"]
        GRPC["Store gRPC<br/>Non-empty condition"] --> REJECT["Explicit rejection"]
        JOB_LANG --> VERIFY["Final boundary verification"]
        REJECT --> VERIFY
    end

    subgraph TRUSTED["Unchanged trusted path"]
        direction LR
        CONFIG["Deployment configuration<br/>Local files"] --> PRELOAD["ScriptFileGremlinPlugin / PRELOAD"]
        PRELOAD --> GROOVY["Deployment-time Groovy"]
    end

    EXECUTE -. "next PR" .-> TEMPLATE
    BUILDER -. "next PR" .-> JOB

    classDef current fill:#ffebe9,stroke:#cf222e,stroke-width:3px,color:#24292f
    classDef future fill:#ddf4ff,stroke:#0969da,stroke-width:2px,color:#24292f
    classDef trusted fill:#dafbe1,stroke:#1a7f37,stroke-width:2px,color:#24292f

    class HTTP,WS,GUARD,ENGINE,TRANSLATE,SOURCE,STEPS,EXECUTE current
    class TEMPLATE,PARSER,PLAN,BUILDER,JOB,JOB_LANG,GRPC,REJECT,VERIFY future
    class CONFIG,PRELOAD,GROOVY trusted

    style CURRENT fill:#fff5f5,stroke:#cf222e,stroke-width:3px
    style SCHEMA fill:#f6f8fa,stroke:#0969da,stroke-width:2px
    style REMAINING fill:#f6f8fa,stroke:#0969da,stroke-width:2px
    style TRUSTED fill:#f0fff4,stroke:#1a7f37,stroke-width:2px
```

1. **This PR — remote Gremlin entry points:** HTTP/WebSocket request routing, GremlinLang text parsing, compatible WebSocket Bytecode and Session handling, protected traversal sources, and high-risk traversal-step checks.
2. **Follow-up PR — Schema Template:** replace Schema Template Groovy execution with a restricted parser and a typed Schema executor while retaining the current Schema DSL.
3. **Follow-up PR — remaining remote strings:** migrate Job and algorithm execution to GremlinLang, reject non-empty Store gRPC conditions, and verify that no remote or metadata-derived string can reach Groovy evaluation.

## Compatibility Notes

| Request path | Behavior in this PR |
|---|---|
| HTTP or WebSocket text without `language` | Supported. The server treats it as `gremlin-lang`. |
| HTTP or WebSocket text with `language: gremlin-lang` | Supported. |
| Text with `gremlin-groovy`, another language, or an explicit non-string/null language | Rejected before engine dispatch. |
| Standard WebSocket GLV Bytecode | Supported when it contains no Lambda. Ordinary `withoutStrategies()` operations remain supported, but requests cannot remove `GremlinLangRestrictionStrategy` or `GremlinLangVerificationStrategy`. |
| Session text eval and Session WebSocket Bytecode | Supported with a string Session ID and the same protected traversal-source rules as non-Session requests. |
| Session close | Supported with a string Session ID. |
| HTTP serialized Bytecode | Rejected. GLVs should use the standard WebSocket traversal protocol. |
| Cypher processor | Unchanged and still supported. |
| Trusted `ScriptFileGremlinPlugin` and PRELOAD Groovy | Unchanged and still supported for deployment-controlled local files. |

Schema Template, Job/algorithm, and Store gRPC condition behavior is not changed by this PR; those boundaries are handled by the two follow-up PRs above. No persisted-data format is changed.

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
  - On Java 17, a targeted JUnit run covered `GremlinLangRequestGuardTest`, `HugeGraphGremlinLangScriptEngineTest`, and `GremlinConfigCompatibilityTest`: 104 tests passed with no failures or errors.
  - The tests cover missing-language defaults, explicit language rejection, Session argument types, standard and Session Bytecode, Lambda rejection, compatible `withoutStrategies()` use, protection of mandatory sandbox strategies, and HTTP/WebSocket handler responses.
  - A real `HugeGraphAuthProxy.GraphTraversalSourceProxy` covers text, Bytecode, Session attachment, repeated evaluation with current bindings, graph removal, and source replacement.
  - Removing or clearing a traversal source invalidates delegates held by Session engines, and a retired source cannot recreate a delegate.
  - Runtime HTTP and WebSocket checks previously passed for normal GremlinLang queries and for rejecting remote Groovy, `IoStep`, `CallStep`, and parameterized `CallStepPlaceholder` requests.
  - Starting with TinkerPop's unprotected `WsAndHttpChannelizer` fails closed before the server opens its ports.
  - Factory metadata tests verify that HugeGraph does not claim TinkerPop standard extension or MIME aliases.
  - PRELOAD completes with the retained deployment-time Groovy engine.
  - `mvn editorconfig:format`, `git diff --check`, and `bash -n` for the two updated smoke scripts passed.

The TinkerPop parser cache is intentionally disabled in this PR. TinkerPop 3.8.1 caches constructed `Traversal` objects; parameter values and later strategy mutations can therefore leak across cache hits, causing stale values, wrong results, or runtime exceptions. The separate `Text.contains()` rewrite-plan cache remains bounded because it stores only immutable rewrite metadata, never a `Traversal` or request value.

## Does this PR potentially affect the following parts?

- [ ] Dependencies
- [x] Modify configurations
- [x] The public API
- [x] Other affects: Gremlin Server HTTP/WebSocket routing and script-engine behavior
- [ ] Nope

## Documentation Status

- [ ] `Doc - TODO`
- [x] `Doc - Done`
- [ ] `Doc - No Need`