### PR TITLE
chore(ci): run Linux jobs on Ubuntu 24.04

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -12,7 +12,7 @@ jobs:
   wait-storage-shell-test:
     permissions:
       contents: read
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,8 +23,7 @@ jobs:
         run: hugegraph-server/hugegraph-dist/src/assembly/travis/test-wait-storage.sh
 
   build-server:
-    # TODO: we need test & replace it to ubuntu-24.04 or ubuntu-latest
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       USE_STAGE: 'false' # Whether to include the stage repository.
       TRAVIS_DIR: hugegraph-server/hugegraph-dist/src/assembly/travis
@@ -160,7 +159,7 @@ jobs:
         run: |
           # Note: lsof removed from prerequisites; check_port now uses ss, falling back
           # to netstat, and warns without blocking when neither can answer.
-          # This job always runs on Linux (ubuntu-22.04), which uses fuser for port cleanup.
+          # This job always runs on Linux (ubuntu-24.04), which uses fuser for port cleanup.
           for tool in crontab curl java; do
             if ! command -v "$tool" >/dev/null 2>&1; then
               echo "can_run=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Purpose of the PR

Use Ubuntu 24.04 consistently for active Linux CI jobs.

## Main Changes

- Replace `ubuntu-latest` and `ubuntu-22.04` with `ubuntu-24.04` in active workflows.
- Remove the completed Server CI upgrade TODO and update its runner comment.

## Verifying these changes

- [x] Need tests and can be verified as follows:
    - `bash hugegraph-server/hugegraph-dist/src/assembly/travis/test-wait-storage.sh` (5 passed)
    - Run the repository CI matrix in this PR.

## Does this PR potentially affect the following parts?

- [x] Other affects (GitHub Actions runner images)

## Documentation Status

- [x] `Doc - No Need`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **维护**
  * 更新持续集成环境至最新 Ubuntu 版本。
  * 优化服务器构建与存储测试流程的环境配置说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->