### PR TITLE
refactor(server): remove remaining untrusted Groovy paths

### DIFF
--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/job/GremlinAPI.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/job/GremlinAPI.java
@@ -91,7 +91,6 @@ public class GremlinAPI extends API {
         GREMLIN_JOB_INPUT_HISTOGRAM.update(request.gremlin.length());
 
         HugeGraph g = graph(manager, graphSpace, graph);
-        request.aliase(graph, "graph");
         JobBuilder<Object> builder = JobBuilder.of(g);
         builder.name(request.name())
                .input(request.toJson())

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/job/GremlinAPI.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/job/GremlinAPI.java
@@ -36,6 +36,7 @@ import org.apache.hugegraph.define.Checkable;
 import org.apache.hugegraph.job.GremlinJob;
 import org.apache.hugegraph.job.JobBuilder;
 import org.apache.hugegraph.metrics.MetricsUtil;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
 import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.JsonUtil;
 import org.apache.hugegraph.util.Log;
@@ -110,8 +111,10 @@ public class GremlinAPI extends API {
         @Schema(description = "The bindings for the Gremlin script")
         private Map<String, Object> bindings = new HashMap<>();
         @JsonProperty
-        @Schema(description = "The language of the Gremlin script", example = "gremlin-groovy")
-        private String language = "gremlin-groovy";
+        @Schema(description = "The language of the Gremlin script",
+                example = "gremlin-lang")
+        private String language =
+                HugeGraphGremlinLangScriptEngineFactory.ENGINE_NAME;
         @JsonProperty
         @Schema(description = "The aliases for graph references")
         private Map<String, String> aliases = new HashMap<>();
@@ -184,6 +187,11 @@ public class GremlinAPI extends API {
                                    "The gremlin parameter can't be null");
             E.checkArgumentNotNull(this.language,
                                    "The language parameter can't be null");
+            E.checkArgument(
+                    HugeGraphGremlinLangScriptEngineFactory.ENGINE_NAME.equals(
+                            this.language),
+                    "The language parameter must be 'gremlin-lang', but got '%s'",
+                    this.language);
             E.checkArgument(this.aliases == null || this.aliases.isEmpty(),
                             "There is no need to pass gremlin aliases");
         }

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/space/SchemaTemplateAPI.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/api/space/SchemaTemplateAPI.java
@@ -114,6 +114,29 @@ public class SchemaTemplateAPI extends API {
         return manager.serializer().writeSchemaTemplate(template);
     }
 
+    @POST
+    @Timed
+    @Path("{name}/validate")
+    @Produces(APPLICATION_JSON_WITH_CHARSET)
+    @RolesAllowed({"space_member", "$dynamic"})
+    public Object validate(@Context GraphManager manager,
+                           @PathParam("graphspace") String graphSpace,
+                           @PathParam("name") String name) {
+        LOG.debug("Validate schema template '{}' for graph space '{}'",
+                  name, graphSpace);
+        ensurePdModeEnabled(manager);
+
+        SchemaTemplate template = schemaTemplate(manager, graphSpace, name);
+        try {
+            manager.validateSchemaTemplate(template.schema());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format(
+                      "Schema template '%s' is invalid: %s",
+                      name, e.getMessage()), e);
+        }
+        return ImmutableMap.of("name", name, "valid", true);
+    }
+
     @DELETE
     @Timed
     @Path("{name}")

--- a/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
+++ b/hugegraph-server/hugegraph-api/src/main/java/org/apache/hugegraph/core/GraphManager.java
@@ -103,6 +103,8 @@ import org.apache.hugegraph.rpc.RpcServer;
 import org.apache.hugegraph.serializer.JsonSerializer;
 import org.apache.hugegraph.serializer.Serializer;
 import org.apache.hugegraph.server.RestServer;
+import org.apache.hugegraph.schema.RestrictedSchemaTemplateParser;
+import org.apache.hugegraph.schema.SchemaTemplateExecutor;
 import org.apache.hugegraph.space.GraphSpace;
 import org.apache.hugegraph.space.SchemaTemplate;
 import org.apache.hugegraph.space.Service;
@@ -111,7 +113,6 @@ import org.apache.hugegraph.space.register.dto.ServiceDTO;
 import org.apache.hugegraph.space.register.registerImpl.PdRegister;
 import org.apache.hugegraph.task.TaskManager;
 import org.apache.hugegraph.testutil.Whitebox;
-import org.apache.hugegraph.traversal.optimize.HugeScriptTraversal;
 import org.apache.hugegraph.type.define.CollectionType;
 import org.apache.hugegraph.type.define.GraphMode;
 import org.apache.hugegraph.type.define.GraphReadMode;
@@ -422,22 +423,8 @@ public final class GraphManager {
         }
     }
 
-    public static void prepareSchema(HugeGraph graph, String gremlin) {
-        Map<String, Object> bindings = ImmutableMap.of(
-                "graph", graph,
-                "schema", graph.schema());
-        HugeScriptTraversal<?, ?> traversal = new HugeScriptTraversal<>(
-                graph.traversal(),
-                "gremlin-groovy", gremlin,
-                bindings, ImmutableMap.of());
-        while (traversal.hasNext()) {
-            traversal.next();
-        }
-        try {
-            traversal.close();
-        } catch (Exception e) {
-            throw new HugeException("Failed to init schema", e);
-        }
+    public static void prepareSchema(HugeGraph graph, String template) {
+        SchemaTemplateExecutor.execute(graph, template);
     }
 
     private KvStore kvStoreInit() {
@@ -2335,6 +2322,7 @@ public final class GraphManager {
                                     "standalone (non-PD) mode");
         }
         checkSchemaTemplateName(template.name());
+        validateSchemaTemplate(template.schema());
         this.metaManager.addSchemaTemplate(graphSpace, template);
     }
 
@@ -2351,7 +2339,12 @@ public final class GraphManager {
             throw new HugeException("Schema templates are not supported in " +
                                     "standalone (non-PD) mode");
         }
+        validateSchemaTemplate(template.schema());
         this.metaManager.updateSchemaTemplate(graphSpace, template);
+    }
+
+    public void validateSchemaTemplate(String schema) {
+        RestrictedSchemaTemplateParser.validate(schema);
     }
 
     private static void checkSchemaTemplateName(String name) {

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/job/GremlinJob.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/job/GremlinJob.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.apache.hugegraph.backend.query.Query;
 import org.apache.hugegraph.exception.LimitExceedException;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
 import org.apache.hugegraph.traversal.optimize.HugeScriptTraversal;
 import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.JsonUtil;
@@ -31,7 +32,6 @@ import org.apache.hugegraph.util.JsonUtil;
 public class GremlinJob extends UserJob<Object> {
 
     public static final String TASK_TYPE = "gremlin";
-    public static final String TASK_BIND_NAME = "gremlinJob";
     public static final int TASK_RESULTS_MAX_SIZE = (int) Query.DEFAULT_CAPACITY;
 
     @Override
@@ -61,6 +61,11 @@ public class GremlinJob extends UserJob<Object> {
         E.checkArgument(value instanceof String,
                         "Invalid language value '%s'", value);
         String language = (String) value;
+        E.checkArgument(
+                HugeGraphGremlinLangScriptEngineFactory.ENGINE_NAME.equals(
+                        language),
+                "Invalid language value '%s', only 'gremlin-lang' is supported",
+                language);
 
         value = map.get("aliases");
         E.checkArgument(value instanceof Map,
@@ -68,12 +73,8 @@ public class GremlinJob extends UserJob<Object> {
         @SuppressWarnings("unchecked")
         Map<String, String> aliases = (Map<String, String>) value;
 
-        bindings.put(TASK_BIND_NAME, new GremlinJobProxy());
-
         HugeScriptTraversal<?, ?> traversal = new HugeScriptTraversal<>(
-                this.graph().traversal(),
-                language, gremlin,
-                bindings, aliases);
+                this.graph().traversal(), gremlin, bindings, aliases);
         List<Object> results = new ArrayList<>();
         long capacity = Query.defaultCapacity(Query.NO_CAPACITY);
         try {
@@ -107,25 +108,6 @@ public class GremlinJob extends UserJob<Object> {
             throw new LimitExceedException(
                     "Job results size %s has exceeded the max limit %s",
                     size, TASK_RESULTS_MAX_SIZE);
-        }
-    }
-
-    /**
-     * Used by gremlin script
-     */
-    @SuppressWarnings("unused")
-    private class GremlinJobProxy {
-
-        public void setMinSaveInterval(long seconds) {
-            GremlinJob.this.setMinSaveInterval(seconds);
-        }
-
-        public void updateProgress(int progress) {
-            GremlinJob.this.updateProgress(progress);
-        }
-
-        public int progress() {
-            return GremlinJob.this.progress();
         }
     }
 }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/job/algorithm/SubgraphStatAlgorithm.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/job/algorithm/SubgraphStatAlgorithm.java
@@ -101,8 +101,7 @@ public class SubgraphStatAlgorithm extends AbstractAlgorithm {
         if (copySchema) {
             graph.schema().copyFrom(parent.schema());
         }
-        new HugeScriptTraversal<>(graph.traversal(), "gremlin-groovy",
-                                  script, ImmutableMap.of(),
+        new HugeScriptTraversal<>(graph.traversal(), script, ImmutableMap.of(),
                                   ImmutableMap.of()).iterate();
         graph.tx().commit();
     }

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/RestrictedSchemaTemplateParser.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/RestrictedSchemaTemplateParser.java
@@ -429,7 +429,17 @@ public final class RestrictedSchemaTemplateParser {
             }
         }
 
-        String value = this.input.substring(start, this.offset);
+        int numberEnd = this.offset;
+        if (!this.end() && (this.current() == 'L' ||
+                            this.current() == 'l')) {
+            if (floating) {
+                throw this.error("Long suffix is only allowed for integer " +
+                                 "literals");
+            }
+            this.advance();
+        }
+
+        String value = this.input.substring(start, numberEnd);
         try {
             if (floating) {
                 return Double.valueOf(value);

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/RestrictedSchemaTemplateParser.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/RestrictedSchemaTemplateParser.java
@@ -1,0 +1,831 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.schema;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hugegraph.schema.SchemaTemplatePlan.SchemaCommand;
+import org.apache.hugegraph.schema.SchemaTemplatePlan.SchemaKind;
+import org.apache.hugegraph.schema.SchemaTemplatePlan.SchemaMethod;
+import org.apache.hugegraph.schema.SchemaTemplatePlan.SchemaOperation;
+import org.apache.hugegraph.type.HugeType;
+import org.apache.hugegraph.type.define.AggregateType;
+import org.apache.hugegraph.type.define.Cardinality;
+import org.apache.hugegraph.type.define.DataType;
+import org.apache.hugegraph.type.define.Frequency;
+import org.apache.hugegraph.type.define.IdStrategy;
+import org.apache.hugegraph.type.define.IndexType;
+import org.apache.hugegraph.type.define.WriteType;
+
+public final class RestrictedSchemaTemplateParser {
+
+    private static final int MAX_LITERAL_NESTING = 32;
+    private static final Map<SchemaKind, Map<SchemaMethod, ArgumentRule>>
+            ALLOWED_METHODS = allowedMethods();
+
+    private final String input;
+    private int offset;
+    private int line;
+    private int column;
+    private int literalNesting;
+
+    private RestrictedSchemaTemplateParser(String input) {
+        if (input == null) {
+            throw new IllegalArgumentException(
+                      "Schema template is null at line 1, column 1");
+        }
+        this.input = input;
+        this.offset = 0;
+        this.line = 1;
+        this.column = 1;
+        this.literalNesting = 0;
+    }
+
+    public static SchemaTemplatePlan parse(String template) {
+        return new RestrictedSchemaTemplateParser(template).parseDocument();
+    }
+
+    public static void validate(String template) {
+        parse(template);
+    }
+
+    private SchemaTemplatePlan parseDocument() {
+        this.skipIgnored();
+        this.tryParseSchemaAssignment();
+
+        List<SchemaCommand> commands = new ArrayList<>();
+        this.skipIgnored();
+        while (!this.end()) {
+            commands.add(this.parseCommand());
+            this.skipIgnored();
+        }
+        if (commands.isEmpty()) {
+            throw this.error("Schema template contains no schema commands");
+        }
+        return new SchemaTemplatePlan(commands);
+    }
+
+    private void tryParseSchemaAssignment() {
+        Cursor cursor = this.cursor();
+        if (!this.tryIdentifier("schema")) {
+            return;
+        }
+        this.skipIgnored();
+        if (!this.tryConsume('=')) {
+            this.restore(cursor);
+            return;
+        }
+
+        this.skipIgnored();
+        this.expectIdentifier("graph");
+        this.skipIgnored();
+        this.expect('.');
+        this.skipIgnored();
+        this.expectIdentifier("schema");
+        this.skipIgnored();
+        this.expect('(');
+        this.skipIgnored();
+        this.expect(')');
+        boolean separated = this.end() || this.peek(';') ||
+                            this.ignoredAhead();
+        this.skipIgnored();
+        this.tryConsume(';');
+        this.skipIgnored();
+        if (!separated && !this.end()) {
+            throw this.error("Expected a separator after schema assignment");
+        }
+    }
+
+    private SchemaCommand parseCommand() {
+        String root = this.readIdentifier("schema command root");
+        if ("schema".equals(root)) {
+            this.skipIgnored();
+            this.expect('.');
+        } else if ("graph".equals(root)) {
+            this.skipIgnored();
+            this.expect('.');
+            this.skipIgnored();
+            this.expectIdentifier("schema");
+            this.skipIgnored();
+            this.expect('(');
+            this.skipIgnored();
+            this.expect(')');
+            this.skipIgnored();
+            this.expect('.');
+        } else {
+            throw this.error("Unsupported schema template root '" + root + "'");
+        }
+
+        this.skipIgnored();
+        String builder = this.readIdentifier("schema builder");
+        SchemaKind kind = SchemaKind.fromDsl(builder);
+        if (kind == null) {
+            throw this.error("Unsupported schema builder '" + builder + "'");
+        }
+        this.skipIgnored();
+        this.expect('(');
+        this.skipIgnored();
+        Object name = this.parseLiteral();
+        if (!(name instanceof String)) {
+            throw this.error("Schema name must be a string literal");
+        }
+        this.skipIgnored();
+        this.expect(')');
+
+        List<SchemaOperation> operations = new ArrayList<>();
+        boolean created = false;
+        while (!created) {
+            this.skipIgnored();
+            this.expect('.');
+            this.skipIgnored();
+            String methodName = this.readIdentifier("schema method");
+            SchemaMethod method = SchemaMethod.fromDsl(methodName);
+            if (method == null) {
+                throw this.error("Unsupported schema method '" + methodName + "'");
+            }
+            this.skipIgnored();
+            List<Object> arguments = this.parseArguments();
+            this.validateOperation(kind, method, arguments);
+            operations.add(new SchemaOperation(method, arguments));
+            created = method == SchemaMethod.CREATE;
+        }
+
+        boolean separated = this.end() || this.peek(';') ||
+                            this.ignoredAhead();
+        this.skipIgnored();
+        if (this.peek('.')) {
+            throw this.error("No method is allowed after create()");
+        }
+        if (!this.tryConsume(';') && !separated && !this.end()) {
+            throw this.error("Expected a separator after create()");
+        }
+        return new SchemaCommand(kind, (String) name, operations);
+    }
+
+    private List<Object> parseArguments() {
+        this.expect('(');
+        this.skipIgnored();
+        List<Object> arguments = new ArrayList<>();
+        if (this.tryConsume(')')) {
+            return arguments;
+        }
+
+        while (true) {
+            arguments.add(this.parseLiteral());
+            this.skipIgnored();
+            if (this.tryConsume(')')) {
+                return arguments;
+            }
+            this.expect(',');
+            this.skipIgnored();
+        }
+    }
+
+    private Object parseLiteral() {
+        if (this.end()) {
+            throw this.error("Expected a literal but reached the end");
+        }
+        char current = this.current();
+        if (current == '[') {
+            return this.readCollection();
+        }
+        if (current == '\'' || current == '"') {
+            return this.readString();
+        }
+        if (current == '-' || Character.isDigit(current)) {
+            return this.readNumber();
+        }
+        if (isIdentifierStart(current)) {
+            String identifier = this.readIdentifier("literal");
+            if ("true".equals(identifier)) {
+                return Boolean.TRUE;
+            }
+            if ("false".equals(identifier)) {
+                return Boolean.FALSE;
+            }
+            return this.readEnum(identifier);
+        }
+        throw this.error("Unsupported literal starting with '" + current + "'");
+    }
+
+    private Object readCollection() {
+        if (this.literalNesting >= MAX_LITERAL_NESTING) {
+            throw this.error("Literal nesting exceeds " +
+                             MAX_LITERAL_NESTING + " levels");
+        }
+        this.literalNesting++;
+        try {
+            return this.readCollectionValue();
+        } finally {
+            this.literalNesting--;
+        }
+    }
+
+    private Object readCollectionValue() {
+        this.expect('[');
+        this.skipIgnored();
+        if (this.tryConsume(']')) {
+            return new ArrayList<>();
+        }
+        if (this.tryConsume(':')) {
+            this.skipIgnored();
+            this.expect(']');
+            return new LinkedHashMap<String, Object>();
+        }
+
+        Object first = this.parseLiteral();
+        this.skipIgnored();
+        if (this.tryConsume(':')) {
+            if (!(first instanceof String)) {
+                throw this.error("Map literal keys must be strings");
+            }
+            Map<String, Object> values = new LinkedHashMap<>();
+            this.skipIgnored();
+            this.putMapValue(values, (String) first, this.parseLiteral());
+            this.skipIgnored();
+            while (this.tryConsume(',')) {
+                this.skipIgnored();
+                if (this.tryConsume(']')) {
+                    return values;
+                }
+                Object key = this.parseLiteral();
+                if (!(key instanceof String)) {
+                    throw this.error("Map literal keys must be strings");
+                }
+                this.skipIgnored();
+                this.expect(':');
+                this.skipIgnored();
+                this.putMapValue(values, (String) key, this.parseLiteral());
+                this.skipIgnored();
+            }
+            this.expect(']');
+            return values;
+        }
+
+        List<Object> values = new ArrayList<>();
+        values.add(first);
+        while (this.tryConsume(',')) {
+            this.skipIgnored();
+            if (this.tryConsume(']')) {
+                return values;
+            }
+            values.add(this.parseLiteral());
+            this.skipIgnored();
+        }
+        this.expect(']');
+        return values;
+    }
+
+    private void putMapValue(Map<String, Object> values, String key,
+                             Object value) {
+        if (values.putIfAbsent(key, value) != null) {
+            throw this.error("Duplicate map literal key '" + key + "'");
+        }
+    }
+
+    private Object readEnum(String firstIdentifier) {
+        List<String> parts = new ArrayList<>();
+        parts.add(firstIdentifier);
+        this.skipIgnored();
+        while (this.tryConsume('.')) {
+            this.skipIgnored();
+            parts.add(this.readIdentifier("enum constant"));
+            this.skipIgnored();
+        }
+        if (parts.size() < 2) {
+            throw this.error("Unsupported dynamic value '" + firstIdentifier + "'");
+        }
+
+        String type = parts.get(parts.size() - 2);
+        String constant = parts.get(parts.size() - 1);
+        try {
+            switch (type) {
+                case "WriteType":
+                    return WriteType.valueOf(constant);
+                case "Cardinality":
+                    return Cardinality.valueOf(constant);
+                case "DataType":
+                    return DataType.valueOf(constant);
+                case "AggregateType":
+                    return AggregateType.valueOf(constant);
+                case "IdStrategy":
+                    return IdStrategy.valueOf(constant);
+                case "Frequency":
+                    return Frequency.valueOf(constant);
+                case "IndexType":
+                    return IndexType.valueOf(constant);
+                case "HugeType":
+                    return HugeType.valueOf(constant);
+                default:
+                    throw this.error("Unsupported enum type '" + type + "'");
+            }
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage() != null && e.getMessage().contains("at line")) {
+                throw e;
+            }
+            throw this.error("Unsupported enum constant '" + type + "." +
+                             constant + "'");
+        }
+    }
+
+    private String readString() {
+        char quote = this.current();
+        this.advance();
+        StringBuilder value = new StringBuilder();
+        while (!this.end()) {
+            char current = this.current();
+            this.advance();
+            if (current == quote) {
+                return value.toString();
+            }
+            if (current != '\\') {
+                value.append(current);
+                continue;
+            }
+            if (this.end()) {
+                throw this.error("Unterminated string escape");
+            }
+            char escaped = this.current();
+            this.advance();
+            switch (escaped) {
+                case 'b':
+                    value.append('\b');
+                    break;
+                case 'f':
+                    value.append('\f');
+                    break;
+                case 'n':
+                    value.append('\n');
+                    break;
+                case 'r':
+                    value.append('\r');
+                    break;
+                case 't':
+                    value.append('\t');
+                    break;
+                case '\\':
+                case '\'':
+                case '"':
+                    value.append(escaped);
+                    break;
+                default:
+                    throw this.error("Unsupported string escape '\\" + escaped +
+                                     "'");
+            }
+        }
+        throw this.error("Unterminated string literal");
+    }
+
+    private Number readNumber() {
+        int start = this.offset;
+        this.tryConsume('-');
+        if (this.end() || !Character.isDigit(this.current())) {
+            throw this.error("Invalid numeric literal");
+        }
+        while (!this.end() && Character.isDigit(this.current())) {
+            this.advance();
+        }
+
+        boolean floating = false;
+        if (this.tryConsume('.')) {
+            floating = true;
+            if (this.end() || !Character.isDigit(this.current())) {
+                throw this.error("Invalid numeric literal");
+            }
+            while (!this.end() && Character.isDigit(this.current())) {
+                this.advance();
+            }
+        }
+        if (!this.end() && (this.current() == 'e' || this.current() == 'E')) {
+            floating = true;
+            this.advance();
+            if (!this.end() && (this.current() == '+' || this.current() == '-')) {
+                this.advance();
+            }
+            if (this.end() || !Character.isDigit(this.current())) {
+                throw this.error("Invalid numeric exponent");
+            }
+            while (!this.end() && Character.isDigit(this.current())) {
+                this.advance();
+            }
+        }
+
+        String value = this.input.substring(start, this.offset);
+        try {
+            if (floating) {
+                return Double.valueOf(value);
+            }
+            return Long.valueOf(value);
+        } catch (NumberFormatException e) {
+            throw this.error("Invalid numeric literal '" + value + "'");
+        }
+    }
+
+    private void validateOperation(SchemaKind kind, SchemaMethod method,
+                                   List<Object> arguments) {
+        ArgumentRule rule = ALLOWED_METHODS.get(kind).get(method);
+        if (rule == null) {
+            throw this.error("Method '" + method.dslName() +
+                             "' is not allowed for " + kind.dslName());
+        }
+        String mismatch = rule.validate(arguments);
+        if (mismatch != null) {
+            throw this.error("Invalid arguments for '" + method.dslName() +
+                             "': " + mismatch);
+        }
+    }
+
+    private void skipIgnored() {
+        boolean skipped;
+        do {
+            skipped = false;
+            while (!this.end() && Character.isWhitespace(this.current())) {
+                this.advance();
+                skipped = true;
+            }
+            if (this.startsWith("//")) {
+                skipped = true;
+                while (!this.end() && this.current() != '\n') {
+                    this.advance();
+                }
+            } else if (this.startsWith("/*")) {
+                skipped = true;
+                this.advance();
+                this.advance();
+                while (!this.end() && !this.startsWith("*/")) {
+                    this.advance();
+                }
+                if (this.end()) {
+                    throw this.error("Unterminated block comment");
+                }
+                this.advance();
+                this.advance();
+            }
+        } while (skipped);
+    }
+
+    private String readIdentifier(String description) {
+        if (this.end() || !isIdentifierStart(this.current())) {
+            throw this.error("Expected " + description);
+        }
+        int start = this.offset;
+        this.advance();
+        while (!this.end() && isIdentifierPart(this.current())) {
+            this.advance();
+        }
+        return this.input.substring(start, this.offset);
+    }
+
+    private boolean tryIdentifier(String value) {
+        if (this.end() || !isIdentifierStart(this.current())) {
+            return false;
+        }
+        Cursor cursor = this.cursor();
+        String actual = this.readIdentifier("identifier");
+        if (value.equals(actual)) {
+            return true;
+        }
+        this.restore(cursor);
+        return false;
+    }
+
+    private void expectIdentifier(String value) {
+        String actual = this.readIdentifier("'" + value + "'");
+        if (!value.equals(actual)) {
+            throw this.error("Expected '" + value + "' but found '" + actual +
+                             "'");
+        }
+    }
+
+    private void expect(char expected) {
+        if (!this.tryConsume(expected)) {
+            String actual = this.end() ? "end of template" :
+                            "'" + this.current() + "'";
+            throw this.error("Expected '" + expected + "' but found " + actual);
+        }
+    }
+
+    private boolean tryConsume(char expected) {
+        if (this.end() || this.current() != expected) {
+            return false;
+        }
+        this.advance();
+        return true;
+    }
+
+    private boolean peek(char expected) {
+        return !this.end() && this.current() == expected;
+    }
+
+    private boolean startsWith(String value) {
+        return this.input.startsWith(value, this.offset);
+    }
+
+    private boolean ignoredAhead() {
+        return !this.end() &&
+               (Character.isWhitespace(this.current()) ||
+                this.startsWith("//") || this.startsWith("/*"));
+    }
+
+    private char current() {
+        return this.input.charAt(this.offset);
+    }
+
+    private boolean end() {
+        return this.offset >= this.input.length();
+    }
+
+    private void advance() {
+        char current = this.input.charAt(this.offset++);
+        if (current == '\n') {
+            this.line++;
+            this.column = 1;
+        } else {
+            this.column++;
+        }
+    }
+
+    private Cursor cursor() {
+        return new Cursor(this.offset, this.line, this.column);
+    }
+
+    private void restore(Cursor cursor) {
+        this.offset = cursor.offset;
+        this.line = cursor.line;
+        this.column = cursor.column;
+    }
+
+    private IllegalArgumentException error(String message) {
+        return new IllegalArgumentException(message + " at line " + this.line +
+                                            ", column " + this.column);
+    }
+
+    private static boolean isIdentifierStart(char value) {
+        return value == '_' || value >= 'A' && value <= 'Z' ||
+               value >= 'a' && value <= 'z';
+    }
+
+    private static boolean isIdentifierPart(char value) {
+        return isIdentifierStart(value) || Character.isDigit(value);
+    }
+
+    private static Map<SchemaKind, Map<SchemaMethod, ArgumentRule>>
+                   allowedMethods() {
+        Map<SchemaKind, Map<SchemaMethod, ArgumentRule>> methods =
+                new EnumMap<>(SchemaKind.class);
+        for (SchemaKind kind : SchemaKind.values()) {
+            methods.put(kind, new EnumMap<>(SchemaMethod.class));
+            allow(methods, kind, ArgumentRule.LONG, SchemaMethod.ID);
+            allow(methods, kind, ArgumentRule.USERDATA,
+                  SchemaMethod.USERDATA);
+            allow(methods, kind, ArgumentRule.NONE,
+                  SchemaMethod.IF_NOT_EXIST, SchemaMethod.CREATE);
+            allow(methods, kind, ArgumentRule.BOOLEAN, SchemaMethod.CHECK_EXIST);
+        }
+
+        allow(methods, SchemaKind.PROPERTY_KEY, ArgumentRule.NONE,
+              SchemaMethod.AS_TEXT, SchemaMethod.AS_INT, SchemaMethod.AS_DATE,
+              SchemaMethod.AS_UUID, SchemaMethod.AS_BOOLEAN,
+              SchemaMethod.AS_BYTE, SchemaMethod.AS_BLOB,
+              SchemaMethod.AS_DOUBLE, SchemaMethod.AS_FLOAT,
+              SchemaMethod.AS_LONG, SchemaMethod.VALUE_SINGLE,
+              SchemaMethod.VALUE_LIST, SchemaMethod.VALUE_SET,
+              SchemaMethod.CALC_MAX, SchemaMethod.CALC_MIN,
+              SchemaMethod.CALC_SUM, SchemaMethod.CALC_OLD,
+              SchemaMethod.CALC_SET, SchemaMethod.CALC_LIST);
+        allow(methods, SchemaKind.PROPERTY_KEY,
+              ArgumentRule.enumValue(WriteType.class), SchemaMethod.WRITE_TYPE);
+        allow(methods, SchemaKind.PROPERTY_KEY,
+              ArgumentRule.enumValue(Cardinality.class),
+              SchemaMethod.CARDINALITY);
+        allow(methods, SchemaKind.PROPERTY_KEY,
+              ArgumentRule.enumValue(DataType.class), SchemaMethod.DATA_TYPE);
+        allow(methods, SchemaKind.PROPERTY_KEY,
+              ArgumentRule.enumValue(AggregateType.class),
+              SchemaMethod.AGGREGATE_TYPE);
+
+        allow(methods, SchemaKind.VERTEX_LABEL,
+              ArgumentRule.enumValue(IdStrategy.class),
+              SchemaMethod.ID_STRATEGY);
+        allow(methods, SchemaKind.VERTEX_LABEL, ArgumentRule.NONE,
+              SchemaMethod.USE_AUTOMATIC_ID, SchemaMethod.USE_PRIMARY_KEY_ID,
+              SchemaMethod.USE_CUSTOMIZE_STRING_ID,
+              SchemaMethod.USE_CUSTOMIZE_NUMBER_ID,
+              SchemaMethod.USE_CUSTOMIZE_UUID_ID);
+        allow(methods, SchemaKind.VERTEX_LABEL, ArgumentRule.STRINGS,
+              SchemaMethod.PROPERTIES, SchemaMethod.PRIMARY_KEYS,
+              SchemaMethod.NULLABLE_KEYS);
+        allow(methods, SchemaKind.VERTEX_LABEL, ArgumentRule.LONG,
+              SchemaMethod.TTL);
+        allow(methods, SchemaKind.VERTEX_LABEL, ArgumentRule.STRING,
+              SchemaMethod.TTL_START_TIME);
+        allow(methods, SchemaKind.VERTEX_LABEL, ArgumentRule.BOOLEAN,
+              SchemaMethod.ENABLE_LABEL_INDEX);
+
+        allow(methods, SchemaKind.EDGE_LABEL, ArgumentRule.NONE,
+              SchemaMethod.AS_BASE, SchemaMethod.SINGLE_TIME,
+              SchemaMethod.MULTI_TIMES);
+        allow(methods, SchemaKind.EDGE_LABEL, ArgumentRule.STRING,
+              SchemaMethod.WITH_BASE, SchemaMethod.SOURCE_LABEL,
+              SchemaMethod.TARGET_LABEL, SchemaMethod.TTL_START_TIME);
+        allow(methods, SchemaKind.EDGE_LABEL, ArgumentRule.TWO_STRINGS,
+              SchemaMethod.LINK);
+        allow(methods, SchemaKind.EDGE_LABEL, ArgumentRule.STRINGS,
+              SchemaMethod.SORT_KEYS, SchemaMethod.PROPERTIES,
+              SchemaMethod.NULLABLE_KEYS);
+        allow(methods, SchemaKind.EDGE_LABEL,
+              ArgumentRule.enumValue(Frequency.class), SchemaMethod.FREQUENCY);
+        allow(methods, SchemaKind.EDGE_LABEL, ArgumentRule.LONG,
+              SchemaMethod.TTL);
+        allow(methods, SchemaKind.EDGE_LABEL, ArgumentRule.BOOLEAN,
+              SchemaMethod.ENABLE_LABEL_INDEX);
+
+        allow(methods, SchemaKind.INDEX_LABEL, ArgumentRule.STRING,
+              SchemaMethod.ON_V, SchemaMethod.ON_E);
+        allow(methods, SchemaKind.INDEX_LABEL, ArgumentRule.STRINGS,
+              SchemaMethod.BY);
+        allow(methods, SchemaKind.INDEX_LABEL, ArgumentRule.NONE,
+              SchemaMethod.SECONDARY, SchemaMethod.RANGE, SchemaMethod.SEARCH,
+              SchemaMethod.SHARD, SchemaMethod.UNIQUE);
+        allow(methods, SchemaKind.INDEX_LABEL,
+              ArgumentRule.ENUM_HUGE_TYPE_AND_STRING, SchemaMethod.ON);
+        allow(methods, SchemaKind.INDEX_LABEL,
+              ArgumentRule.enumValue(IndexType.class), SchemaMethod.INDEX_TYPE);
+        allow(methods, SchemaKind.INDEX_LABEL, ArgumentRule.BOOLEAN,
+              SchemaMethod.REBUILD);
+        return methods;
+    }
+
+    private static void allow(
+                        Map<SchemaKind, Map<SchemaMethod, ArgumentRule>> methods,
+                        SchemaKind kind, ArgumentRule rule,
+                        SchemaMethod... allowed) {
+        for (SchemaMethod method : allowed) {
+            methods.get(kind).put(method, rule);
+        }
+    }
+
+    private static final class Cursor {
+
+        private final int offset;
+        private final int line;
+        private final int column;
+
+        private Cursor(int offset, int line, int column) {
+            this.offset = offset;
+            this.line = line;
+            this.column = column;
+        }
+    }
+
+    private static final class ArgumentRule {
+
+        private static final ArgumentRule NONE = new ArgumentRule(Kind.NONE,
+                                                                  null);
+        private static final ArgumentRule LONG = new ArgumentRule(Kind.LONG,
+                                                                  null);
+        private static final ArgumentRule BOOLEAN =
+                new ArgumentRule(Kind.BOOLEAN, null);
+        private static final ArgumentRule STRING =
+                new ArgumentRule(Kind.STRING, null);
+        private static final ArgumentRule STRINGS =
+                new ArgumentRule(Kind.STRINGS, null);
+        private static final ArgumentRule TWO_STRINGS =
+                new ArgumentRule(Kind.TWO_STRINGS, null);
+        private static final ArgumentRule USERDATA =
+                new ArgumentRule(Kind.USERDATA, null);
+        private static final ArgumentRule ENUM_HUGE_TYPE_AND_STRING =
+                new ArgumentRule(Kind.ENUM_HUGE_TYPE_AND_STRING, null);
+
+        private final Kind kind;
+        private final Class<? extends Enum<?>> enumType;
+
+        private ArgumentRule(Kind kind, Class<? extends Enum<?>> enumType) {
+            this.kind = kind;
+            this.enumType = enumType;
+        }
+
+        private static ArgumentRule enumValue(
+                                    Class<? extends Enum<?>> enumType) {
+            return new ArgumentRule(Kind.ENUM, enumType);
+        }
+
+        private String validate(List<Object> arguments) {
+            switch (this.kind) {
+                case NONE:
+                    return arguments.isEmpty() ? null : "expected no arguments";
+                case LONG:
+                    return exact(arguments, 1, Long.class, "one integer");
+                case BOOLEAN:
+                    return exact(arguments, 1, Boolean.class, "one boolean");
+                case STRING:
+                    return exact(arguments, 1, String.class, "one string");
+                case STRINGS:
+                    if (arguments.isEmpty()) {
+                        return "expected at least one string";
+                    }
+                    if (arguments.size() == 1 &&
+                        arguments.get(0) instanceof List) {
+                        List<?> values = (List<?>) arguments.get(0);
+                        if (values.isEmpty()) {
+                            return "expected at least one string";
+                        }
+                        return all(values, String.class,
+                                   "expected only string arguments");
+                    }
+                    return all(arguments, String.class,
+                               "expected only string arguments");
+                case TWO_STRINGS:
+                    if (arguments.size() != 2) {
+                        return "expected two strings";
+                    }
+                    return all(arguments, String.class, "expected two strings");
+                case USERDATA:
+                    if (arguments.size() == 1 &&
+                        arguments.get(0) instanceof Map) {
+                        return mapKeys((Map<?, ?>) arguments.get(0),
+                                       String.class,
+                                       "expected only string map keys");
+                    }
+                    if (arguments.size() == 2 &&
+                        arguments.get(0) instanceof String) {
+                        return null;
+                    }
+                    return "expected a map or a string key and literal value";
+                case ENUM:
+                    return exact(arguments, 1, this.enumType,
+                                 "one " + this.enumType.getSimpleName() +
+                                 " constant");
+                case ENUM_HUGE_TYPE_AND_STRING:
+                    if (arguments.size() != 2 ||
+                        !(arguments.get(0) instanceof HugeType) ||
+                        !(arguments.get(1) instanceof String)) {
+                        return "expected a HugeType constant and one string";
+                    }
+                    return null;
+                default:
+                    throw new AssertionError("Unknown argument rule " + this.kind);
+            }
+        }
+
+        private static String exact(List<Object> arguments, int count,
+                                    Class<?> type, String description) {
+            if (arguments.size() != count ||
+                !type.isInstance(arguments.get(0))) {
+                return "expected " + description;
+            }
+            return null;
+        }
+
+        private static String all(List<?> arguments, Class<?> type,
+                                  String description) {
+            for (Object argument : arguments) {
+                if (!type.isInstance(argument)) {
+                    return description;
+                }
+            }
+            return null;
+        }
+
+        private static String mapKeys(Map<?, ?> arguments, Class<?> type,
+                                      String description) {
+            for (Object key : arguments.keySet()) {
+                if (!type.isInstance(key)) {
+                    return description;
+                }
+            }
+            return null;
+        }
+
+        private enum Kind {
+            NONE,
+            LONG,
+            BOOLEAN,
+            STRING,
+            STRINGS,
+            TWO_STRINGS,
+            USERDATA,
+            ENUM,
+            ENUM_HUGE_TYPE_AND_STRING
+        }
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/SchemaTemplateExecutor.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/SchemaTemplateExecutor.java
@@ -1,0 +1,456 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.schema;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hugegraph.HugeGraph;
+import org.apache.hugegraph.schema.SchemaTemplatePlan.SchemaCommand;
+import org.apache.hugegraph.schema.SchemaTemplatePlan.SchemaOperation;
+import org.apache.hugegraph.schema.builder.SchemaBuilder;
+import org.apache.hugegraph.type.HugeType;
+import org.apache.hugegraph.type.define.AggregateType;
+import org.apache.hugegraph.type.define.Cardinality;
+import org.apache.hugegraph.type.define.DataType;
+import org.apache.hugegraph.type.define.Frequency;
+import org.apache.hugegraph.type.define.IdStrategy;
+import org.apache.hugegraph.type.define.IndexType;
+import org.apache.hugegraph.type.define.WriteType;
+import org.apache.hugegraph.util.E;
+
+public final class SchemaTemplateExecutor {
+
+    private SchemaTemplateExecutor() {
+    }
+
+    public static void execute(HugeGraph graph, String template) {
+        execute(graph, RestrictedSchemaTemplateParser.parse(template));
+    }
+
+    public static void execute(HugeGraph graph, SchemaTemplatePlan plan) {
+        E.checkNotNull(graph, "graph");
+        E.checkNotNull(plan, "schema template plan");
+        for (SchemaCommand command : plan.commands()) {
+            switch (command.kind()) {
+                case PROPERTY_KEY:
+                    executePropertyKey(graph, command);
+                    break;
+                case VERTEX_LABEL:
+                    executeVertexLabel(graph, command);
+                    break;
+                case EDGE_LABEL:
+                    executeEdgeLabel(graph, command);
+                    break;
+                case INDEX_LABEL:
+                    executeIndexLabel(graph, command);
+                    break;
+                default:
+                    throw new AssertionError("Unknown schema kind " +
+                                             command.kind());
+            }
+        }
+    }
+
+    private static void executePropertyKey(HugeGraph graph,
+                                           SchemaCommand command) {
+        PropertyKey.Builder builder = graph.schema().propertyKey(command.name());
+        for (SchemaOperation operation : command.operations()) {
+            if (applyCommon(builder, operation)) {
+                continue;
+            }
+            switch (operation.method()) {
+                case AS_TEXT:
+                    builder.asText();
+                    break;
+                case AS_INT:
+                    builder.asInt();
+                    break;
+                case AS_DATE:
+                    builder.asDate();
+                    break;
+                case AS_UUID:
+                    builder.asUUID();
+                    break;
+                case AS_BOOLEAN:
+                    builder.asBoolean();
+                    break;
+                case AS_BYTE:
+                    builder.asByte();
+                    break;
+                case AS_BLOB:
+                    builder.asBlob();
+                    break;
+                case AS_DOUBLE:
+                    builder.asDouble();
+                    break;
+                case AS_FLOAT:
+                    builder.asFloat();
+                    break;
+                case AS_LONG:
+                    builder.asLong();
+                    break;
+                case VALUE_SINGLE:
+                    builder.valueSingle();
+                    break;
+                case VALUE_LIST:
+                    builder.valueList();
+                    break;
+                case VALUE_SET:
+                    builder.valueSet();
+                    break;
+                case CALC_MAX:
+                    builder.calcMax();
+                    break;
+                case CALC_MIN:
+                    builder.calcMin();
+                    break;
+                case CALC_SUM:
+                    builder.calcSum();
+                    break;
+                case CALC_OLD:
+                    builder.calcOld();
+                    break;
+                case CALC_SET:
+                    builder.calcSet();
+                    break;
+                case CALC_LIST:
+                    builder.calcList();
+                    break;
+                case WRITE_TYPE:
+                    builder.writeType(argument(operation, 0, WriteType.class));
+                    break;
+                case CARDINALITY:
+                    builder.cardinality(argument(operation, 0,
+                                                 Cardinality.class));
+                    break;
+                case DATA_TYPE:
+                    builder.dataType(argument(operation, 0, DataType.class));
+                    break;
+                case AGGREGATE_TYPE:
+                    builder.aggregateType(argument(operation, 0,
+                                                   AggregateType.class));
+                    break;
+                case USERDATA:
+                    applyUserdata(builder, operation);
+                    break;
+                default:
+                    throw unexpected(command, operation);
+            }
+        }
+    }
+
+    private static void executeVertexLabel(HugeGraph graph,
+                                           SchemaCommand command) {
+        VertexLabel.Builder builder = graph.schema().vertexLabel(command.name());
+        for (SchemaOperation operation : command.operations()) {
+            if (applyCommon(builder, operation)) {
+                continue;
+            }
+            switch (operation.method()) {
+                case ID_STRATEGY:
+                    builder.idStrategy(argument(operation, 0, IdStrategy.class));
+                    break;
+                case USE_AUTOMATIC_ID:
+                    builder.useAutomaticId();
+                    break;
+                case USE_PRIMARY_KEY_ID:
+                    builder.usePrimaryKeyId();
+                    break;
+                case USE_CUSTOMIZE_STRING_ID:
+                    builder.useCustomizeStringId();
+                    break;
+                case USE_CUSTOMIZE_NUMBER_ID:
+                    builder.useCustomizeNumberId();
+                    break;
+                case USE_CUSTOMIZE_UUID_ID:
+                    builder.useCustomizeUuidId();
+                    break;
+                case PROPERTIES:
+                    builder.properties(strings(operation));
+                    break;
+                case PRIMARY_KEYS:
+                    builder.primaryKeys(strings(operation));
+                    break;
+                case NULLABLE_KEYS:
+                    builder.nullableKeys(strings(operation));
+                    break;
+                case TTL:
+                    builder.ttl(integer(operation, 0));
+                    break;
+                case TTL_START_TIME:
+                    builder.ttlStartTime(string(operation, 0));
+                    break;
+                case ENABLE_LABEL_INDEX:
+                    builder.enableLabelIndex(bool(operation, 0));
+                    break;
+                case USERDATA:
+                    applyUserdata(builder, operation);
+                    break;
+                default:
+                    throw unexpected(command, operation);
+            }
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void executeEdgeLabel(HugeGraph graph,
+                                         SchemaCommand command) {
+        EdgeLabel.Builder builder = graph.schema().edgeLabel(command.name());
+        for (SchemaOperation operation : command.operations()) {
+            if (applyCommon(builder, operation)) {
+                continue;
+            }
+            switch (operation.method()) {
+                case AS_BASE:
+                    builder.asBase();
+                    break;
+                case WITH_BASE:
+                    builder.withBase(string(operation, 0));
+                    break;
+                case LINK:
+                    builder.link(string(operation, 0), string(operation, 1));
+                    break;
+                case SOURCE_LABEL:
+                    builder.sourceLabel(string(operation, 0));
+                    break;
+                case TARGET_LABEL:
+                    builder.targetLabel(string(operation, 0));
+                    break;
+                case SINGLE_TIME:
+                    builder.singleTime();
+                    break;
+                case MULTI_TIMES:
+                    builder.multiTimes();
+                    break;
+                case SORT_KEYS:
+                    builder.sortKeys(strings(operation));
+                    break;
+                case PROPERTIES:
+                    builder.properties(strings(operation));
+                    break;
+                case NULLABLE_KEYS:
+                    builder.nullableKeys(strings(operation));
+                    break;
+                case FREQUENCY:
+                    builder.frequency(argument(operation, 0, Frequency.class));
+                    break;
+                case TTL:
+                    builder.ttl(integer(operation, 0));
+                    break;
+                case TTL_START_TIME:
+                    builder.ttlStartTime(string(operation, 0));
+                    break;
+                case ENABLE_LABEL_INDEX:
+                    builder.enableLabelIndex(bool(operation, 0));
+                    break;
+                case USERDATA:
+                    applyUserdata(builder, operation);
+                    break;
+                default:
+                    throw unexpected(command, operation);
+            }
+        }
+    }
+
+    private static void executeIndexLabel(HugeGraph graph,
+                                          SchemaCommand command) {
+        IndexLabel.Builder builder = graph.schema().indexLabel(command.name());
+        for (SchemaOperation operation : command.operations()) {
+            if (applyCommon(builder, operation)) {
+                continue;
+            }
+            switch (operation.method()) {
+                case ON_V:
+                    builder.onV(string(operation, 0));
+                    break;
+                case ON_E:
+                    builder.onE(string(operation, 0));
+                    break;
+                case BY:
+                    builder.by(strings(operation));
+                    break;
+                case SECONDARY:
+                    builder.secondary();
+                    break;
+                case RANGE:
+                    builder.range();
+                    break;
+                case SEARCH:
+                    builder.search();
+                    break;
+                case SHARD:
+                    builder.shard();
+                    break;
+                case UNIQUE:
+                    builder.unique();
+                    break;
+                case ON:
+                    builder.on(argument(operation, 0, HugeType.class),
+                               string(operation, 1));
+                    break;
+                case INDEX_TYPE:
+                    builder.indexType(argument(operation, 0, IndexType.class));
+                    break;
+                case USERDATA:
+                    applyUserdata(builder, operation);
+                    break;
+                case REBUILD:
+                    builder.rebuild(bool(operation, 0));
+                    break;
+                default:
+                    throw unexpected(command, operation);
+            }
+        }
+    }
+
+    private static boolean applyCommon(SchemaBuilder<?> builder,
+                                       SchemaOperation operation) {
+        switch (operation.method()) {
+            case ID:
+                builder.id(integer(operation, 0));
+                return true;
+            case IF_NOT_EXIST:
+                builder.ifNotExist();
+                return true;
+            case CHECK_EXIST:
+                builder.checkExist(bool(operation, 0));
+                return true;
+            case CREATE:
+                builder.create();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static IllegalArgumentException unexpected(
+                                            SchemaCommand command,
+                                            SchemaOperation operation) {
+        return new IllegalArgumentException(
+                   "Unexpected method '" + operation.method().dslName() +
+                   "' for " + command.kind().dslName());
+    }
+
+    private static String string(SchemaOperation operation, int index) {
+        return argument(operation, index, String.class);
+    }
+
+    private static long integer(SchemaOperation operation, int index) {
+        return argument(operation, index, Long.class);
+    }
+
+    private static boolean bool(SchemaOperation operation, int index) {
+        return argument(operation, index, Boolean.class);
+    }
+
+    private static Object value(SchemaOperation operation, int index) {
+        return operation.arguments().get(index);
+    }
+
+    private static String[] strings(SchemaOperation operation) {
+        List<Object> arguments = operation.arguments();
+        if (arguments.size() == 1 && arguments.get(0) instanceof List) {
+            @SuppressWarnings("unchecked")
+            List<Object> values = (List<Object>) arguments.get(0);
+            return strings(operation, values);
+        }
+        return strings(operation, arguments);
+    }
+
+    private static String[] strings(SchemaOperation operation,
+                                    List<Object> arguments) {
+        String[] values = new String[arguments.size()];
+        for (int i = 0; i < arguments.size(); i++) {
+            Object value = arguments.get(i);
+            if (!(value instanceof String)) {
+                throw new IllegalArgumentException(
+                          "Expected String for method '" +
+                          operation.method().dslName() + "' argument " + i);
+            }
+            values[i] = (String) value;
+        }
+        return values;
+    }
+
+    private static void applyUserdata(PropertyKey.Builder builder,
+                                      SchemaOperation operation) {
+        if (operation.arguments().size() == 1) {
+            builder.userdata(userdata(operation));
+        } else {
+            builder.userdata(string(operation, 0), value(operation, 1));
+        }
+    }
+
+    private static void applyUserdata(VertexLabel.Builder builder,
+                                      SchemaOperation operation) {
+        if (operation.arguments().size() == 1) {
+            builder.userdata(userdata(operation));
+        } else {
+            builder.userdata(string(operation, 0), value(operation, 1));
+        }
+    }
+
+    private static void applyUserdata(EdgeLabel.Builder builder,
+                                      SchemaOperation operation) {
+        if (operation.arguments().size() == 1) {
+            builder.userdata(userdata(operation));
+        } else {
+            builder.userdata(string(operation, 0), value(operation, 1));
+        }
+    }
+
+    private static void applyUserdata(IndexLabel.Builder builder,
+                                      SchemaOperation operation) {
+        if (operation.arguments().size() == 1) {
+            builder.userdata(userdata(operation));
+        } else {
+            builder.userdata(string(operation, 0), value(operation, 1));
+        }
+    }
+
+    private static Map<String, Object> userdata(SchemaOperation operation) {
+        Object value = operation.arguments().get(0);
+        if (!(value instanceof Map)) {
+            throw new IllegalArgumentException(
+                      "Expected Map for method 'userdata' argument 0");
+        }
+        Map<?, ?> source = (Map<?, ?>) value;
+        Map<String, Object> userdata = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : source.entrySet()) {
+            if (!(entry.getKey() instanceof String)) {
+                throw new IllegalArgumentException(
+                          "Expected String key for method 'userdata'");
+            }
+            userdata.put((String) entry.getKey(), entry.getValue());
+        }
+        return userdata;
+    }
+
+    private static <T> T argument(SchemaOperation operation, int index,
+                                  Class<T> type) {
+        Object value = operation.arguments().get(index);
+        if (!type.isInstance(value)) {
+            throw new IllegalArgumentException(
+                      "Expected " + type.getSimpleName() + " for method '" +
+                      operation.method().dslName() + "' argument " + index);
+        }
+        return type.cast(value);
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/SchemaTemplatePlan.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/schema/SchemaTemplatePlan.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.schema;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hugegraph.util.E;
+
+public final class SchemaTemplatePlan {
+
+    private final List<SchemaCommand> commands;
+
+    SchemaTemplatePlan(List<SchemaCommand> commands) {
+        E.checkArgument(commands != null && !commands.isEmpty(),
+                        "Schema template must contain at least one command");
+        this.commands = immutableCopy(commands);
+    }
+
+    public List<SchemaCommand> commands() {
+        return this.commands;
+    }
+
+    private static <T> List<T> immutableCopy(List<T> values) {
+        return Collections.unmodifiableList(new ArrayList<>(values));
+    }
+
+    public enum SchemaKind {
+        PROPERTY_KEY("propertyKey"),
+        VERTEX_LABEL("vertexLabel"),
+        EDGE_LABEL("edgeLabel"),
+        INDEX_LABEL("indexLabel");
+
+        private final String dslName;
+
+        SchemaKind(String dslName) {
+            this.dslName = dslName;
+        }
+
+        public String dslName() {
+            return this.dslName;
+        }
+
+        static SchemaKind fromDsl(String name) {
+            for (SchemaKind kind : values()) {
+                if (kind.dslName.equals(name)) {
+                    return kind;
+                }
+            }
+            return null;
+        }
+    }
+
+    public enum SchemaMethod {
+        ID("id"),
+        AS_TEXT("asText"),
+        AS_INT("asInt"),
+        AS_DATE("asDate"),
+        AS_UUID("asUUID"),
+        AS_BOOLEAN("asBoolean"),
+        AS_BYTE("asByte"),
+        AS_BLOB("asBlob"),
+        AS_DOUBLE("asDouble"),
+        AS_FLOAT("asFloat"),
+        AS_LONG("asLong"),
+        VALUE_SINGLE("valueSingle"),
+        VALUE_LIST("valueList"),
+        VALUE_SET("valueSet"),
+        CALC_MAX("calcMax"),
+        CALC_MIN("calcMin"),
+        CALC_SUM("calcSum"),
+        CALC_OLD("calcOld"),
+        CALC_SET("calcSet"),
+        CALC_LIST("calcList"),
+        WRITE_TYPE("writeType"),
+        CARDINALITY("cardinality"),
+        DATA_TYPE("dataType"),
+        AGGREGATE_TYPE("aggregateType"),
+        USERDATA("userdata"),
+        IF_NOT_EXIST("ifNotExist"),
+        CHECK_EXIST("checkExist"),
+        ID_STRATEGY("idStrategy"),
+        USE_AUTOMATIC_ID("useAutomaticId"),
+        USE_PRIMARY_KEY_ID("usePrimaryKeyId"),
+        USE_CUSTOMIZE_STRING_ID("useCustomizeStringId"),
+        USE_CUSTOMIZE_NUMBER_ID("useCustomizeNumberId"),
+        USE_CUSTOMIZE_UUID_ID("useCustomizeUuidId"),
+        PROPERTIES("properties"),
+        PRIMARY_KEYS("primaryKeys"),
+        NULLABLE_KEYS("nullableKeys"),
+        TTL("ttl"),
+        TTL_START_TIME("ttlStartTime"),
+        ENABLE_LABEL_INDEX("enableLabelIndex"),
+        AS_BASE("asBase"),
+        WITH_BASE("withBase"),
+        LINK("link"),
+        SOURCE_LABEL("sourceLabel"),
+        TARGET_LABEL("targetLabel"),
+        SINGLE_TIME("singleTime"),
+        MULTI_TIMES("multiTimes"),
+        SORT_KEYS("sortKeys"),
+        FREQUENCY("frequency"),
+        ON_V("onV"),
+        ON_E("onE"),
+        BY("by"),
+        SECONDARY("secondary"),
+        RANGE("range"),
+        SEARCH("search"),
+        SHARD("shard"),
+        UNIQUE("unique"),
+        ON("on"),
+        INDEX_TYPE("indexType"),
+        REBUILD("rebuild"),
+        CREATE("create");
+
+        private static final Map<String, SchemaMethod> METHODS_BY_DSL_NAME;
+
+        static {
+            Map<String, SchemaMethod> methods = new HashMap<>();
+            for (SchemaMethod method : values()) {
+                methods.put(method.dslName, method);
+            }
+            METHODS_BY_DSL_NAME = Collections.unmodifiableMap(methods);
+        }
+
+        private final String dslName;
+
+        SchemaMethod(String dslName) {
+            this.dslName = dslName;
+        }
+
+        public String dslName() {
+            return this.dslName;
+        }
+
+        static SchemaMethod fromDsl(String name) {
+            return METHODS_BY_DSL_NAME.get(name);
+        }
+    }
+
+    public static final class SchemaCommand {
+
+        private final SchemaKind kind;
+        private final String name;
+        private final List<SchemaOperation> operations;
+
+        SchemaCommand(SchemaKind kind, String name,
+                      List<SchemaOperation> operations) {
+            E.checkNotNull(kind, "schema kind");
+            E.checkNotNull(name, "schema name");
+            E.checkNotNull(operations, "schema operations");
+            this.kind = kind;
+            this.name = name;
+            this.operations = immutableCopy(operations);
+        }
+
+        public SchemaKind kind() {
+            return this.kind;
+        }
+
+        public String name() {
+            return this.name;
+        }
+
+        public List<SchemaOperation> operations() {
+            return this.operations;
+        }
+    }
+
+    public static final class SchemaOperation {
+
+        private final SchemaMethod method;
+        private final List<Object> arguments;
+
+        SchemaOperation(SchemaMethod method, List<Object> arguments) {
+            E.checkNotNull(method, "schema method");
+            E.checkNotNull(arguments, "schema arguments");
+            this.method = method;
+            this.arguments = immutableArguments(arguments);
+        }
+
+        public SchemaMethod method() {
+            return this.method;
+        }
+
+        public List<Object> arguments() {
+            return this.arguments;
+        }
+
+        private static List<Object> immutableArguments(List<Object> values) {
+            List<Object> copy = new ArrayList<>(values.size());
+            for (Object value : values) {
+                copy.add(immutableValue(value));
+            }
+            return Collections.unmodifiableList(copy);
+        }
+
+        private static Object immutableValue(Object value) {
+            if (value instanceof List) {
+                @SuppressWarnings("unchecked")
+                List<Object> list = (List<Object>) value;
+                return immutableArguments(list);
+            }
+            if (value instanceof Map) {
+                Map<?, ?> map = (Map<?, ?>) value;
+                Map<Object, Object> copy = new LinkedHashMap<>();
+                for (Map.Entry<?, ?> entry : map.entrySet()) {
+                    copy.put(entry.getKey(), immutableValue(entry.getValue()));
+                }
+                return Collections.unmodifiableMap(copy);
+            }
+            return value;
+        }
+    }
+}

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugeScriptTraversal.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugeScriptTraversal.java
@@ -54,7 +54,6 @@ public final class HugeScriptTraversal<S, E> extends DefaultTraversal<S, E> {
     private final GraphTraversalSource traversalSource;
     private final String script;
     private final Map<String, Object> bindings;
-    private final Map<String, String> aliases;
 
     private Object result;
 
@@ -70,12 +69,14 @@ public final class HugeScriptTraversal<S, E> extends DefaultTraversal<S, E> {
         org.apache.hugegraph.util.E.checkArgument(
                 traversalSource instanceof GraphTraversalSource,
                 "The traversal source must be a GraphTraversalSource");
+        org.apache.hugegraph.util.E.checkArgument(
+                aliases.isEmpty(),
+                "Gremlin aliases are not supported by gremlin-lang");
         this.graph = traversalSource.getGraph();
         this.traversalSource = (GraphTraversalSource) traversalSource;
         this.strategies = traversalSource.getStrategies().clone();
         this.script = script;
         this.bindings = bindings;
-        this.aliases = aliases;
         this.result = null;
     }
 
@@ -115,17 +116,6 @@ public final class HugeScriptTraversal<S, E> extends DefaultTraversal<S, E> {
             GraphTraversalSource protectedSource =
                     engine.add(this.traversalSource.clone());
             bindings.put("g", protectedSource);
-            bindings.put("graph", protectedSource);
-
-            for (Map.Entry<String, String> entry : this.aliases.entrySet()) {
-                Object value = bindings.get(entry.getValue());
-                if (value == null) {
-                    throw new IllegalArgumentException(String.format(
-                              "Invalid alias '%s':'%s'", entry.getKey(),
-                              entry.getValue()));
-                }
-                bindings.put(entry.getKey(), value);
-            }
 
             Object result = engine.eval(this.script, bindings);
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugeScriptTraversal.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/traversal/optimize/HugeScriptTraversal.java
@@ -19,23 +19,28 @@
 
 package org.apache.hugegraph.traversal.optimize;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import javax.script.Bindings;
-import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
 import org.apache.hugegraph.HugeException;
-import org.apache.tinkerpop.gremlin.jsr223.SingleGremlinScriptEngineManager;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngine;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
+import org.apache.tinkerpop.gremlin.jsr223.Customizer;
+import org.apache.tinkerpop.gremlin.jsr223.GremlinLangPlugin;
+import org.apache.tinkerpop.gremlin.jsr223.VariableResolverPlugin;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversal;
 
 /**
- * ScriptTraversal encapsulates a {@link ScriptEngine} and a script which is
- * compiled into a {@link Traversal} at {@link Admin#applyStrategies()}.
+ * HugeScriptTraversal parses a GremlinLang query into a {@link Traversal} at
+ * {@link Admin#applyStrategies()} through HugeGraph's protected engine.
  * <p>
  * This is useful for serializing traversals as the compilation can happen on
  * the remote end where the traversal will ultimately be processed.
@@ -46,21 +51,47 @@ public final class HugeScriptTraversal<S, E> extends DefaultTraversal<S, E> {
 
     private static final long serialVersionUID = 4617322697747299673L;
 
+    private final GraphTraversalSource traversalSource;
     private final String script;
-    private final String language;
     private final Map<String, Object> bindings;
     private final Map<String, String> aliases;
 
     private Object result;
 
-    public HugeScriptTraversal(TraversalSource traversalSource, String language, String script,
-                               Map<String, Object> bindings, Map<String, String> aliases) {
+    public HugeScriptTraversal(TraversalSource traversalSource, String script,
+                               Map<String, Object> bindings,
+                               Map<String, String> aliases) {
+        org.apache.hugegraph.util.E.checkNotNull(traversalSource,
+                                                 "traversal source");
+        org.apache.hugegraph.util.E.checkNotNull(script, "gremlin script");
+        org.apache.hugegraph.util.E.checkNotNull(bindings,
+                                                 "gremlin bindings");
+        org.apache.hugegraph.util.E.checkNotNull(aliases, "gremlin aliases");
+        org.apache.hugegraph.util.E.checkArgument(
+                traversalSource instanceof GraphTraversalSource,
+                "The traversal source must be a GraphTraversalSource");
         this.graph = traversalSource.getGraph();
-        this.language = language;
+        this.traversalSource = (GraphTraversalSource) traversalSource;
+        this.strategies = traversalSource.getStrategies().clone();
         this.script = script;
         this.bindings = bindings;
         this.aliases = aliases;
         this.result = null;
+    }
+
+    /**
+     * Kept for callers compiled against the former language-selecting API.
+     * The language can no longer select an arbitrary JSR-223 engine.
+     */
+    @Deprecated
+    public HugeScriptTraversal(TraversalSource traversalSource, String language,
+                               String script, Map<String, Object> bindings,
+                               Map<String, String> aliases) {
+        this(traversalSource, script, bindings, aliases);
+        org.apache.hugegraph.util.E.checkArgument(
+                HugeGraphGremlinLangScriptEngineFactory.ENGINE_NAME.equals(
+                        language),
+                "The language must be 'gremlin-lang', but got '%s'", language);
     }
 
     public Object result() {
@@ -73,31 +104,29 @@ public final class HugeScriptTraversal<S, E> extends DefaultTraversal<S, E> {
 
     @Override
     public void applyStrategies() throws IllegalStateException {
-        ScriptEngine engine = SingleGremlinScriptEngineManager.get(this.language);
-
-        Bindings bindings = engine.createBindings();
-        bindings.putAll(this.bindings);
-
-        @SuppressWarnings("rawtypes")
-        TraversalStrategy[] strategies = this.getStrategies().toList()
-                                             .toArray(new TraversalStrategy[0]);
-        GraphTraversalSource g = this.graph.traversal();
-        if (strategies.length > 0) {
-            g = g.withStrategies(strategies);
-        }
-        bindings.put("g", g);
-        bindings.put("graph", this.graph);
-
-        for (Map.Entry<String, String> entry : this.aliases.entrySet()) {
-            Object value = bindings.get(entry.getValue());
-            if (value == null) {
-                throw new IllegalArgumentException(String.format("Invalid alias '%s':'%s'",
-                                                                 entry.getKey(), entry.getValue()));
-            }
-            bindings.put(entry.getKey(), value);
-        }
+        HugeGraphGremlinLangScriptEngineFactory factory =
+                new HugeGraphGremlinLangScriptEngineFactory(customizers());
+        HugeGraphGremlinLangScriptEngine engine = factory.getScriptEngine();
 
         try {
+            Bindings bindings = engine.createBindings();
+            bindings.putAll(this.bindings);
+
+            GraphTraversalSource protectedSource =
+                    engine.add(this.traversalSource.clone());
+            bindings.put("g", protectedSource);
+            bindings.put("graph", protectedSource);
+
+            for (Map.Entry<String, String> entry : this.aliases.entrySet()) {
+                Object value = bindings.get(entry.getValue());
+                if (value == null) {
+                    throw new IllegalArgumentException(String.format(
+                              "Invalid alias '%s':'%s'", entry.getKey(),
+                              entry.getValue()));
+                }
+                bindings.put(entry.getKey(), value);
+            }
+
             Object result = engine.eval(this.script, bindings);
 
             if (result instanceof Admin) {
@@ -112,6 +141,28 @@ public final class HugeScriptTraversal<S, E> extends DefaultTraversal<S, E> {
             super.applyStrategies();
         } catch (ScriptException e) {
             throw new HugeException(e.getMessage(), e);
+        } finally {
+            engine.clear();
         }
+    }
+
+    private static Customizer[] customizers() {
+        List<Customizer> customizers = new ArrayList<>();
+        GremlinLangPlugin gremlinLang = GremlinLangPlugin.build()
+                                                          .cacheEnabled(false)
+                                                          .create();
+        customizers.addAll(Arrays.asList(
+                gremlinLang.getCustomizers(
+                        HugeGraphGremlinLangScriptEngineFactory.ENGINE_NAME)
+                           .get()));
+        VariableResolverPlugin variables =
+                VariableResolverPlugin.build()
+                                      .resolver("DefaultVariableResolver")
+                                      .create();
+        customizers.addAll(Arrays.asList(
+                variables.getCustomizers(
+                        HugeGraphGremlinLangScriptEngineFactory.ENGINE_NAME)
+                         .get()));
+        return customizers.toArray(new Customizer[0]);
     }
 }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/api/SchemaTemplateApiTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/api/SchemaTemplateApiTest.java
@@ -35,6 +35,7 @@ import jakarta.ws.rs.core.Response;
  *  GET    /graphspaces/{gs}/schematemplates
  *  GET    /graphspaces/{gs}/schematemplates/{name}
  *  POST   /graphspaces/{gs}/schematemplates
+ *  POST   /graphspaces/{gs}/schematemplates/{name}/validate
  *  PUT    /graphspaces/{gs}/schematemplates/{name}
  *  DELETE /graphspaces/{gs}/schematemplates/{name}
  */
@@ -81,6 +82,14 @@ public class SchemaTemplateApiTest extends BaseApiTest {
         String body = String.format("{\"name\":\"%s\",\"schema\":\"%s\"}",
                                    TEMPLATE_NAME, TEMPLATE_SCHEMA);
         Response r = client().post(PATH, body);
+        String content = assertResponseStatus(400, r);
+        Assert.assertTrue(content.contains(STANDALONE_ERROR));
+    }
+
+    @Test
+    public void testValidateSchemaTemplateReturnsFriendlyError() {
+        Response r = client().post(PATH + "/" + TEMPLATE_NAME + "/validate",
+                                   jakarta.ws.rs.client.Entity.text(""));
         String content = assertResponseStatus(400, r);
         Assert.assertTrue(content.contains(STANDALONE_ERROR));
     }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/api/TaskApiTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/api/TaskApiTest.java
@@ -89,7 +89,7 @@ public class TaskApiTest extends BaseApiTest {
 
     @Test
     public void testGetWithoutResult() {
-        int taskId = this.gremlinJob("1 + 2");
+        int taskId = this.gremlinJob("g.inject(3)");
 
         waitTaskSuccess(taskId);
 
@@ -165,14 +165,14 @@ public class TaskApiTest extends BaseApiTest {
     }
 
     private int gremlinJob() {
-        return this.gremlinJob("Thread.sleep(1000L)");
+        return this.gremlinJob("g.inject(1).repeat(__.identity())." +
+                               "emit().times(800000)");
     }
 
     private int gremlinJob(String gremlin) {
         String body = "{" +
                       "\"gremlin\":\"" + gremlin + "\"," +
                       "\"bindings\":{}," +
-                      "\"language\":\"gremlin-groovy\"," +
                       "\"aliases\":{}}";
         String path = "/graphspaces/DEFAULT/graphs/hugegraph/jobs/gremlin";
         String content = assertResponseStatus(201, client().post(path, body));

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CoreTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/CoreTestSuite.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
         EdgeCoreTest.class,
         CountStrategyCoreTest.class,
         GremlinLangTextContainsCoreTest.class,
+        SchemaTemplateCoreTest.class,
         TinkerPop37StepsCoreTest.class,
         ParentAndSubEdgeCoreTest.class,
         PropertyCoreTest.VertexPropertyCoreTest.class,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/SchemaTemplateCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/SchemaTemplateCoreTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.core;
+
+import org.apache.hugegraph.schema.EdgeLabel;
+import org.apache.hugegraph.schema.IndexLabel;
+import org.apache.hugegraph.schema.PropertyKey;
+import org.apache.hugegraph.schema.SchemaTemplateExecutor;
+import org.apache.hugegraph.schema.VertexLabel;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.type.HugeType;
+import org.apache.hugegraph.type.define.DataType;
+import org.apache.hugegraph.type.define.Frequency;
+import org.apache.hugegraph.type.define.IdStrategy;
+import org.apache.hugegraph.type.define.IndexType;
+import org.junit.Test;
+
+public class SchemaTemplateCoreTest extends BaseCoreTest {
+
+    @Test
+    public void testParseWholeTemplateBeforeCreatingSchema() {
+        String template = "schema.propertyKey('safe').asText().create();\n" +
+                          "System.exit(0);";
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> SchemaTemplateExecutor.execute(this.graph(),
+                                                                 template));
+        Assert.assertFalse(this.graph().existsPropertyKey("safe"));
+    }
+
+    @Test
+    public void testPrepareSchemaRejectsWholeTemplateBeforeCreatingSchema() {
+        String template = "schema.propertyKey('safe').asText().create();\n" +
+                          "schema.propertyKey('other').remove();";
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> GraphManager.prepareSchema(this.graph(),
+                                                             template));
+        Assert.assertFalse(this.graph().existsPropertyKey("safe"));
+    }
+
+    @Test
+    public void testExecuteTypedSchemaTemplate() {
+        String template = "schema.propertyKey('name').asText()" +
+                          ".valueSingle()" +
+                          ".userdata(['source': 'import', 'rank': 3])" +
+                          ".create();" +
+                          "schema.propertyKey('age')" +
+                          ".dataType(DataType.INT).create();" +
+                          "schema.vertexLabel('person').usePrimaryKeyId()" +
+                          ".properties(['name', 'age']).primaryKeys('name')" +
+                          ".create();" +
+                          "schema.edgeLabel('knows')" +
+                          ".link('person', 'person').properties('age')" +
+                          ".sortKeys('age')" +
+                          ".frequency(Frequency.MULTIPLE).create();" +
+                          "schema.indexLabel('personByAge')" +
+                          ".on(HugeType.VERTEX_LABEL, 'person').by('age')" +
+                          ".indexType(IndexType.SECONDARY).create();";
+
+        SchemaTemplateExecutor.execute(this.graph(), template);
+
+        PropertyKey name = this.graph().propertyKey("name");
+        PropertyKey age = this.graph().propertyKey("age");
+        VertexLabel person = this.graph().vertexLabel("person");
+        EdgeLabel knows = this.graph().edgeLabel("knows");
+        IndexLabel personByAge = this.graph().indexLabel("personByAge");
+        Assert.assertEquals(DataType.TEXT, name.dataType());
+        Assert.assertEquals("import", name.userdata().get("source"));
+        Assert.assertEquals(3L, name.userdata().get("rank"));
+        Assert.assertEquals(DataType.INT, age.dataType());
+        Assert.assertEquals(IdStrategy.PRIMARY_KEY, person.idStrategy());
+        Assert.assertTrue(person.primaryKeys().contains(name.id()));
+        Assert.assertEquals("person", knows.sourceLabelName());
+        Assert.assertEquals("person", knows.targetLabelName());
+        Assert.assertEquals(Frequency.MULTIPLE, knows.frequency());
+        Assert.assertEquals(HugeType.VERTEX_LABEL, personByAge.baseType());
+        Assert.assertEquals(IndexType.SECONDARY, personByAge.indexType());
+        Assert.assertTrue(personByAge.indexFields().contains(age.id()));
+    }
+
+    @Test
+    public void testExecuteIfNotExistTemplateTwice() {
+        String template = "schema.propertyKey('name').asText()" +
+                          ".ifNotExist().create();";
+
+        SchemaTemplateExecutor.execute(this.graph(), template);
+        SchemaTemplateExecutor.execute(this.graph(), template);
+
+        Assert.assertEquals(DataType.TEXT,
+                            this.graph().propertyKey("name").dataType());
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/TaskCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/TaskCoreTest.java
@@ -18,6 +18,7 @@
 package org.apache.hugegraph.core;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,7 @@ import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.api.job.GremlinAPI.GremlinRequest;
 import org.apache.hugegraph.backend.id.Id;
 import org.apache.hugegraph.backend.id.IdGenerator;
+import org.apache.hugegraph.config.CoreOptions;
 import org.apache.hugegraph.exception.NotFoundException;
 import org.apache.hugegraph.job.EphemeralJob;
 import org.apache.hugegraph.job.EphemeralJobBuilder;
@@ -45,6 +47,8 @@ import org.apache.hugegraph.task.TaskScheduler;
 import org.apache.hugegraph.task.TaskStatus;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.testutil.Whitebox;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -619,7 +623,7 @@ public class TaskCoreTest extends BaseCoreTest {
         TaskScheduler scheduler = graph.taskScheduler();
 
         GremlinRequest request = new GremlinRequest();
-        request.gremlin("sleep(100); 3 + 5");
+        request.gremlin("g.V().count()");
 
         JobBuilder<Object> builder = JobBuilder.of(graph);
         builder.name("test-job-gremlin")
@@ -636,104 +640,94 @@ public class TaskCoreTest extends BaseCoreTest {
         Assert.assertEquals("test-job-gremlin", task.name());
         Assert.assertEquals("gremlin", task.type());
         Assert.assertEquals(TaskStatus.SUCCESS, task.status());
-        Assert.assertEquals("8", task.result());
+        Assert.assertEquals("[0]", task.result());
 
         task = scheduler.task(task.id());
         Assert.assertEquals("test-job-gremlin", task.name());
         Assert.assertEquals("gremlin", task.type());
         Assert.assertEquals(TaskStatus.SUCCESS, task.status());
-        Assert.assertEquals("8", task.result());
+        Assert.assertEquals("[0]", task.result());
     }
 
     @Test
-    public void testGremlinJobWithScript() throws TimeoutException {
+    public void testGremlinJobWithTraversalQueries() throws TimeoutException {
         HugeGraph graph = graph();
         TaskScheduler scheduler = graph.taskScheduler();
+        graph.schema().propertyKey("name").asText().create();
+        graph.schema().propertyKey("age").asInt().create();
+        graph.schema().propertyKey("date").asDate().create();
+        graph.schema().vertexLabel("person1").properties("name", "age")
+             .create();
+        graph.schema().vertexLabel("person2").properties("name", "age")
+             .create();
+        graph.schema().edgeLabel("knows").link("person1", "person2")
+             .properties("date").create();
+        for (int i = 0; i < 100; i++) {
+            Vertex p1 = graph.addVertex(T.label, "person1",
+                                        "name", "p1-" + i, "age", 29);
+            Vertex p2 = graph.addVertex(T.label, "person2",
+                                        "name", "p2-" + i, "age", 27);
+            p1.addEdge("knows", p2, "date", "2016-01-10");
+        }
+        graph.tx().commit();
 
-        String script = "schema=graph.schema();" +
-                        "schema.propertyKey('name').asText().ifNotExist().create();" +
-                        "schema.propertyKey('age').asInt().ifNotExist().create();" +
-                        "schema.propertyKey('lang').asText().ifNotExist().create();" +
-                        "schema.propertyKey('date').asDate().ifNotExist().create();" +
-                        "schema.propertyKey('price').asInt().ifNotExist().create();" +
-                        "schema.vertexLabel('person1').properties('name','age').ifNotExist()" +
-                        ".create();" +
-                        "schema.vertexLabel('person2').properties('name','age').ifNotExist()" +
-                        ".create();" +
-                        "schema.edgeLabel('knows').sourceLabel('person1').targetLabel('person2')." +
-                        "properties('date').ifNotExist().create();" +
-                        "for(int i = 0; i < 1000; i++) {" +
-                        "  p1=graph.addVertex(T.label,'person1','name','p1-'+i,'age',29);" +
-                        "  p2=graph.addVertex(T.label,'person2','name','p2-'+i,'age',27);" +
-                        "  p1.addEdge('knows',p2,'date','2016-01-10');" +
-                        "}";
-
+        String script = "g.V().count()";
         HugeTask<Object> task = runGremlinJob(script);
         task = scheduler.waitUntilTaskCompleted(task.id(), 10);
-        Assert.assertEquals("test-gremlin-job", task.name());
-        Assert.assertEquals("gremlin", task.type());
         Assert.assertEquals(TaskStatus.SUCCESS, task.status());
-        Assert.assertEquals("[]", task.result());
-
-        script = "g.V().count()";
-        task = runGremlinJob(script);
-        task = scheduler.waitUntilTaskCompleted(task.id(), 10);
-        Assert.assertEquals(TaskStatus.SUCCESS, task.status());
-        Assert.assertEquals("[2000]", task.result());
+        Assert.assertEquals("[200]", task.result());
 
         script = "g.V().hasLabel('person1').count()";
         task = runGremlinJob(script);
         task = scheduler.waitUntilTaskCompleted(task.id(), 10);
         Assert.assertEquals(TaskStatus.SUCCESS, task.status());
-        Assert.assertEquals("[1000]", task.result());
+        Assert.assertEquals("[100]", task.result());
 
         script = "g.V().hasLabel('person2').count()";
         task = runGremlinJob(script);
         task = scheduler.waitUntilTaskCompleted(task.id(), 10);
         Assert.assertEquals(TaskStatus.SUCCESS, task.status());
-        Assert.assertEquals("[1000]", task.result());
+        Assert.assertEquals("[100]", task.result());
 
         script = "g.E().count()";
         task = runGremlinJob(script);
         task = scheduler.waitUntilTaskCompleted(task.id(), 10);
         Assert.assertEquals(TaskStatus.SUCCESS, task.status());
-        Assert.assertEquals("[1000]", task.result());
+        Assert.assertEquals("[100]", task.result());
 
         script = "g.E().hasLabel('knows').count()";
         task = runGremlinJob(script);
         task = scheduler.waitUntilTaskCompleted(task.id(), 10);
         Assert.assertEquals(TaskStatus.SUCCESS, task.status());
-        Assert.assertEquals("[1000]", task.result());
+        Assert.assertEquals("[100]", task.result());
     }
 
     @Test
     public void testGremlinJobWithSerializedResults() throws TimeoutException {
         HugeGraph graph = graph();
         TaskScheduler scheduler = graph.taskScheduler();
+        graph.schema().propertyKey("name").asText().create();
+        graph.schema().vertexLabel("char").useCustomizeNumberId()
+             .properties("name").create();
+        graph.schema().edgeLabel("next").link("char", "char")
+             .properties("name").create();
+        Vertex a = graph.addVertex(T.id, 1L, T.label, "char", "name", "A");
+        Vertex b = graph.addVertex(T.id, 2L, T.label, "char", "name", "B");
+        Vertex c = graph.addVertex(T.id, 3L, T.label, "char", "name", "C");
+        Vertex d = graph.addVertex(T.id, 4L, T.label, "char", "name", "D");
+        Vertex e = graph.addVertex(T.id, 5L, T.label, "char", "name", "E");
+        Vertex f = graph.addVertex(T.id, 6L, T.label, "char", "name", "F");
+        a.addEdge("next", b, "name", "ab");
+        b.addEdge("next", c, "name", "bc");
+        b.addEdge("next", d, "name", "bd");
+        c.addEdge("next", d, "name", "cd");
+        c.addEdge("next", e, "name", "ce");
+        d.addEdge("next", e, "name", "de");
+        e.addEdge("next", f, "name", "ef");
+        f.addEdge("next", d, "name", "fd");
+        graph.tx().commit();
 
-        String script = "schema=graph.schema();" +
-                        "schema.propertyKey('name').asText().ifNotExist().create();" +
-                        "schema.vertexLabel('char').useCustomizeNumberId()" +
-                        "      .properties('name').ifNotExist().create();" +
-                        "schema.edgeLabel('next').sourceLabel('char').targetLabel('char')" +
-                        "      .properties('name').ifNotExist().create();" +
-                        "g.addV('char').property(id,1).property('name','A').as('a')" +
-                        " .addV('char').property(id,2).property('name','B').as('b')" +
-                        " .addV('char').property(id,3).property('name','C').as('c')" +
-                        " .addV('char').property(id,4).property('name','D').as('d')" +
-                        " .addV('char').property(id,5).property('name','E').as('e')" +
-                        " .addV('char').property(id,6).property('name','F').as('f')" +
-                        " .addE('next').from('a').to('b').property('name','ab')" +
-                        " .addE('next').from('b').to('c').property('name','bc')" +
-                        " .addE('next').from('b').to('d').property('name','bd')" +
-                        " .addE('next').from('c').to('d').property('name','cd')" +
-                        " .addE('next').from('c').to('e').property('name','ce')" +
-                        " .addE('next').from('d').to('e').property('name','de')" +
-                        " .addE('next').from('e').to('f').property('name','ef')" +
-                        " .addE('next').from('f').to('d').property('name','fd')" +
-                        " .iterate();" +
-                        "g.tx().commit(); g.E().count();";
-
+        String script = "g.E().count()";
         HugeTask<Object> task = runGremlinJob(script);
         task = scheduler.waitUntilTaskCompleted(task.id(), 10);
         Assert.assertEquals("test-gremlin-job", task.name());
@@ -896,18 +890,24 @@ public class TaskCoreTest extends BaseCoreTest {
         task = builder.schedule();
         task = scheduler.waitUntilTaskCompleted(task.id(), 10);
         Assert.assertEquals(TaskStatus.FAILED, task.status());
-        Assert.assertContains("Invalid aliases value 'null'", task.result());
+        Assert.assertContains("Invalid language value ''", task.result());
+        Assert.assertContains("only 'gremlin-lang' is supported", task.result());
 
         builder = JobBuilder.of(graph);
         builder.name("test-job-gremlin")
                .input("{\"gremlin\":\"\", \"bindings\":{}, " +
-                      "\"language\":\"test\", \"aliases\":{}}")
+                      "\"language\":\"gremlin-groovy\", \"aliases\":{}}")
                .job(new GremlinJob());
         task = builder.schedule();
         task = scheduler.waitUntilTaskCompleted(task.id(), 10);
         Assert.assertEquals(TaskStatus.FAILED, task.status());
-        Assert.assertContains("test is not an available GremlinScriptEngine",
+        Assert.assertContains("Invalid language value 'gremlin-groovy'",
                               task.result());
+        Assert.assertContains("only 'gremlin-lang' is supported", task.result());
+
+        task = runGremlinJob("1 + 2");
+        task = scheduler.waitUntilTaskCompleted(task.id(), 10);
+        Assert.assertEquals(TaskStatus.FAILED, task.status());
     }
 
     @Test
@@ -948,42 +948,37 @@ public class TaskCoreTest extends BaseCoreTest {
     }
 
     @Test
-    public void testGremlinJobAndCancel() throws TimeoutException {
+    public void testTaskCancellationAndResultLimits() throws TimeoutException {
         HugeGraph graph = graph();
         TaskScheduler scheduler = graph.taskScheduler();
 
-        HugeTask<Object> task = runGremlinJob("Thread.sleep(1000 * 10);");
-
-        sleepAWhile(200 * 6);
+        Id sleepingId = IdGenerator.of(88894);
+        HugeTask<Object> task = new HugeTask<>(sleepingId, null,
+                                               new SleepCallable<>());
+        task.type("test");
+        task.name("test-task-cancel");
+        scheduler.schedule(task);
+        sleepAWhile(200);
         task = scheduler.task(task.id());
         scheduler.cancel(task);
 
-        task = scheduler.task(task.id());
-        // For DistributedTaskScheduler, local cancel may result in CANCELLED directly
-        // (task thread updates status after being interrupted)
-        // or CANCELLING (if task hasn't processed the interrupt yet)
-        Assert.assertTrue("Task status should be CANCELLING or CANCELLED, but was " + task.status(),
-                          task.status() == TaskStatus.CANCELLING ||
-                          task.status() == TaskStatus.CANCELLED);
-
         task = scheduler.waitUntilTaskCompleted(task.id(), 10);
         Assert.assertEquals(TaskStatus.CANCELLED, task.status());
-        Assert.assertEquals("test-gremlin-job", task.name());
+        Assert.assertEquals("test-task-cancel", task.name());
         Assert.assertTrue(task.result(), task.result() == null ||
                                          task.result().endsWith("InterruptedException"));
 
-        // Cancel success task
-        HugeTask<Object> task2 = runGremlinJob("1+2");
+        HugeTask<Object> task2 = runGremlinJob("g.inject(3)");
         task2 = scheduler.waitUntilTaskCompleted(task2.id(), 10);
         Assert.assertEquals(TaskStatus.SUCCESS, task2.status());
         scheduler.cancel(task2);
         task2 = scheduler.task(task2.id());
         Assert.assertEquals(TaskStatus.SUCCESS, task2.status());
-        Assert.assertEquals("3", task2.result());
+        Assert.assertEquals("[3]", task2.result());
 
-        // Cancel failure task with big results (job size exceeded limit)
-        String bigList = "def l=[]; for (i in 1..800001) l.add(i); l;";
-        HugeTask<Object> task3 = runGremlinJob(bigList);
+        String oversizedTraversal = "g.inject(1).repeat(__.identity())." +
+                                    "emit().times(800001)";
+        HugeTask<Object> task3 = runGremlinJob(oversizedTraversal);
         task3 = scheduler.waitUntilTaskCompleted(task3.id(), 12);
         Assert.assertEquals(TaskStatus.FAILED, task3.status());
         scheduler.cancel(task3);
@@ -993,59 +988,56 @@ public class TaskCoreTest extends BaseCoreTest {
                               "has exceeded the max limit 800000",
                               task3.result());
 
-        // Cancel failure task with big results (task exceeded limit 16M)
-        String bigResults = "def random = new Random(); def rs=[];" +
-                            "for (i in 0..4) {" +
-                            "  def len = 1024 * 1024;" +
-                            "  def item = new StringBuilder(len);" +
-                            "  for (j in 0..len) { " +
-                            "    item.append(\"node:\"); " +
-                            "    item.append((char) random.nextInt(256)); " +
-                            "    item.append(\",\"); " +
-                            "  };" +
-                            "  rs.add(item);" +
-                            "};" +
-                            "rs;";
-        HugeTask<Object> task4 = runGremlinJob(bigResults);
-        task4 = scheduler.waitUntilTaskCompleted(task4.id(), 10);
-        Assert.assertEquals(TaskStatus.FAILED, task4.status());
-        scheduler.cancel(task4);
-        task4 = scheduler.task(task4.id());
-        Assert.assertEquals(TaskStatus.FAILED, task4.status());
-        Assert.assertContains("LimitExceedException: Task result size",
-                              task4.result());
-        Assert.assertContains("exceeded limit 16777216 bytes",
-                              task4.result());
+        long defaultResultLimit = graph.option(CoreOptions.TASK_RESULT_SIZE_LIMIT);
+        long testResultLimit = 1024L * 1024L;
+        graph.configuration().setProperty(CoreOptions.TASK_RESULT_SIZE_LIMIT.name(),
+                                          testResultLimit);
+        try {
+            Id largeResultId = IdGenerator.of(88895);
+            HugeTask<String> largeResult = new HugeTask<>(
+                    largeResultId, null, new LargeResultCallable());
+            largeResult.type("test");
+            largeResult.name("test-task-large-result");
+            scheduler.schedule(largeResult);
+            HugeTask<?> task4 = scheduler.waitUntilTaskCompleted(largeResultId, 10);
+            Assert.assertEquals(TaskStatus.FAILED, task4.status());
+            scheduler.cancel(task4);
+            task4 = scheduler.task(task4.id());
+            Assert.assertEquals(TaskStatus.FAILED, task4.status());
+            Assert.assertContains("LimitExceedException: Task result size",
+                                  task4.result());
+            Assert.assertContains("exceeded limit 1048576 bytes",
+                                  task4.result());
+        } finally {
+            graph.configuration().setProperty(
+                    CoreOptions.TASK_RESULT_SIZE_LIMIT.name(), defaultResultLimit);
+        }
     }
 
     @Test
-    public void testGremlinJobAndRestore() throws Exception {
+    public void testTaskAndRestore() throws Exception {
         HugeGraph graph = graph();
         TaskScheduler scheduler = graph.taskScheduler();
 
-        String gremlin = "println('task start');" +
-                         "for(int i=gremlinJob.progress(); i<=10; i++) {" +
-                         "  gremlinJob.updateProgress(i);" +
-                         "  Thread.sleep(200); " +
-                         "  println('sleep=>'+i);" +
-                         "}; 100;";
-        HugeTask<Object> task = runGremlinJob(gremlin);
+        Id id = IdGenerator.of(88896);
+        HugeTask<Object> task = new HugeTask<>(id, null,
+                                               new ProgressCallable());
+        task.type("test");
+        task.name("test-task-restore");
+        scheduler.schedule(task);
 
         sleepAWhile(200 * 6);
         task = scheduler.task(task.id());
         scheduler.cancel(task);
-
-        task = scheduler.task(task.id());
-        Assert.assertTrue("Task status should be CANCELLING or CANCELLED, but was " + task.status(),
-                          task.status() == TaskStatus.CANCELLING ||
-                          task.status() == TaskStatus.CANCELLED);
 
         task = scheduler.waitUntilTaskCompleted(task.id(), 10);
         Assert.assertEquals(TaskStatus.CANCELLED, task.status());
         Assert.assertTrue("progress=" + task.progress(),
                           0 < task.progress() && task.progress() < 10);
         Assert.assertEquals(0, task.retries());
-        Assert.assertNull(task.result());
+        Assert.assertTrue(task.result(), task.result() == null ||
+                                         task.result().endsWith(
+                                                 "InterruptedException"));
 
         HugeTask<Object> finalTask = task;
 
@@ -1093,10 +1085,13 @@ public class TaskCoreTest extends BaseCoreTest {
     }
 
     private HugeTask<Object> runGremlinJob(String gremlin) {
-        HugeGraph graph = graph();
-
         GremlinRequest request = new GremlinRequest();
         request.gremlin(gremlin);
+        return this.runGremlinJob(request);
+    }
+
+    private HugeTask<Object> runGremlinJob(GremlinRequest request) {
+        HugeGraph graph = graph();
 
         JobBuilder<Object> builder = JobBuilder.of(graph);
         builder.name("test-gremlin-job")
@@ -1115,6 +1110,51 @@ public class TaskCoreTest extends BaseCoreTest {
             Thread.sleep(ms);
         } catch (InterruptedException e) {
             // ignore
+        }
+    }
+
+    public static class ProgressCallable extends TaskCallable<Object> {
+
+        public ProgressCallable() {
+            // pass
+        }
+
+        @Override
+        public Object call() throws Exception {
+            for (int i = this.progress(); i <= 10; i++) {
+                this.updateProgress(i);
+                Thread.sleep(200L);
+            }
+            return 100;
+        }
+
+        @Override
+        public void done() {
+            this.graph().taskScheduler().save(this.task());
+        }
+
+        @Override
+        protected void cancelled() {
+            this.graph().taskScheduler().save(this.task());
+        }
+    }
+
+    public static class LargeResultCallable extends TaskCallable<String> {
+
+        public LargeResultCallable() {
+            // pass
+        }
+
+        @Override
+        public String call() {
+            byte[] bytes = new byte[2 * 1024 * 1024];
+            new Random(1L).nextBytes(bytes);
+            return Base64.getEncoder().encodeToString(bytes);
+        }
+
+        @Override
+        public void done() {
+            this.graph().taskScheduler().save(this.task());
         }
     }
 
@@ -1172,6 +1212,11 @@ public class TaskCoreTest extends BaseCoreTest {
 
         @Override
         public void done() {
+            this.graph().taskScheduler().save(this.task());
+        }
+
+        @Override
+        protected void cancelled() {
             this.graph().taskScheduler().save(this.task());
         }
     }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -33,6 +33,7 @@ import org.apache.hugegraph.unit.api.auth.LoginAPITest;
 import org.apache.hugegraph.unit.api.filter.LoadDetectFilterTest;
 import org.apache.hugegraph.unit.api.filter.PathFilterTest;
 import org.apache.hugegraph.unit.api.gremlin.GremlinQueryAPITest;
+import org.apache.hugegraph.unit.api.job.GremlinAPIRequestTest;
 import org.apache.hugegraph.unit.api.space.GraphSpaceAPITest;
 import org.apache.hugegraph.unit.auth.HugeGraphAuthProxyTest;
 import org.apache.hugegraph.unit.cache.CacheManagerTest;
@@ -76,6 +77,7 @@ import org.apache.hugegraph.unit.rocksdb.RocksDBCountersTest;
 import org.apache.hugegraph.unit.rocksdb.RocksDBSessionTest;
 import org.apache.hugegraph.unit.rocksdb.RocksDBSessionsTest;
 import org.apache.hugegraph.unit.rocksdb.RocksDBTableQueryByIdsTest;
+import org.apache.hugegraph.unit.schema.RestrictedSchemaTemplateParserTest;
 import org.apache.hugegraph.unit.serializer.BinaryBackendEntryTest;
 import org.apache.hugegraph.unit.serializer.BinaryScatterSerializerTest;
 import org.apache.hugegraph.unit.serializer.BinarySerializerTest;
@@ -88,6 +90,7 @@ import org.apache.hugegraph.unit.serializer.TextBackendEntryTest;
 import org.apache.hugegraph.unit.serializer.TextSerializerTest;
 import org.apache.hugegraph.unit.security.HugeGraphGremlinLangScriptEngineTest;
 import org.apache.hugegraph.unit.store.RamIntObjectMapTest;
+import org.apache.hugegraph.unit.traversal.optimize.HugeScriptTraversalTest;
 import org.apache.hugegraph.unit.util.CompressUtilTest;
 import org.apache.hugegraph.unit.util.JsonUtilTest;
 import org.apache.hugegraph.unit.util.RateLimiterTest;
@@ -111,6 +114,7 @@ import org.junit.runners.Suite;
 
         /* api gremlin */
         GremlinQueryAPITest.class,
+        GremlinAPIRequestTest.class,
         CypherClientTest.class,
         GremlinLangRequestGuardTest.class,
         WsAndHttpBasicAuthHandlerTest.class,
@@ -173,6 +177,9 @@ import org.junit.runners.Suite;
         SchemaElementTest.class,
         HugeGraphTestInfrastructureTest.class,
 
+        /* schema */
+        RestrictedSchemaTemplateParserTest.class,
+
         /* cmd */
         InitStoreConfigTest.class,
 
@@ -193,6 +200,9 @@ import org.junit.runners.Suite;
 
         /* security */
         HugeGraphGremlinLangScriptEngineTest.class,
+
+        /* traversal.optimize */
+        HugeScriptTraversalTest.class,
 
         /* rocksdb */
         RocksDBSessionsTest.class,

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/api/job/GremlinAPIRequestTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/api/job/GremlinAPIRequestTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.unit.api.job;
+
+import org.apache.hugegraph.api.job.GremlinAPI.GremlinRequest;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.unit.BaseUnitTest;
+import org.junit.Test;
+
+public class GremlinAPIRequestTest extends BaseUnitTest {
+
+    @Test
+    public void testDefaultLanguageIsGremlinLang() {
+        GremlinRequest request = new GremlinRequest();
+
+        Assert.assertEquals("gremlin-lang", request.language());
+    }
+
+    @Test
+    public void testRejectExplicitGroovyLanguage() {
+        GremlinRequest request = new GremlinRequest();
+        request.gremlin("g.V().count()");
+        request.language("gremlin-groovy");
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> request.checkCreate(false),
+                            e -> Assert.assertContains("gremlin-lang",
+                                                       e.getMessage()));
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SecurityManagerTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/core/SecurityManagerTest.java
@@ -28,44 +28,60 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.hugegraph.HugeException;
+import javax.script.Bindings;
+
 import org.apache.hugegraph.HugeFactory;
 import org.apache.hugegraph.HugeGraph;
 import org.apache.hugegraph.auth.HugeFactoryAuthProxy;
 import org.apache.hugegraph.config.HugeConfig;
-import org.apache.hugegraph.job.GremlinJob;
-import org.apache.hugegraph.job.JobBuilder;
 import org.apache.hugegraph.masterelection.GlobalMasterInfo;
 import org.apache.hugegraph.security.HugeSecurityManager;
-import org.apache.hugegraph.task.HugeTask;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.unit.FakeObjects;
-import org.apache.hugegraph.util.JsonUtil;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 public class SecurityManagerTest {
 
     private static HugeGraph graph;
     private static final HugeSecurityManager sm = new HugeSecurityManager();
+    private static GremlinGroovyScriptEngine groovy;
+    private static ExecutorService groovyExecutor;
 
     @BeforeClass
     public static void init() {
         graph = loadGraph(false);
-        runGremlinJob("1 + 1");
+        // External Gremlin jobs now accept only gremlin-lang. Exercise the
+        // deployment-controlled Groovy boundary directly in this legacy test.
+        groovy = new GremlinGroovyScriptEngine();
+        groovyExecutor = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("task-worker-security-test");
+            return thread;
+        });
+        runGroovyScript("1 + 1");
         System.setSecurityManager(new HugeSecurityManager());
     }
 
     @AfterClass
     public static void clear() throws Exception {
+        groovyExecutor.submit(() -> graph.tx().close())
+                      .get(30L, TimeUnit.SECONDS);
+        groovyExecutor.shutdownNow();
+        groovyExecutor.awaitTermination(30L, TimeUnit.SECONDS);
         System.setSecurityManager(null);
         graph.clearBackend();
         graph.close();
@@ -94,22 +110,22 @@ public class SecurityManagerTest {
 
     @Test
     public void testNormal() {
-        String result = runGremlinJob("g.V()");
+        String result = runGroovyScript("g.V()");
         Assert.assertEquals("[]", result);
 
-        result = runGremlinJob("1 + 2");
+        result = runGroovyScript("1 + 2");
         Assert.assertEquals("3", result);
     }
 
     @Test
     public void testPermission() {
-        String result = runGremlinJob("System.setSecurityManager(null)");
+        String result = runGroovyScript("System.setSecurityManager(null)");
         assertError(result, "Not allowed to access denied permission via Gremlin");
     }
 
     @Test
     public void testClassLoader() {
-        String result = runGremlinJob("System.getSecurityManager().checkCreateClassLoader()");
+        String result = runGroovyScript("System.getSecurityManager().checkCreateClassLoader()");
         assertError(result, "Not allowed to create class loader via Gremlin");
     }
 
@@ -117,18 +133,18 @@ public class SecurityManagerTest {
     public void testThread() {
         // access a thread group
         new Thread();
-        String result = runGremlinJob("new Thread()");
+        String result = runGroovyScript("new Thread()");
         assertError(result, "Not allowed to access thread group via Gremlin");
 
         // access thread
         Thread.currentThread().checkAccess();
-        result = runGremlinJob("Thread.currentThread().stop()");
+        result = runGroovyScript("Thread.currentThread().stop()");
         assertError(result, "Not allowed to access thread via Gremlin");
     }
 
     @Test
     public void testExit() {
-        String result = runGremlinJob("System.exit(-1)");
+        String result = runGroovyScript("System.exit(-1)");
         assertError(result, "Not allowed to call System.exit() via Gremlin");
     }
 
@@ -140,7 +156,7 @@ public class SecurityManagerTest {
         } catch (IOException ignored) {
             // ignored exception
         }
-        String result = runGremlinJob("new FileInputStream(new File(\"\"))");
+        String result = runGroovyScript("new FileInputStream(new File(\"\"))");
         assertError(result, "Not allowed to read file via Gremlin");
 
         // read file
@@ -150,18 +166,18 @@ public class SecurityManagerTest {
         } catch (IOException ignored) {
             // ignored exception
         }
-        result = runGremlinJob(String.format(
+        result = runGroovyScript(String.format(
                 "new FileInputStream(new File(\"%s\"))", pom));
         assertError(result, "(No such file or directory)");
 
         // read file fd
         @SuppressWarnings({"unused", "resource"})
         FileInputStream fis = new FileInputStream(FileDescriptor.in);
-        result = runGremlinJob("new FileInputStream(FileDescriptor.in)");
+        result = runGroovyScript("new FileInputStream(FileDescriptor.in)");
         assertError(result, "Not allowed to read fd via Gremlin");
 
         sm.checkRead("", new Object());
-        result = runGremlinJob("System.getSecurityManager()" +
+        result = runGroovyScript("System.getSecurityManager()" +
                                ".checkRead(\"\", new Object())");
         assertError(result, "Not allowed to read file via Gremlin");
 
@@ -171,23 +187,23 @@ public class SecurityManagerTest {
         } catch (IOException ignored) {
             // ignored IOException
         }
-        result = runGremlinJob("new FileOutputStream(new File(\"\"))");
+        result = runGroovyScript("new FileOutputStream(new File(\"\"))");
         assertError(result, "Not allowed to write file via Gremlin");
 
         // write file fd
         @SuppressWarnings({"unused", "resource"})
         FileOutputStream fos = new FileOutputStream(FileDescriptor.out);
-        result = runGremlinJob("new FileOutputStream(FileDescriptor.out)");
+        result = runGroovyScript("new FileOutputStream(FileDescriptor.out)");
         assertError(result, "Not allowed to write fd via Gremlin");
 
         // delete file
         new File("").delete();
-        result = runGremlinJob("new File(\"\").delete()");
+        result = runGroovyScript("new File(\"\").delete()");
         assertError(result, "Not allowed to delete file via Gremlin");
 
         // get absolute path
         new File("").getAbsolutePath();
-        result = runGremlinJob("new File(\"\").getAbsolutePath()");
+        result = runGroovyScript("new File(\"\").getAbsolutePath()");
         assertError(result, "Not allowed to access " +
                             "system property(user.dir) via Gremlin");
     }
@@ -203,7 +219,7 @@ public class SecurityManagerTest {
         } catch (IOException ignored) {
             // ignored UnsatisfiedLinkError
         }
-        String result = runGremlinJob("new ServerSocket(8200)");
+        String result = runGroovyScript("new ServerSocket(8200)");
         assertError(result, "Not allowed to listen socket via Gremlin");
 
         /*
@@ -211,7 +227,7 @@ public class SecurityManagerTest {
          * from checkListen
          */
         sm.checkAccept("localhost", 8200);
-        result = runGremlinJob("System.getSecurityManager()" +
+        result = runGroovyScript("System.getSecurityManager()" +
                                ".checkAccept(\"localhost\", 8200)");
         assertError(result, "Not allowed to accept socket via Gremlin");
 
@@ -221,32 +237,32 @@ public class SecurityManagerTest {
         } catch (ConnectException ignored) {
             // ignored ConnectException
         }
-        result = runGremlinJob("new Socket().connect(" +
+        result = runGroovyScript("new Socket().connect(" +
                                "new InetSocketAddress(\"localhost\", 8200))");
         assertError(result, "Not allowed to connect socket via Gremlin");
 
         sm.checkConnect("localhost", 8200, new Object());
-        result = runGremlinJob("System.getSecurityManager()" +
+        result = runGroovyScript("System.getSecurityManager()" +
                                ".checkConnect(\"localhost\", 8200, " +
                                "new Object())");
         assertError(result, "Not allowed to connect socket via Gremlin");
 
         sm.checkMulticast(InetAddress.getByAddress(new byte[]{0, 0, 0, 0}));
-        result = runGremlinJob("bs = [0, 0, 0, 0] as byte[];" +
+        result = runGroovyScript("bs = [0, 0, 0, 0] as byte[];" +
                                "System.getSecurityManager()" +
                                ".checkMulticast(InetAddress.getByAddress(bs))");
         assertError(result, "Not allowed to multicast via Gremlin");
 
         sm.checkMulticast(InetAddress.getByAddress(new byte[]{0, 0, 0, 0}),
                           (byte) 1);
-        result = runGremlinJob("bs = [0, 0, 0, 0] as byte[]; ttl = (byte) 1;" +
+        result = runGroovyScript("bs = [0, 0, 0, 0] as byte[]; ttl = (byte) 1;" +
                                "System.getSecurityManager()" +
                                ".checkMulticast(InetAddress.getByAddress(" +
                                "bs), ttl)");
         assertError(result, "Not allowed to multicast via Gremlin");
 
         sm.checkSetFactory();
-        result = runGremlinJob("System.getSecurityManager().checkSetFactory()");
+        result = runGroovyScript("System.getSecurityManager().checkSetFactory()");
         assertError(result, "Not allowed to set socket factory via Gremlin");
     }
 
@@ -255,7 +271,7 @@ public class SecurityManagerTest {
         Process process = Runtime.getRuntime().exec("ls");
         process.waitFor();
 
-        String result = runGremlinJob("process=Runtime.getRuntime().exec(" +
+        String result = runGroovyScript("process=Runtime.getRuntime().exec(" +
                                       "'ls'); process.waitFor()");
         assertError(result, "Not allowed to execute command via Gremlin");
     }
@@ -268,7 +284,7 @@ public class SecurityManagerTest {
             // ignored UnsatisfiedLinkError
         }
 
-        String result = runGremlinJob("Runtime.getRuntime().loadLibrary" +
+        String result = runGroovyScript("Runtime.getRuntime().loadLibrary" +
                                       "(\"test.jar\")");
         assertError(result, "Not allowed to link library via Gremlin");
     }
@@ -276,24 +292,24 @@ public class SecurityManagerTest {
     @Test
     public void testProperties() {
         System.getProperties();
-        String result = runGremlinJob("System.getProperties()");
+        String result = runGroovyScript("System.getProperties()");
         assertError(result, "Not allowed to access system properties via Gremlin");
 
         System.getProperty("java.version");
-        result = runGremlinJob("System.getProperty(\"java.version\")");
+        result = runGroovyScript("System.getProperty(\"java.version\")");
         assertError(result, "Not allowed to access system property(java.version) via Gremlin");
 
-        result = runGremlinJob("System.getProperty(\"socksProxyHost\")");
+        result = runGroovyScript("System.getProperty(\"socksProxyHost\")");
         assertError(result, "Not allowed to access system property(socksProxyHost) via Gremlin");
 
-        result = runGremlinJob("System.getProperty(\"file.encoding\")");
+        result = runGroovyScript("System.getProperty(\"file.encoding\")");
         assertError(result, "Not allowed to access system property(file.encoding) via Gremlin");
     }
 
     @Test
     public void testPrintJobAccess() {
         sm.checkPrintJobAccess();
-        String result = runGremlinJob("System.getSecurityManager()" +
+        String result = runGroovyScript("System.getSecurityManager()" +
                                       ".checkPrintJobAccess()");
         assertError(result, "Not allowed to print job via Gremlin");
     }
@@ -312,23 +328,39 @@ public class SecurityManagerTest {
         Assert.assertTrue(result, result.endsWith(message) || result.contains(message));
     }
 
-    private static String runGremlinJob(String gremlin) {
-        JobBuilder<Object> builder = JobBuilder.of(graph);
-        Map<String, Object> input = new HashMap<>();
-        input.put("gremlin", gremlin);
-        input.put("bindings", ImmutableMap.of());
-        input.put("language", "gremlin-groovy");
-        input.put("aliases", ImmutableMap.of());
-        builder.name("test-gremlin-job")
-               .input(JsonUtil.toJson(input))
-               .job(new GremlinJob());
-        HugeTask<?> task = builder.schedule();
+    private static String runGroovyScript(String script) {
         try {
-            task = graph.taskScheduler().waitUntilTaskCompleted(task.id(), 10);
+            return groovyExecutor.submit(() -> evalGroovyScript(script))
+                                  .get(10L, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return e.toString();
+        } catch (ExecutionException e) {
+            return e.getCause().toString();
         } catch (TimeoutException e) {
-            throw new HugeException("Wait for task timeout: %s", e, task);
+            return e.toString();
         }
-        return task.result();
+    }
+
+    private static String evalGroovyScript(String script) {
+        try (GraphTraversalSource g = graph.traversal()) {
+            Bindings bindings = groovy.createBindings();
+            bindings.put("g", g);
+            bindings.put("graph", graph);
+            Object result = groovy.eval(script, bindings);
+            if (result instanceof Traversal) {
+                Traversal<?, ?> traversal = (Traversal<?, ?>) result;
+                try {
+                    List<?> results = traversal.toList();
+                    return results.toString();
+                } finally {
+                    traversal.close();
+                }
+            }
+            return String.valueOf(result);
+        } catch (Exception e) {
+            return e.toString();
+        }
     }
 
     private static HugeGraph loadGraph(boolean needClear) {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/schema/RestrictedSchemaTemplateParserTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/schema/RestrictedSchemaTemplateParserTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.unit.schema;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hugegraph.schema.RestrictedSchemaTemplateParser;
+import org.apache.hugegraph.schema.SchemaTemplatePlan;
+import org.apache.hugegraph.schema.SchemaTemplatePlan.SchemaCommand;
+import org.apache.hugegraph.schema.SchemaTemplatePlan.SchemaKind;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.unit.BaseUnitTest;
+import org.junit.Test;
+
+public class RestrictedSchemaTemplateParserTest extends BaseUnitTest {
+
+    @Test
+    public void testParseAllSchemaKinds() {
+        String template = "schema = graph.schema();\n" +
+                          "schema.propertyKey('name').asText()" +
+                          ".valueSingle().ifNotExist().create();\n" +
+                          "schema.vertexLabel(\"person\")" +
+                          ".properties('name').primaryKeys('name')" +
+                          ".ifNotExist().create();\n" +
+                          "schema.edgeLabel('knows')" +
+                          ".link('person', 'person').multiTimes()" +
+                          ".ifNotExist().create();\n" +
+                          "schema.indexLabel('personByName').onV('person')" +
+                          ".by('name').secondary().ifNotExist().create();";
+
+        SchemaTemplatePlan plan = RestrictedSchemaTemplateParser.parse(template);
+
+        Assert.assertEquals(4, plan.commands().size());
+        assertCommand(plan.commands().get(0), SchemaKind.PROPERTY_KEY, "name",
+                      "asText", "valueSingle", "ifNotExist", "create");
+        assertCommand(plan.commands().get(1), SchemaKind.VERTEX_LABEL, "person",
+                      "properties", "primaryKeys", "ifNotExist", "create");
+        assertCommand(plan.commands().get(2), SchemaKind.EDGE_LABEL, "knows",
+                      "link", "multiTimes", "ifNotExist", "create");
+        assertCommand(plan.commands().get(3), SchemaKind.INDEX_LABEL,
+                      "personByName", "onV", "by", "secondary",
+                      "ifNotExist", "create");
+    }
+
+    @Test
+    public void testParseCommentsEscapesAndLiterals() {
+        String template = "// schema for imported data\n" +
+                          "graph.schema().propertyKey('person\\'s score')" +
+                          ".asDouble().userdata(\"source\", \"a\\\"b\")" +
+                          ".ifNotExist().create(); /* kept on import */\n" +
+                          "schema.vertexLabel('person').ttl(3600)" +
+                          ".enableLabelIndex(false).ifNotExist().create()";
+
+        SchemaTemplatePlan plan = RestrictedSchemaTemplateParser.parse(template);
+
+        Assert.assertEquals(2, plan.commands().size());
+        Assert.assertEquals("person's score", plan.commands().get(0).name());
+        Assert.assertEquals("a\"b", plan.commands().get(0).operations()
+                                                   .get(1).arguments().get(1));
+        Assert.assertEquals(3600L, plan.commands().get(1).operations()
+                                                  .get(0).arguments().get(0));
+        Assert.assertEquals(false, plan.commands().get(1).operations()
+                                                   .get(1).arguments().get(0));
+    }
+
+    @Test
+    public void testAllowSchemaAssignmentWithoutSemicolon() {
+        String template = "schema = graph.schema()\n" +
+                          "schema.propertyKey('name').asText().create()";
+
+        SchemaTemplatePlan plan = RestrictedSchemaTemplateParser.parse(template);
+
+        Assert.assertEquals(1, plan.commands().size());
+        Assert.assertEquals("name", plan.commands().get(0).name());
+    }
+
+    @Test
+    public void testParseListAndMapLiterals() {
+        String template = "schema.propertyKey('name').asText()" +
+                          ".userdata(['source': 'import', 'rank': 3])" +
+                          ".create();" +
+                          "schema.vertexLabel('person')" +
+                          ".properties(['name']).create();";
+
+        SchemaTemplatePlan plan = RestrictedSchemaTemplateParser.parse(template);
+
+        Object userdata = plan.commands().get(0).operations().get(1)
+                              .arguments().get(0);
+        Assert.assertTrue(userdata instanceof Map);
+        Assert.assertEquals("import", ((Map<?, ?>) userdata).get("source"));
+        Assert.assertEquals(3L, ((Map<?, ?>) userdata).get("rank"));
+        Object properties = plan.commands().get(1).operations().get(0)
+                                .arguments().get(0);
+        Assert.assertEquals(List.of("name"), properties);
+    }
+
+    @Test
+    public void testRejectUnsafeOrDynamicSyntax() {
+        List<String> templates = Arrays.asList(
+                "System.exit(0)",
+                "schema.getClass().forName('java.lang.Runtime')",
+                "new File('/tmp/x')",
+                "schema.propertyKey(name).asText().create()",
+                "schema.propertyKey('name').remove()",
+                "schema.propertyKey('name').create(); Runtime.runtime.exec('id')",
+                "schema.propertyKey('a').create()" +
+                "schema.propertyKey('b').create()",
+                "schema=graph.schema()" +
+                "schema.propertyKey('name').create()",
+                "for (i in 1..10) { schema.propertyKey('p' + i).create() }"
+        );
+
+        for (String template : templates) {
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> RestrictedSchemaTemplateParser.parse(template),
+                                e -> {
+                                    Assert.assertContains("line 1", e.getMessage());
+                                    Assert.assertContains("column", e.getMessage());
+                                });
+        }
+    }
+
+    @Test
+    public void testRejectTrailingUnsafeStatementBeforeAnyExecution() {
+        String template = "schema.propertyKey('safe').asText().create();\n" +
+                          "Runtime.runtime.exec('id');";
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> RestrictedSchemaTemplateParser.validate(template),
+                            e -> {
+                                Assert.assertContains("line 2", e.getMessage());
+                                Assert.assertContains("Runtime", e.getMessage());
+                            });
+    }
+
+    @Test
+    public void testRejectExcessiveLiteralNesting() {
+        String nested = "[".repeat(33) + "1" + "]".repeat(33);
+        String template = "schema.propertyKey('name')" +
+                          ".userdata('nested', " + nested + ").create()";
+
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> RestrictedSchemaTemplateParser.parse(template),
+                            e -> Assert.assertContains("nesting",
+                                                       e.getMessage()));
+    }
+
+    private static void assertCommand(SchemaCommand command, SchemaKind kind,
+                                      String name, String... methods) {
+        Assert.assertEquals(kind, command.kind());
+        Assert.assertEquals(name, command.name());
+        Assert.assertEquals(methods.length, command.operations().size());
+        for (int i = 0; i < methods.length; i++) {
+            Assert.assertEquals(methods[i], command.operations().get(i)
+                                                         .method().dslName());
+        }
+    }
+}

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/schema/RestrictedSchemaTemplateParserTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/schema/RestrictedSchemaTemplateParserTest.java
@@ -81,6 +81,38 @@ public class RestrictedSchemaTemplateParserTest extends BaseUnitTest {
     }
 
     @Test
+    public void testParseLongLiteralSuffix() {
+        String template = "schema.propertyKey('code').id(100L)" +
+                          ".asText().userdata(['rank': -3l]).create();" +
+                          "schema.vertexLabel('person').ttl(86400L).create();";
+
+        SchemaTemplatePlan plan = RestrictedSchemaTemplateParser.parse(template);
+
+        Assert.assertEquals(100L, plan.commands().get(0).operations()
+                                           .get(0).arguments().get(0));
+        Object userdata = plan.commands().get(0).operations().get(2)
+                              .arguments().get(0);
+        Assert.assertEquals(-3L, ((Map<?, ?>) userdata).get("rank"));
+        Assert.assertEquals(86400L, plan.commands().get(1).operations()
+                                             .get(0).arguments().get(0));
+    }
+
+    @Test
+    public void testRejectLongSuffixOnFloatingPointLiteral() {
+        List<String> templates = Arrays.asList(
+                "schema.vertexLabel('person').ttl(1.0L).create();",
+                "schema.vertexLabel('person').ttl(1e3l).create();"
+        );
+
+        for (String template : templates) {
+            Assert.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> RestrictedSchemaTemplateParser.parse(template),
+                    e -> Assert.assertContains("Long suffix", e.getMessage()));
+        }
+    }
+
+    @Test
     public void testAllowSchemaAssignmentWithoutSemicolon() {
         String template = "schema = graph.schema()\n" +
                           "schema.propertyKey('name').asText().create()";

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/traversal/optimize/HugeScriptTraversalTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/traversal/optimize/HugeScriptTraversalTest.java
@@ -28,6 +28,7 @@ import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
 import org.apache.hugegraph.testutil.Assert;
 import org.apache.hugegraph.traversal.optimize.HugeScriptTraversal;
 import org.apache.hugegraph.unit.BaseUnitTest;
+import org.apache.tinkerpop.gremlin.process.traversal.GType;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.LazyBarrierStrategy;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
@@ -84,6 +85,61 @@ public class HugeScriptTraversalTest extends BaseUnitTest {
             Assert.assertFalse(traversal.getStrategies()
                                         .getStrategy(LazyBarrierStrategy.class)
                                         .isPresent());
+            traversal.close();
+        }
+    }
+
+    @Test
+    public void testRejectTraversalSourceAlias() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            Assert.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new HugeScriptTraversal<>(
+                            g, "hugegraph.V().count()",
+                            Collections.emptyMap(),
+                            Map.of("hugegraph", "graph")),
+                    e -> Assert.assertContains("aliases are not supported",
+                                               e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testRejectAliasToArbitraryBinding() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            Assert.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new HugeScriptTraversal<>(
+                            g, "hugegraph.V().count()", Map.of("other", g),
+                            Map.of("hugegraph", "other")),
+                    e -> Assert.assertContains("aliases are not supported",
+                                               e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testRejectAliasOverwritingProtectedSource() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            Assert.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new HugeScriptTraversal<>(
+                            g, "g.V().count()", Collections.emptyMap(),
+                            Map.of("g", "graph")),
+                    e -> Assert.assertContains("aliases are not supported",
+                                               e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testGraphTokenDoesNotExposeGraphObject() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeScriptTraversal<Object, Object> traversal =
+                    traversal(g, "g.inject(graph)");
+
+            Assert.assertEquals(GType.GRAPH, traversal.next());
             traversal.close();
         }
     }

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/traversal/optimize/HugeScriptTraversalTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/traversal/optimize/HugeScriptTraversalTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.unit.traversal.optimize;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.script.Bindings;
+
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngine;
+import org.apache.hugegraph.security.HugeGraphGremlinLangScriptEngineFactory;
+import org.apache.hugegraph.testutil.Assert;
+import org.apache.hugegraph.traversal.optimize.HugeScriptTraversal;
+import org.apache.hugegraph.unit.BaseUnitTest;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.optimization.LazyBarrierStrategy;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.junit.Test;
+
+public class HugeScriptTraversalTest extends BaseUnitTest {
+
+    @Test
+    public void testExecuteGremlinLangWithBindings() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex("name", "marko");
+            Map<String, Object> bindings = Collections.singletonMap("person",
+                                                                     "marko");
+            HugeScriptTraversal<Object, Object> traversal =
+                    new HugeScriptTraversal<>(
+                            g, "g.V().has('name', person).values('name')",
+                            bindings, Collections.emptyMap());
+
+            Assert.assertEquals(List.of("marko"), traversal.toList());
+            traversal.close();
+        }
+    }
+
+    @Test
+    public void testAllowRemovingOrdinaryTraversalStrategy() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex();
+            HugeScriptTraversal<Object, Object> traversal =
+                    traversal(g,
+                              "g.withoutStrategies(LazyBarrierStrategy)" +
+                              ".V().count()");
+
+            Assert.assertEquals(1L, traversal.next());
+            traversal.close();
+        }
+    }
+
+    @Test
+    public void testPreserveCallerTraversalSourceStrategies() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal();
+             GraphTraversalSource requestSource =
+                     g.withoutStrategies(LazyBarrierStrategy.class)) {
+            Assert.assertTrue(g.getStrategies()
+                               .getStrategy(LazyBarrierStrategy.class)
+                               .isPresent());
+            HugeScriptTraversal<Object, Object> traversal =
+                    traversal(requestSource, "g.V()");
+
+            traversal.asAdmin().applyStrategies();
+
+            Assert.assertFalse(traversal.getStrategies()
+                                        .getStrategy(LazyBarrierStrategy.class)
+                                        .isPresent());
+            traversal.close();
+        }
+    }
+
+    @Test
+    public void testDoesNotRetireCallerProtectedTraversalSource()
+            throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            graph.addVertex();
+            HugeGraphGremlinLangScriptEngine engine =
+                    new HugeGraphGremlinLangScriptEngineFactory()
+                            .getScriptEngine();
+            GraphTraversalSource protectedSource = engine.add(g);
+            HugeScriptTraversal<Object, Object> traversal =
+                    traversal(protectedSource, "g.V().count()");
+
+            Assert.assertEquals(1L, traversal.next());
+            traversal.close();
+
+            Bindings bindings = engine.createBindings();
+            bindings.put("g", protectedSource);
+            Assert.assertEquals(1L, engine.eval("g.V().count().next()",
+                                                bindings));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testLegacyConstructorCannotSelectGroovy() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeScriptTraversal<Object, Object> traversal =
+                    new HugeScriptTraversal<>(
+                            g, "gremlin-lang", "g.inject(1)",
+                            Collections.emptyMap(), Collections.emptyMap());
+
+            Assert.assertEquals(1, traversal.next());
+            traversal.close();
+            Assert.assertThrows(IllegalArgumentException.class,
+                                () -> new HugeScriptTraversal<>(
+                                        g, "gremlin-groovy", "g.inject(1)",
+                                        Collections.emptyMap(),
+                                        Collections.emptyMap()),
+                                e -> Assert.assertContains("gremlin-lang",
+                                                           e.getMessage()));
+        }
+    }
+
+    @Test
+    public void testRejectCallStep() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeScriptTraversal<Object, Object> traversal =
+                    traversal(g, "g.call('service').iterate()");
+
+            Assert.assertThrows(SecurityException.class, traversal::hasNext,
+                                e -> Assert.assertContains("CallStep",
+                                                           e.getMessage()));
+            traversal.close();
+        }
+    }
+
+    @Test
+    public void testRejectGroovySyntax() throws Exception {
+        try (TinkerGraph graph = TinkerGraph.open();
+             GraphTraversalSource g = graph.traversal()) {
+            HugeScriptTraversal<Object, Object> systemExit =
+                    traversal(g, "System.exit(0)");
+            HugeScriptTraversal<Object, Object> closure =
+                    traversal(g, "g.V().map { it.get() }");
+
+            Assert.assertThrows(RuntimeException.class, systemExit::hasNext);
+            Assert.assertThrows(RuntimeException.class, closure::hasNext);
+            systemExit.close();
+            closure.close();
+        }
+    }
+
+    private static HugeScriptTraversal<Object, Object> traversal(
+                   GraphTraversalSource g, String script) {
+        return new HugeScriptTraversal<>(g, script, Collections.emptyMap(),
+                                         Collections.emptyMap());
+    }
+}

--- a/hugegraph-store/hg-store-core/pom.xml
+++ b/hugegraph-store/hg-store-core/pom.xml
@@ -154,21 +154,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.tinkerpop</groupId>
-            <artifactId>gremlin-groovy</artifactId>
-            <version>${tinkerpop.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.github.jeremyh</groupId>
-                    <artifactId>jBCrypt</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>commons-lang3</artifactId>
-                    <groupId>org.apache.commons</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.9</version>

--- a/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/BusinessHandlerImpl.java
+++ b/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/BusinessHandlerImpl.java
@@ -463,6 +463,10 @@ public class BusinessHandlerImpl implements BusinessHandler {
 
     @Override
     public GraphStoreIterator scan(ScanPartitionRequest spr) throws HgStoreException {
+        if (!spr.getScanRequest().getCondition().isEmpty()) {
+            throw new HgStoreException(
+                    "String scan condition is no longer supported");
+        }
         return new GraphStoreIterator(scanOriginal(spr), spr);
     }
 

--- a/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/GraphStoreIterator.java
+++ b/hugegraph-store/hg-store-core/src/main/java/org/apache/hugegraph/store/business/GraphStoreIterator.java
@@ -24,12 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import javax.script.Bindings;
-import javax.script.CompiledScript;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
-
-import org.apache.commons.lang.StringUtils;
 import org.apache.hugegraph.backend.BackendColumn;
 import org.apache.hugegraph.id.Id;
 import org.apache.hugegraph.rocksdb.access.RocksDBSession;
@@ -51,12 +45,10 @@ import org.apache.hugegraph.structure.BaseProperty;
 import org.apache.hugegraph.structure.BaseVertex;
 import org.apache.hugegraph.type.HugeType;
 import org.apache.hugegraph.util.Blob;
-import org.codehaus.groovy.jsr223.GroovyScriptEngineImpl;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 
-import groovy.lang.MissingMethodException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -76,10 +68,7 @@ public class GraphStoreIterator<T> extends AbstractSelectIterator
     private Vertex.Builder vertex;
     private Edge.Builder edge;
     private ArrayList<RocksDBSession.BackendColumn> data;
-    private GroovyScriptEngineImpl engine;
-    private CompiledScript script;
     private BaseElement current;
-    private Exception stopCause;
 
     public GraphStoreIterator(ScanIterator iterator,
                               ScanPartitionRequest scanRequest) {
@@ -103,16 +92,6 @@ public class GraphStoreIterator<T> extends AbstractSelectIterator
                 properties.add(i);
             }
         }
-        String condition = request.getCondition();
-        if (!StringUtils.isEmpty(condition)) {
-            ScriptEngineManager factory = new ScriptEngineManager();
-            engine = (GroovyScriptEngineImpl) factory.getEngineByName("groovy");
-            try {
-                script = engine.compile(condition);
-            } catch (ScriptException e) {
-                log.error("create script with error:", e);
-            }
-        }
     }
 
     private BaseElement getElement(RocksDBSession.BackendColumn next) {
@@ -126,31 +105,8 @@ public class GraphStoreIterator<T> extends AbstractSelectIterator
                 RocksDBSession.BackendColumn next = this.iter.next();
                 BaseElement element = getElement(next);
                 try {
-                    boolean evalResult = true;
-                    if (isVertex) {
-                        BaseVertex el = (BaseVertex) element;
-                        if (engine != null) {
-                            Bindings bindings = engine.createBindings();
-                            bindings.put("element", el);
-                            evalResult = (boolean) script.eval(bindings);
-                        }
-                    } else {
-                        BaseEdge el = (BaseEdge) element;
-                        if (engine != null) {
-                            Bindings bindings = engine.createBindings();
-                            bindings.put("element", el);
-                            evalResult = (boolean) script.eval(bindings);
-                        }
-                    }
-                    if (!evalResult) {
-                        continue;
-                    }
                     current = element;
                     return true;
-                } catch (ScriptException | MissingMethodException se) {
-                    stopCause = se;
-                    log.error("get next with error which cause to stop:", se);
-                    return false;
                 } catch (Exception e) {
                     log.error("get next with error:", e);
                 }
@@ -338,7 +294,12 @@ public class GraphStoreIterator<T> extends AbstractSelectIterator
         iter.close();
     }
 
+    /**
+     * Script evaluation has been removed, so the iterator no longer has a
+     * script-specific stop cause. Kept for binary compatibility.
+     */
+    @Deprecated
     public Exception getStopCause() {
-        return stopCause;
+        return null;
     }
 }

--- a/hugegraph-store/hg-store-node/src/main/java/org/apache/hugegraph/store/node/grpc/scan/ScanResponseObserver.java
+++ b/hugegraph-store/hg-store-node/src/main/java/org/apache/hugegraph/store/node/grpc/scan/ScanResponseObserver.java
@@ -38,6 +38,7 @@ import org.apache.hugegraph.store.grpc.Graphpb.ScanResponse;
 
 import com.google.protobuf.Descriptors;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,6 +48,8 @@ public class ScanResponseObserver<T> implements
 
     private static final int BATCH_SIZE = 100000;
     private static final int MAX_PAGE = 8; //
+    private static final String CONDITION_UNSUPPORTED =
+            "String scan condition is no longer supported";
     private static final Error ok = Error.newBuilder().setType(ErrorType.OK).build();
     private static final ResponseHeader okHeader =
             ResponseHeader.newBuilder().setError(ok).build();
@@ -149,6 +152,13 @@ public class ScanResponseObserver<T> implements
         if (scanReq.hasScanRequest() && !scanReq.hasReplyRequest()) {
             this.scanReq = scanReq;
             Request request = scanReq.getScanRequest();
+            if (!request.getCondition().isEmpty()) {
+                close();
+                sender.onError(Status.UNIMPLEMENTED
+                                     .withDescription(CONDITION_UNSUPPORTED)
+                                     .asRuntimeException());
+                return;
+            }
             long rl = request.getLimit();
             leftCount = rl > 0 ? rl : Long.MAX_VALUE;
             iter = handler.scan(scanReq);
@@ -185,7 +195,9 @@ public class ScanResponseObserver<T> implements
                 readTask.cancel(true);
             }
             readOver.set(true);
-            iter.close();
+            if (iter != null) {
+                iter.close();
+            }
         } catch (Exception e) {
             log.warn("on Complete with error:", e);
         }

--- a/hugegraph-store/hg-store-node/src/test/java/org/apache/hugegraph/store/business/BusinessHandlerImplTest.java
+++ b/hugegraph-store/hg-store-node/src/test/java/org/apache/hugegraph/store/business/BusinessHandlerImplTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hugegraph.store.business;
+
+import org.apache.hugegraph.store.grpc.Graphpb.ScanPartitionRequest;
+import org.apache.hugegraph.store.grpc.Graphpb.ScanPartitionRequest.Request;
+import org.apache.hugegraph.store.meta.PartitionManager;
+import org.apache.hugegraph.store.util.HgStoreException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class BusinessHandlerImplTest {
+
+    @Test
+    public void testRejectNonEmptyConditionBeforeStoreScan() {
+        PartitionManager partitionManager =
+                Mockito.mock(PartitionManager.class);
+        BusinessHandlerImpl handler =
+                new BusinessHandlerImpl(partitionManager);
+        Mockito.clearInvocations(partitionManager);
+        Request request = Request.newBuilder()
+                                 .setCondition("element.name() == 'marko'")
+                                 .build();
+        ScanPartitionRequest scanRequest =
+                ScanPartitionRequest.newBuilder()
+                                    .setScanRequest(request)
+                                    .build();
+
+        HgStoreException exception = Assertions.assertThrows(
+                HgStoreException.class, () -> handler.scan(scanRequest));
+
+        Assertions.assertTrue(exception.getMessage().contains("condition"));
+        Mockito.verifyNoInteractions(partitionManager);
+    }
+}

--- a/hugegraph-store/hg-store-node/src/test/java/org/apache/hugegraph/store/node/grpc/scan/ScanResponseObserverTest.java
+++ b/hugegraph-store/hg-store-node/src/test/java/org/apache/hugegraph/store/node/grpc/scan/ScanResponseObserverTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.store.node.grpc.scan;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hugegraph.store.business.BusinessHandler;
+import org.apache.hugegraph.store.business.GraphStoreIterator;
+import org.apache.hugegraph.store.grpc.Graphpb.ScanPartitionRequest;
+import org.apache.hugegraph.store.grpc.Graphpb.ScanPartitionRequest.Request;
+import org.apache.hugegraph.store.grpc.Graphpb.ScanResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+
+public class ScanResponseObserverTest {
+
+    private ThreadPoolExecutor executor;
+
+    @BeforeEach
+    public void setup() {
+        this.executor = new ThreadPoolExecutor(
+                1, 1, 0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>());
+    }
+
+    @AfterEach
+    public void teardown() {
+        this.executor.shutdownNow();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRejectNonEmptyConditionBeforeStoreScan() {
+        BusinessHandler handler = Mockito.mock(BusinessHandler.class);
+        GraphStoreIterator<Object> iterator =
+                Mockito.mock(GraphStoreIterator.class);
+        Mockito.when(handler.scan(Mockito.any())).thenReturn(iterator);
+        RecordingObserver sender = new RecordingObserver();
+        ScanResponseObserver<Object> observer =
+                new ScanResponseObserver<>(sender, handler, this.executor);
+
+        observer.onNext(request("element.name() == 'marko'"));
+
+        Assertions.assertNotNull(sender.error);
+        Assertions.assertEquals(Status.Code.UNIMPLEMENTED,
+                                Status.fromThrowable(sender.error).getCode());
+        Assertions.assertTrue(Status.fromThrowable(sender.error)
+                                    .getDescription().contains("condition"));
+        Assertions.assertFalse(sender.completed);
+        Mockito.verifyNoInteractions(handler);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testEmptyConditionKeepsExistingScanBehavior() {
+        BusinessHandler handler = Mockito.mock(BusinessHandler.class);
+        GraphStoreIterator<Object> iterator =
+                Mockito.mock(GraphStoreIterator.class);
+        Mockito.when(handler.scan(Mockito.any())).thenReturn(iterator);
+        Mockito.when(iterator.hasNext()).thenReturn(false);
+        RecordingObserver sender = new RecordingObserver();
+        ScanResponseObserver<Object> observer =
+                new ScanResponseObserver<>(sender, handler, this.executor);
+        ScanPartitionRequest request = request("");
+
+        observer.onNext(request);
+
+        Assertions.assertNull(sender.error);
+        Assertions.assertTrue(sender.completed);
+        Mockito.verify(handler).scan(request);
+        Mockito.verify(iterator).close();
+    }
+
+    private static ScanPartitionRequest request(String condition) {
+        Request request = Request.newBuilder().setCondition(condition).build();
+        return ScanPartitionRequest.newBuilder().setScanRequest(request).build();
+    }
+
+    private static final class RecordingObserver
+            implements StreamObserver<ScanResponse> {
+
+        private Throwable error;
+        private boolean completed;
+
+        @Override
+        public void onNext(ScanResponse value) {
+            // No response is expected from the empty iterator fixture.
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            this.error = throwable;
+        }
+
+        @Override
+        public void onCompleted() {
+            this.completed = true;
+        }
+    }
+}


### PR DESCRIPTION
## Purpose of the PR

- Follow-up to [#203](https://github.com/hugegraph/hugegraph/pull/203), which moved remote HTTP and WebSocket Gremlin requests to the protected GremlinLang path.
- Phase 3 design: [Phase 3 Gremlin security sandbox refactoring](https://hugegraph.feishu.cn/wiki/V6dKwaQEVi6tdskgtmscFh0dnMN).

This PR completes the remaining first-stage security boundary. Strings from the Job API, persisted Job metadata, Schema Template metadata, and Store gRPC scan requests can no longer reach Groovy `eval` or `compile`.

Schema Template remains available as HugeGraph's schema DSL. HugeGraph now parses the template into a typed plan and executes that plan through SchemaManager builder APIs instead of evaluating the stored text as Groovy.

Groovy remains available for trusted deployment-time local files through `ScriptFileGremlinPlugin` and PRELOAD. Those paths require control of the server configuration or filesystem and are outside the remote-input boundary addressed here.

## Main Changes

- Replace Schema Template Groovy execution with a restricted parser and typed executor:
  - support the property-key, vertex-label, edge-label, and index-label builder DSL through explicit method and argument allowlists;
  - parse the complete template before applying schema mutations;
  - accept typed literals, safe `L/l` integer suffixes, enum constants, lists, maps, comments, and the existing `schema = graph.schema()` preamble;
  - reject dynamic expressions, control flow, reflection, arbitrary calls, and destructive operations;
  - validate templates before create or update, and add `POST /graphspaces/{graphspace}/schematemplates/{name}/validate` for stored templates.
- Move Gremlin Job and internal algorithm execution to the protected GremlinLang engine:
  - default a missing `language` to `gremlin-lang` and reject other languages when the request is submitted and when persisted metadata is loaded;
  - preserve caller bindings and traversal strategies while using a cloned, protected traversal source;
  - keep the former `HugeScriptTraversal` constructors for binary compatibility, but reject nonempty aliases and languages other than `gremlin-lang`;
  - do not expose the former Groovy `graph` and `gremlinJob` Java objects to GremlinLang text;
  - keep the TinkerPop parser cache disabled because it caches mutable traversal instances rather than immutable parse results.
- Remove the Store scan condition Groovy path:
  - reject nonempty string conditions with gRPC `UNIMPLEMENTED` before the scan handler runs;
  - repeat the check in `BusinessHandlerImpl.scan()` so internal callers cannot bypass it;
  - remove Groovy compilation from `GraphStoreIterator` and remove hg-store-core's direct `gremlin-groovy` dependency.
- Keep deployment-controlled `ScriptFileGremlinPlugin`, PRELOAD, and local Groovy configuration unchanged.

## Phase 3 PR Boundary

The blue block was merged in #203. The red block is the scope of this PR. The green block remains available only to deployment-controlled local configuration and files.

```mermaid
flowchart TB
    subgraph MERGED["PR #203 — merged"]
        direction LR
        HTTP["HTTP text"] --> REMOTE_GUARD["Default to gremlin-lang<br/>Reject remote Groovy"]
        WS["WebSocket text / Bytecode<br/>Standard or Session"] --> REMOTE_GUARD
        REMOTE_GUARD --> REMOTE_ENGINE["Protected GremlinLang engine"]
        REMOTE_ENGINE --> REMOTE_EXEC["HugeGraph traversal execution"]
    end

    subgraph CURRENT["PR #206 — remaining untrusted strings"]
        direction TB

        JOB["Job API or persisted Job metadata"] --> JOB_CHECK["Require gremlin-lang"]
        JOB_CHECK --> JOB_ENGINE["Protected GremlinLang traversal"]
        JOB_ENGINE --> JOB_EXEC["Job and algorithm execution"]

        TEMPLATE["Stored Schema Template DSL"] --> PARSER["Restricted parser<br/>Parse the complete template"]
        PARSER --> PLAN["Typed schema plan"]
        PLAN --> SCHEMA_API["SchemaManager builder APIs"]

        CONDITION["Store gRPC scan condition"] --> CONDITION_CHECK{"Condition empty?"}
        CONDITION_CHECK -->|Yes| SCAN["Normal scan"]
        CONDITION_CHECK -->|No| REJECT["Return UNIMPLEMENTED"]
    end

    subgraph TRUSTED["Unchanged trusted deployment path"]
        direction LR
        CONFIG["Server configuration and local files"] --> PRELOAD["ScriptFileGremlinPlugin / PRELOAD"]
        PRELOAD --> GROOVY["Deployment-time Groovy"]
    end

    REMOTE_ENGINE -. "same protected engine" .-> JOB_ENGINE

    classDef merged fill:#ddf4ff,stroke:#0969da,stroke-width:2px,color:#24292f
    classDef current fill:#ffebe9,stroke:#cf222e,stroke-width:3px,color:#24292f
    classDef trusted fill:#dafbe1,stroke:#1a7f37,stroke-width:2px,color:#24292f

    class HTTP,WS,REMOTE_GUARD,REMOTE_ENGINE,REMOTE_EXEC merged
    class JOB,JOB_CHECK,JOB_ENGINE,JOB_EXEC,TEMPLATE,PARSER,PLAN,SCHEMA_API,CONDITION,CONDITION_CHECK,SCAN,REJECT current
    class CONFIG,PRELOAD,GROOVY trusted

    style MERGED fill:#f6f8fa,stroke:#0969da,stroke-width:2px
    style CURRENT fill:#fff5f5,stroke:#cf222e,stroke-width:3px
    style TRUSTED fill:#f0fff4,stroke:#1a7f37,stroke-width:2px
```

Together, #203 and this PR enforce the first-stage rule: strings originating from HTTP, WebSocket, Job API, Store gRPC, Schema Template, or persisted metadata cannot be evaluated or compiled as Groovy.

## Compatibility Notes

| Path | Behavior in this PR |
|---|---|
| Job request without `language` | Supported. The request defaults to `gremlin-lang`. |
| Job request with `language: gremlin-lang` | Supported. |
| Job request or persisted metadata with another language | Rejected before script execution. |
| Job aliases | Nonempty aliases remain unsupported. GremlinLang text starts from the fixed `g` traversal source. |
| Caller bindings and traversal strategies | Preserved. The mandatory sandbox strategies remain protected. |
| Former `graph` binding | The old Groovy Java Graph object is not exposed. In GremlinLang, `graph` is the built-in `GType.GRAPH` token. |
| Former `gremlinJob` binding | Removed. Scripts can no longer update progress or the save interval through a Java proxy. |
| Job cancellation | The task framework still accepts cancellation, but interruption of an in-flight traversal remains best effort. |
| Existing `HugeScriptTraversal` constructors | Kept for binary compatibility. Only `gremlin-lang` and empty aliases are accepted. |
| Ordinary `withoutStrategies()` use | Preserved. Mandatory remote sandbox strategies still cannot be removed. |
| Schema Template builder DSL | Supported through explicit typed builder operations. Safe `L/l` integer suffixes are accepted. |
| Schema Template dynamic Groovy | Rejected with a line and column error. |
| Stored-template validate endpoint | Checks restricted syntax, allowlisted methods, literal types, and builder-chain shape. It does not promise execution success or cross-command atomicity. |
| Store gRPC scan with an empty condition | Supported as before. |
| Store gRPC scan with a nonempty string condition | Rejected with `UNIMPLEMENTED`; no replacement string language is introduced here. |
| Trusted local PRELOAD and `ScriptFileGremlinPlugin` Groovy | Unchanged. |

Schema Template execution keeps the existing builder-by-builder write semantics. A later semantic or backend failure can leave earlier schema writes in place. Plan-level semantic preflight, rollback, and graph-creation cleanup are follow-up work outside this PR.

No persisted-data format is changed.

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows:
  - Unit tests cover the restricted parser, safe long suffixes, alias rejection, protected traversal lifecycle, Job language defaults, and retained trusted Groovy compatibility.
  - Memory Core tests apply Schema Templates through real builder APIs and cover Gremlin Job execution, persisted-language rejection, task result limits, and `Text.contains()` compatibility.
  - Store tests cover both the gRPC observer rejection and the direct `BusinessHandlerImpl.scan()` defense-in-depth check.
  - RocksDB API tests cover `TaskApiTest`, `SchemaTemplateApiTest`, and `GremlinApiTest` with authentication enabled.
  - The Job API test submits a request without `language`, confirming the default through the real HTTP path.
  - The server distribution package, source formatting, and `git diff --check` are included in the validation pass.

## Does this PR potentially affect the following parts?

- [x] Dependencies: removes hg-store-core's direct `gremlin-groovy` dependency; the server retains Groovy for trusted deployment-time scripts.
- [ ] Modify configurations
- [x] The public API
- [x] Other affects: Schema Template execution, Gremlin Job and algorithm execution, and Store gRPC scan conditions
- [ ] Nope

## Documentation Status

- [ ] `Doc - TODO`
- [x] `Doc - Done`
- [ ] `Doc - No Need`
